### PR TITLE
Change directory before any operation to one readable by INSTALLUSER

### DIFF
--- a/src/ejabberdctl.template
+++ b/src/ejabberdctl.template
@@ -389,6 +389,10 @@ wait_for_status()
     return $status
 }
 
+# We need to cd to directory readable by INSTALLUSER in order to
+# prevent "File operation error: eacces." messages
+cd $HOME
+
 case $ARGS in
     ' start') start;;
     ' debug') debug;;


### PR DESCRIPTION
Hello!

Sometimes users are facing strange error messages, when trying to start ejabberd - "File operation error: eacces". This is due to combination of two events:
- ejabberd may be configured to drop its process privileges down to INSTALLUSER before starting ejabberd's nodes (which is reasonable).
- user tries to start ejabberd from directory unaccessible (at least for reading and listing) for INSTALLUSER. For example user tries to start ejabberd from the /root directory.

This patch is designed to suppress these error messages. I just executes "cd $HOME" before any actual erlang's invocation. Initially I used "cd /" but after some consideration I believe that changing current working directory to $HOME seems to be a better solution.

See rhbz #564686 for the user's error report:

```
https://bugzilla.redhat.com/564686
```

Also try googling for "File operation error: eacces"
