### PR TITLE
Blacklist hook bugfix

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -196,8 +196,7 @@ init([{SockMod, Socket}, Opts]) ->
     %% Check if IP is blacklisted:
     case is_ip_blacklisted(IP) of
 	true ->
-	    ?INFO_MSG("Connection attempt from blacklisted IP: ~s",
-		      [jlib:ip_to_list(IP)]),
+	    ?INFO_MSG("Connection attempt from blacklisted IP: ~w", [IP]),
 	    {stop, normal};
 	false ->
 	    Socket1 =


### PR DESCRIPTION
When the is_ip_blacklisted/1 in ejabberd_c2s.erl (blacklist hook for c2s connections) returns true and IPv6 is enabled ejabberd_c2s crashes because jlib:ip_to_list/1 doesn't support the format used as IP representation. This change fixes the issue by reporting using the internal format. This is to me preferred since it's the form it's displayed by other parts, providing better log output consistency.
