### PR TITLE
Ejabberd receiver leak fix

### DIFF
--- a/src/ejabberd_receiver.erl
+++ b/src/ejabberd_receiver.erl
@@ -237,6 +237,15 @@ handle_info({Tag, _TCPSocket, Reason}, State)
 	_ ->
 	    {stop, normal, State}
     end;
+handle_info(check_socket, #state{socket = Socket} = State) when is_port(Socket) ->
+    case erlang:port_info(Socket) of
+	undefined ->
+	    % Socket has closed, so this receiver is dead in the sea
+	    ?WARNING_MSG("Stopping ejabberd_receiver due to inactive socket.", []),
+	    {stop, normal, State};
+	_ ->
+	    {noreply, State, ?HIBERNATE_TIMEOUT}
+    end;
 handle_info({timeout, _Ref, activate}, State) ->
     activate_socket(State),
     {noreply, State, ?HIBERNATE_TIMEOUT};

--- a/src/ejabberd_socket.erl
+++ b/src/ejabberd_socket.erl
@@ -87,7 +87,13 @@ start(Module, SockMod, Socket, Opts) ->
 		    end,
 		    ReceiverMod:become_controller(Receiver, Pid);
 		{error, _Reason} ->
-		    SockMod:close(Socket)
+		    SockMod:close(Socket),
+		    case ReceiverMod of
+			ejabberd_receiver ->
+			    ReceiverMod:close(Receiver);
+			_ ->
+			    ok
+		    end
 	    end;
 	independent ->
 	    ok;


### PR DESCRIPTION
From the commit message.

```
Fixes a leak of ejabberd_receiver processes.

When a (non-frontend) socket module without any custom receiver fails to
start, the newly created ejabberd_receiver process needs to be properly
closed.

This patch fixes this problem, as well as provides a solution for
stopping 'dead' (as in with dead sockets/ports) ejabberd_receiver
processes, by sending them the message 'check_socket'.
```

One can then, from a remote shell run:
    lists:map(fun({_,Pid,_,_}) -> Pid ! check_socket end, supervisor:which_children(ejabberd_receiver_sup)).
to invoke the cleanup without having to restart the server.
