### PR TITLE
MUC History Messages should come in the order they were sent

### DIFF
--- a/src/mod_muc/mod_muc_room.erl
+++ b/src/mod_muc/mod_muc_room.erl
@@ -784,7 +784,7 @@ terminate(Reason, _StateName, StateData) ->
 	       tab_remove_online_user(LJID, StateData)
        end, [], StateData#state.users),
     add_to_log(room_existence, stopped, StateData),
-    mod_muc:room_destroyed(StateData#state.host, list_to_binary(StateData#state.room), self(),
+    mod_muc:room_destroyed(StateData#state.host, StateData#state.room, self(),
 			   StateData#state.server_host),
     ok.
 

--- a/src/mod_muc/mod_muc_room.hrl
+++ b/src/mod_muc/mod_muc_room.hrl
@@ -60,7 +60,7 @@
 		   message,
 		   presence}).
 
--record(state, {room, % string()
+-record(state, {room, % binary()
 		host, % binary()
 		server_host, % string()
 		access,


### PR DESCRIPTION
Currently the history is implemented as a queue, but it makes more sense if the messages come in the order they were received.
