### PR TITLE
Predefined ACL rule "local".

### DIFF
--- a/src/acl.erl
+++ b/src/acl.erl
@@ -92,6 +92,8 @@ normalize_spec({A, B}) ->
     {A, normalize(B)};
 normalize_spec({A, B, C}) ->
     {A, normalize(B), normalize(C)};
+normalize_spec(local) ->
+    local;
 normalize_spec(all) ->
     all;
 normalize_spec(none) ->
@@ -163,6 +165,10 @@ match_acl(ACL, JID, Host) ->
 			      case Spec of
 				  all ->
 				      true;
+				  local ->
+				      ((Host == Server) orelse
+				       ((Host == global) andalso
+					lists:member(Server, ?MYHOSTS)));
 				  {user, U} ->
 				      (U == User)
 					  andalso


### PR DESCRIPTION
Addition of another predefined ACL rule called "local" to match a user against either the virtual host of the match rule call, or any configured virtual host in case the rule is on the global scope.