### PR TITLE
Quick security fix

### DIFF
--- a/src/mod_filter.erl
+++ b/src/mod_filter.erl
@@ -1,0 +1,17 @@
+-module(mod_filter).
+-author('n.shukla722@gmail.com').
+behaviour(gen_mod).
+
+export([start/2, stop/1, get_protected_names/0]).
+
+-include("ejabberd.hrl").
+-include("jlib.hrl").
+
+start(Host, Opts) ->
+    ok.
+
+stop(Host) ->
+    ok.
+
+get_protected_names() ->
+    ["NamesTo", "FilterAway", "ToPrevent", "UnwantedSpoofing"].


### PR DESCRIPTION
Added logic to filter unwanted packets names to prevent spoofing. These protected names are managed by mod_filter.erl.

When creating custom packets, not ejabberd should have a blacklist of packets not to read. 
