### PR TITLE
mod_muc migration needs to handle non-mnesia backends

### DIFF
--- a/src/mod_muc/mod_muc.erl
+++ b/src/mod_muc/mod_muc.erl
@@ -1066,4 +1066,6 @@ update_tables(Host, mnesia) ->
 							  opt = Opt,
 							  val = Val})
 		  end, Options)
-	end}]).
+	end}]);
+update_tables(_Host, _) ->
+  ok.


### PR DESCRIPTION
I just made this a no-op, since no one would have another backend in 2.1.x anyways.
