### PR TITLE
BOSH update

### DIFF
--- a/src/web/ejabberd_http_bind.erl
+++ b/src/web/ejabberd_http_bind.erl
@@ -95,7 +95,7 @@
 -define(FSMOPTS, []).
 -endif.
 
--define(BOSH_VERSION_b, <<"1.8">>).
+-define(BOSH_VERSION_b, <<"1.10">>).
 
 -define(MAX_REQUESTS, 2).  % number of simultaneous requests
 -define(MIN_POLLING, 2000000). % don't poll faster than that or we will
@@ -1049,7 +1049,8 @@ prepare_outpacket_response(#http_bind{id=Sid, wait=Wait,
 		    BOSH_attribs =
 			[#xmlattr{name = <<"authid">>, value = list_to_binary(AuthID)},
 			 #xmlattr{name = <<"xmlns:stream">>, value = ?NS_XMPP_b}] ++
-		    [#xmlattr{name = <<"version">>, ns = ?NS_BOSH_s, value = list_to_binary(Version)}],
+		    [#xmlattr{name = <<"version">>, ns = ?NS_BOSH_s, value = list_to_binary(Version)},
+		     #xmlattr{name = <<"restartlogic">>, ns = ?NS_BOSH_s, value = <<"true">>}],
 		    MaxInactivity = get_max_inactivity(To, ?MAX_INACTIVITY),
 		    MaxPause = get_max_pause(To),
 		    {200, ?HEADER,


### PR DESCRIPTION
Those two patches contain cosmetic updates to http_bind module:
- Consistently use NS_BOSH (instead NS_BOSH in some places and NS_XBOSH in other)
- Updated the code to reflect latest (minor) BOSH XEP changes

Changes tested with latest jsjac.
