### PR TITLE
tls:send performance improvement

### DIFF
--- a/src/tls/tls_drv.c
+++ b/src/tls/tls_drv.c
@@ -407,22 +407,12 @@ static int tls_drv_control(ErlDrvData handle,
 	 break;
       case GET_ENCRYPTED_OUTPUT:
 	 die_unless(d->ssl, "SSL not initialized");
-	 size = BUF_SIZE + 1;
-	 rlen = 1;
+	 size = BIO_ctrl_pending(d->bio_write) + 1;
 	 b = driver_alloc_binary(size);
 	 b->orig_bytes[0] = 0;
-	 while ((res = BIO_read(d->bio_write,
-				b->orig_bytes + rlen, BUF_SIZE)) > 0)
-	 {
-	    //printf("%d bytes of encrypted data read from state machine\r\n", res);
-
-	    rlen += res;
-	    size += BUF_SIZE;
-	    b = driver_realloc_binary(b, size);
-	 }
-	 b = driver_realloc_binary(b, rlen);
+	 BIO_read(d->bio_write, b->orig_bytes + 1, size - 1);
 	 *rbuf = (char *)b;
-	 return rlen;
+	 return size;
       case GET_DECRYPTED_INPUT:
 	 if (!SSL_is_init_finished(d->ssl))
 	 {


### PR DESCRIPTION
Fixes the same issue that is present in exmpp TLS driver (that I've send earlier).

Also applies cleanly on 2.1.x branch.
