### PR TITLE
Remove some leftovers of XEP-0018.

### DIFF
--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -227,7 +227,7 @@ c2s_presence_in(C2SState, {From, To, #xmlel{attrs = Attrs, children = Els}}) ->
     Subscription = ejabberd_c2s:get_subscription(From, C2SState),
     Insert = ((Type == <<>>) or (Type == <<"available">>))
 	and ((Subscription == both) or (Subscription == to)),
-    Delete = (Type == <<"unavailable">>) or (Type == <<"error">>) or (Type == <<"invisible">>),
+    Delete = (Type == <<"unavailable">>) or (Type == <<"error">>),
     if Insert or Delete ->
 	    LFrom = exmpp_jid:to_lower(From),
 	    Rs = case ejabberd_c2s:get_aux_field(caps_resources, C2SState) of

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -73,7 +73,6 @@ start(HostB, Opts) ->
     catch ets:new(disco_features, [named_table, ordered_set, public]),
     register_feature(HostB, "iq"),
     register_feature(HostB, "presence"),
-    register_feature(HostB, "presence-invisible"),
 
     catch ets:new(disco_extra_domains, [named_table, ordered_set, public]),
     ExtraDomains = gen_mod:get_opt(extra_domains, Opts, []),


### PR DESCRIPTION
Support for XEP-0018 was dropped long ago, but there are some
leftovers. Remove them.
