### PR TITLE
Add support for publish-only in hometree derived nodes

### DIFF
--- a/src/mod_pubsub/mod_pubsub.erl
+++ b/src/mod_pubsub/mod_pubsub.erl
@@ -2910,6 +2910,7 @@ get_roster_info(OwnerUser, OwnerServer, JID, AllowedGroups) ->
 %% @doc <p>Convert an affiliation type from string to atom.</p>
 string_to_affiliation("owner") -> owner;
 string_to_affiliation("publisher") -> publisher;
+string_to_affiliation("publish-only") -> publish_only;
 string_to_affiliation("member") -> member;
 string_to_affiliation("outcast") -> outcast;
 string_to_affiliation("none") -> none;
@@ -2932,7 +2933,7 @@ string_to_subscription(_) -> false.
 affiliation_to_string(owner) -> "owner";
 affiliation_to_string(publisher) -> "publisher";
 affiliation_to_string(member) -> "member";
-affiliation_to_string(outcast) -> "outcast";
+affiliation_to_string(publish_only) -> "publish-only";
 affiliation_to_string(_) -> "none".
 
 %% @spec (Subscription) -> SubscriptionStr
@@ -3762,6 +3763,7 @@ features() ->
 	 "presence-subscribe",   % RECOMMENDED
 	 % see plugin "publish",   % REQUIRED
 	 %TODO "publish-options",   % OPTIONAL
+	 % see plugin "publish-only-affiliation",   % OPTIONAL
 	 "publisher-affiliation",   % RECOMMENDED
 	 % see plugin "purge-nodes",   % OPTIONAL
 	 % see plugin "retract-items",   % OPTIONAL

--- a/src/mod_pubsub/node_hometree.erl
+++ b/src/mod_pubsub/node_hometree.erl
@@ -169,6 +169,7 @@ features() ->
      "outcast-affiliation",
      "persistent-items",
      "publish",
+	 "publish-only-affiliation",
      "purge-nodes",
      "retract-items",
      "retrieve-affiliations",
@@ -492,6 +493,7 @@ publish_item(NodeIdx, Publisher, PublishModel, MaxItems, ItemId, Payload) ->
     if
 	not ((PublishModel == open)
 	     or ((PublishModel == publishers)
+	     or ((PublishModel == publish_only)
 		 and ((Affiliation == owner) or (Affiliation == publisher)))
 	     or (Subscribed == true)) ->
 	    %% Entity does not have sufficient privileges to publish to node
@@ -929,7 +931,7 @@ get_items(NodeIdx, JID, AccessModel, PresenceSubscription, RosterGroup, _SubId) 
 	%%InvalidSubId ->
 	    %% Entity is subscribed but specifies an invalid subscription ID
 	    %{error, ?ERR_EXTENDED(?ERR_NOT_ACCEPTABLE, "invalid-subid")};
-	GenState#pubsub_state.affiliation == outcast ->
+	(GenState#pubsub_state.affiliation == outcast) or (GenState#pubsub_state.affiliation == publish_only) ->
 	    %% Requesting entity is blocked
 	    {error, ?ERR_FORBIDDEN};
 	(AccessModel == presence) and (not PresenceSubscription) ->
@@ -989,7 +991,7 @@ get_item(NodeIdx, ItemId, JID, AccessModel, PresenceSubscription, RosterGroup, _
 	%%InvalidSubId ->
 	    %% Entity is subscribed but specifies an invalid subscription ID
 	    %{error, ?ERR_EXTENDED(?ERR_NOT_ACCEPTABLE, "invalid-subid")};
-	GenState#pubsub_state.affiliation == outcast ->
+	(GenState#pubsub_state.affiliation == outcast) or (GenState#pubsub_state.affiliation == publish_only) ->
 	    %% Requesting entity is blocked
 	    {error, ?ERR_FORBIDDEN};
 	(AccessModel == presence) and (not PresenceSubscription) ->
@@ -1054,6 +1056,7 @@ path_to_node(Path) ->
 can_fetch_item(owner,        _)             -> true;
 can_fetch_item(member,       _)             -> true;
 can_fetch_item(publisher,    _)             -> true;
+can_fetch_item(publish_only,      _)             -> false;
 can_fetch_item(outcast,      _)             -> false;
 can_fetch_item(none, Subscriptions) -> is_subscribed(Subscriptions);
 can_fetch_item(_Affiliation, _Subscription) -> false.

--- a/src/mod_pubsub/node_hometree.erl
+++ b/src/mod_pubsub/node_hometree.erl
@@ -169,7 +169,7 @@ features() ->
      "outcast-affiliation",
      "persistent-items",
      "publish",
-	 "publish-only-affiliation",
+     "publish-only-affiliation",
      "purge-nodes",
      "retract-items",
      "retrieve-affiliations",
@@ -493,8 +493,7 @@ publish_item(NodeIdx, Publisher, PublishModel, MaxItems, ItemId, Payload) ->
     if
 	not ((PublishModel == open)
 	     or ((PublishModel == publishers)
-	     or ((PublishModel == publish_only)
-		 and ((Affiliation == owner) or (Affiliation == publisher)))
+		 and ((Affiliation == owner) or (Affiliation == publisher) or (Affiliation == publish_only)))
 	     or (Subscribed == true)) ->
 	    %% Entity does not have sufficient privileges to publish to node
 	    {error, ?ERR_FORBIDDEN};


### PR DESCRIPTION
I can port these changes to 3.x also, but it'd be a nice thing to have in the next 2.1.x release.