### PR TITLE
TLS driver impovements

### DIFF
--- a/src/tls/tls_drv.c
+++ b/src/tls/tls_drv.c
@@ -283,10 +283,14 @@ static int verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
  * See http://www.openssl.org/news/secadv_20110906.txt
  * for details.
  */
-#if OPENSSL_VERSION_NUMBER >= 0x1000005fL && !defined(OPENSSL_NO_ECDH)
+#ifndef OPENSSL_NO_ECDH
 static void setup_ecdh(SSL_CTX *ctx)
 {
    EC_KEY *ecdh;
+
+   if (SSLeay() < 0x1000005fL) {
+      return;
+   }
 
    ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
    SSL_CTX_set_options(ctx, SSL_OP_SINGLE_ECDH_USE);
@@ -440,12 +444,12 @@ static ErlDrvSSizeT tls_drv_control(ErlDrvData handle,
 
 	    SSL_CTX_set_cipher_list(ctx, CIPHERS);
 
-#if OPENSSL_VERSION_NUMBER >= 0x1000005fL && !defined(OPENSSL_NO_ECDH)
+#ifndef OPENSSL_NO_ECDH
 	    if (command == SET_CERTIFICATE_FILE_ACCEPT) {
 		setup_ecdh(ctx);
 	    }
 #endif
-#if !defined(OPENSSL_NO_DH)
+#ifndef OPENSSL_NO_DH
 	    if (command == SET_CERTIFICATE_FILE_ACCEPT) {
 		setup_dh(ctx);
 	    }


### PR DESCRIPTION
This set of commits disables SSL 2.0, weak and broken ciphers and enables use of DHE and ECDHE key exchange. This makes ejabberd TLS support a bit more modern;) This is basically the same work that I've done on exmpp some time ago.
It would be better to allow specifying supported ciphers and/or DHE/ECDHE in configuration file, but that is a lot more work, probably not for 2.1.x.
Those commits also apply cleanly on master.
