### PR TITLE
Added command to list all the vhosts registered in an ejabberd node

### DIFF
--- a/src/ejabberd_admin.erl
+++ b/src/ejabberd_admin.erl
@@ -31,6 +31,7 @@
 	 %% Server
 	 status/0, reopen_log/0,
 	 stop_kindly/2, send_service_message_all_mucs/2,
+	 registered_vhosts/0,
 	 %% Erlang
 	 update_list/0, update/1,
 	 %% Accounts
@@ -128,6 +129,11 @@ commands() ->
 			module = ?MODULE, function = registered_users,
 			args = [{host, string}],
 			result = {users, {list, {username, string}}}},
+	 #ejabberd_commands{name = registered_vhosts, tags = [server],
+			desc = "List all registered vhosts in SERVER",
+			module = ?MODULE, function = registered_vhosts,
+			args = [],
+			result = {vhosts, {list, {vhost, string}}}},
 
      #ejabberd_commands{name = import_file, tags = [mnesia],
 			desc = "Import user data from jabberd14 spool file",
@@ -348,6 +354,8 @@ registered_users(Host) ->
     SUsers = lists:sort(Users),
     lists:map(fun({U, _S}) -> U end, SUsers).
 
+registered_vhosts() ->
+	?MYHOSTS.
 
 %%%
 %%% Migration management


### PR DESCRIPTION
Command to find out all registered vhosts in an ejabberd node. We wanted to find this out programmatically (via mod_restful_admin). This is my first erlang code ever, so please be forgiving ;)
