### PR TITLE
Fix errors when generating random binary strings

### DIFF
--- a/src/cyrsasl_anonymous.erl
+++ b/src/cyrsasl_anonymous.erl
@@ -43,7 +43,9 @@ mech_new(Host, _GetPassword, _CheckPassword, _CheckPasswordDigest) ->
     {ok, #state{server = Host}}.
 
 mech_step(#state{server = Server}, _ClientIn) ->
-    User = iolist_to_binary([randoms:get_string() | tuple_to_list(now())]),
+    User = iolist_to_binary([randoms:get_string()
+			     | [jlib:integer_to_binary(X)
+				|| X <- tuple_to_list(now())]]),
     case ejabberd_auth:is_user_exists(User, Server) of
         true  -> {error, <<"not-authorized">>};
         false -> {ok, [{username, User}, {auth_module, ejabberd_auth_anonymous}]}

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -897,7 +897,8 @@ resource_conflict_action(U, S, R) ->
       closenew -> closenew;
       setresource ->
 	  Rnew = iolist_to_binary([randoms:get_string()
-                                   | tuple_to_list(now())]),
+                                   | [jlib:integer_to_binary(X)
+                                      || X <- tuple_to_list(now())]]),
 	  {accept_resource, Rnew}
     end.
 
@@ -912,7 +913,8 @@ wait_for_bind({xmlstreamelement, El}, StateData) ->
 		error -> error;
 		<<"">> ->
                       iolist_to_binary([randoms:get_string()
-                                        | tuple_to_list(now())]);
+                                        | [jlib:integer_to_binary(X)
+                                           || X <- tuple_to_list(now())]]);
 		Resource -> Resource
 	      end,
 	  case R of


### PR DESCRIPTION
There are three places in the code where iolist_to_binary() is called on a list that is not an iolist, causing the code to fail.  This patch fixes the issue.
