### PR TITLE
now() -> os:timestamp()

### DIFF
--- a/src/adhoc.erl
+++ b/src/adhoc.erl
@@ -121,7 +121,7 @@ produce_response(
   }) ->
     SessionID = if is_binary(ProvidedSessionID),
         ProvidedSessionID /= <<"">> -> ProvidedSessionID;
-        true                        -> jlib:now_to_utc_string(now())
+        true                        -> jlib:now_to_utc_string(os:timestamp())
     end,
     case Actions of
         [] ->

--- a/src/cache_tab.erl
+++ b/src/cache_tab.erl
@@ -399,7 +399,7 @@ get_all_procs(Tab) ->
     [get_proc(Tab, N) || N <- lists:seq(1, get_proc_num())].
 
 now_priority() ->
-    {MSec, Sec, USec} = now(),
+    {MSec, Sec, USec} = os:timestamp(),
     -((MSec*1000000 + Sec)*1000000 + USec).
 
 clean_priority(LifeTime) ->
@@ -586,20 +586,20 @@ test2() ->
 test3(Iter) ->
     ok = new(test_tbl, [{max_size, unlimited}, {life_time, unlimited}]),
     L = lists:seq(1, Iter),
-    T1 = now(),
+    T1 = os:timestamp(),
     lists:foreach(
       fun(N) ->
 	      ok = ?insert(test_tbl, N, N, fun() -> ok end)
       end, L),
     io:format("** average insert (size = ~p): ~p usec~n",
-	      [Iter, round(timer:now_diff(now(), T1)/Iter)]),
-    T2 = now(),
+	      [Iter, round(timer:now_diff(os:timestamp(), T1)/Iter)]),
+    T2 = os:timestamp(),
     lists:foreach(
       fun(N) ->
 	      {ok, N} = ?lookup(test_tbl, N, fun() -> ok end)
       end, L),
     io:format("** average lookup (size = ~p): ~p usec~n",
-	      [Iter, round(timer:now_diff(now(), T2)/Iter)]),
+	      [Iter, round(timer:now_diff(os:timestamp(), T2)/Iter)]),
     {ok, Iter} = info(test_tbl, size),
     delete(test_tbl).
 

--- a/src/cyrsasl_anonymous.erl
+++ b/src/cyrsasl_anonymous.erl
@@ -45,7 +45,7 @@ mech_new(Host, _GetPassword, _CheckPassword, _CheckPasswordDigest) ->
 mech_step(#state{server = Server}, _ClientIn) ->
     User = iolist_to_binary([randoms:get_string()
 			     | [jlib:integer_to_binary(X)
-				|| X <- tuple_to_list(now())]]),
+				|| X <- tuple_to_list(os:timestamp())]]),
     case ejabberd_auth:is_user_exists(User, Server) of
         true  -> {error, <<"not-authorized">>};
         false -> {ok, [{username, User}, {auth_module, ejabberd_auth_anonymous}]}

--- a/src/ejabberd_auth_anonymous.erl
+++ b/src/ejabberd_auth_anonymous.erl
@@ -55,7 +55,7 @@
 %% Create the anonymous table if at least one virtual host has anonymous features enabled
 %% Register to login / logout events
 -record(anonymous, {us = {<<"">>, <<"">>} :: {binary(), binary()},
-                    sid = {now(), self()} :: ejabberd_sm:sid()}).
+                    sid = {os:timestamp(), self()} :: ejabberd_sm:sid()}).
 
 start(Host) ->
     %% TODO: Check cluster mode

--- a/src/ejabberd_auth_external.erl
+++ b/src/ejabberd_auth_external.erl
@@ -267,7 +267,7 @@ set_password_internal(User, Server, Password) ->
 					Password).
 
 is_fresh_enough(TimeStampLast, CacheTime) ->
-    {MegaSecs, Secs, _MicroSecs} = now(),
+    {MegaSecs, Secs, _MicroSecs} = os:timestamp(),
     Now = MegaSecs * 1000000 + Secs,
     TimeStampLast + CacheTime > Now.
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -533,7 +533,7 @@ wait_for_auth({xmlstreamelement, El}, StateData) ->
 			?INFO_MSG("(~w) Accepted legacy authentication for ~s by ~p",
 				[StateData#state.socket,
 				 jlib:jid_to_string(JID), AuthModule]),
-			SID = {now(), self()},
+			SID = {os:timestamp(), self()},
 			Conn = (StateData#state.sockmod):get_conn_type(
 				    StateData#state.socket),
 			Info = [{ip, StateData#state.ip}, {conn, Conn},
@@ -898,7 +898,7 @@ resource_conflict_action(U, S, R) ->
       setresource ->
 	  Rnew = iolist_to_binary([randoms:get_string()
                                    | [jlib:integer_to_binary(X)
-                                      || X <- tuple_to_list(now())]]),
+                                      || X <- tuple_to_list(os:timestamp())]]),
 	  {accept_resource, Rnew}
     end.
 
@@ -914,7 +914,7 @@ wait_for_bind({xmlstreamelement, El}, StateData) ->
 		<<"">> ->
                       iolist_to_binary([randoms:get_string()
                                         | [jlib:integer_to_binary(X)
-                                           || X <- tuple_to_list(now())]]);
+                                           || X <- tuple_to_list(os:timestamp())]]);
 		Resource -> Resource
 	      end,
 	  case R of
@@ -991,7 +991,7 @@ wait_for_session({xmlstreamelement, El}, StateData) ->
 			  privacy_get_user_list, StateData#state.server,
 			  #userlist{},
 			  [U, StateData#state.server]),
-		    SID = {now(), self()},
+		    SID = {os:timestamp(), self()},
 		    Conn = get_conn_type(StateData),
 		    Info = [{ip, StateData#state.ip}, {conn, Conn},
 			    {auth_module, StateData#state.auth_module}],
@@ -1833,7 +1833,7 @@ presence_update(From, Packet, StateData) ->
 			  OldPresence -> get_priority_from_presence(OldPresence)
 			end,
 	  NewPriority = get_priority_from_presence(Packet),
-	  Timestamp = calendar:now_to_universal_time(now()),
+	  Timestamp = calendar:now_to_universal_time(os:timestamp()),
 	  update_priority(NewPriority, Packet, StateData),
 	  FromUnavail = (StateData#state.pres_last == undefined),
 	  ?DEBUG("from unavail = ~p~n", [FromUnavail]),

--- a/src/ejabberd_captcha.erl
+++ b/src/ejabberd_captcha.erl
@@ -691,5 +691,5 @@ clean_treap(Treap, CleanPriority) ->
     end.
 
 now_priority() ->
-    {MSec, Sec, USec} = now(),
+    {MSec, Sec, USec} = os:timestamp(),
     -((MSec * 1000000 + Sec) * 1000000 + USec).

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -63,7 +63,7 @@ start() ->
     Config = get_ejabberd_config_path(),
     load_file(Config),
     %% This start time is used by mod_last:
-    add_local_option(node_start, now()),
+    add_local_option(node_start, os:timestamp()),
     ok.
 
 %% @doc Get the filename of the ejabberd configuration file.

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -345,8 +345,8 @@ do_route(OrigFrom, OrigTo, OrigPacket) ->
 			  ejabberd_config:get_local_option({domain_balancing,
 							    LDstDomain}, fun(D) when is_atom(D) -> D end)
 			    of
-			  undefined -> now();
-			  random -> now();
+			  undefined -> os:timestamp();
+			  random -> os:timestamp();
 			  source -> jlib:jid_tolower(From);
 			  destination -> jlib:jid_tolower(To);
 			  bare_source ->

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -68,7 +68,7 @@
 -record(state, {}).
 
 -record(temporarily_blocked, {host = <<"">>     :: binary(),
-                              timestamp = now() :: erlang:timestamp()}).
+                              timestamp = os:timestamp() :: erlang:timestamp()}).
 
 -type temporarily_blocked() :: #temporarily_blocked{}.
 
@@ -110,7 +110,7 @@ external_host_overloaded(Host) ->
     mnesia:transaction(fun () ->
 			       mnesia:write(#temporarily_blocked{host = Host,
 								 timestamp =
-								     now()})
+								     os:timestamp()})
 		       end).
 
 -spec is_temporarly_blocked(binary()) -> boolean().
@@ -119,7 +119,7 @@ is_temporarly_blocked(Host) ->
     case mnesia:dirty_read(temporarily_blocked, Host) of
       [] -> false;
       [#temporarily_blocked{timestamp = T} = Entry] ->
-	  case timer:now_diff(now(), T) of
+	  case timer:now_diff(os:timestamp(), T) of
 	    N when N > (?S2S_OVERLOAD_BLOCK_PERIOD) * 1000 * 1000 ->
 		mnesia:dirty_delete_object(Entry), false;
 	    _ -> true

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -1108,7 +1108,7 @@ get_addr_port(Server) ->
 	  ?DEBUG("srv lookup of '~s': ~p~n",
 		 [Server, HEnt#hostent.h_addr_list]),
 	  AddrList = HEnt#hostent.h_addr_list,
-	  {A1, A2, A3} = now(),
+	  {A1, A2, A3} = os:timestamp(),
 	  random:seed(A1, A2, A3),
 	  case catch lists:map(fun ({Priority, Weight, Port,
 				     Host}) ->
@@ -1256,7 +1256,7 @@ wait_before_reconnect(StateData) ->
     cancel_timer(StateData#state.timer),
     Delay = case StateData#state.delay_to_retry of
 	      undefined_delay ->
-		  {_, _, MicroSecs} = now(), MicroSecs rem 14000 + 1000;
+		  {_, _, MicroSecs} = os:timestamp(), MicroSecs rem 14000 + 1000;
 	      D1 -> lists:min([D1 * 2, get_max_retry_delay()])
 	    end,
     Timer = erlang:start_timer(Delay, self(), []),

--- a/src/extauth.erl
+++ b/src/extauth.erl
@@ -100,7 +100,7 @@ call_port(Server, Msg) ->
     receive {eauth, Result} -> Result end.
 
 random_instance(MaxNum) ->
-    {A1, A2, A3} = now(),
+    {A1, A2, A3} = os:timestamp(),
     random:seed(A1, A2, A3),
     random:uniform(MaxNum) - 1.
 

--- a/src/gen_iq_handler.erl
+++ b/src/gen_iq_handler.erl
@@ -101,7 +101,7 @@ handle(Host, Module, Function, Opts, From, To, IQ) ->
 	  process_iq(Host, Module, Function, From, To, IQ);
       {one_queue, Pid} -> Pid ! {process_iq, From, To, IQ};
       {queues, Pids} ->
-	  Pid = lists:nth(erlang:phash(now(), length(Pids)),
+	  Pid = lists:nth(erlang:phash(os:timestamp(), length(Pids)),
 			  Pids),
 	  Pid ! {process_iq, From, To, IQ};
       parallel ->

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -614,7 +614,7 @@ gb_trees_fold_iter(F, Acc, Iter) ->
     end.
 
 now_ts() ->
-    {MegaSecs, Secs, _} = now(), MegaSecs * 1000000 + Secs.
+    {MegaSecs, Secs, _} = os:timestamp(), MegaSecs * 1000000 + Secs.
 
 is_valid_node(Node) ->
     case str:tokens(Node, <<"#">>) of

--- a/src/mod_configure2.erl
+++ b/src/mod_configure2.erl
@@ -183,7 +183,7 @@ process_get(#xmlel{name = <<"last">>, attrs = Attrs}) ->
       {'EXIT', _Reason} ->
 	  {error, ?ERR_INTERNAL_SERVER_ERROR};
       Vals ->
-	  {MegaSecs, Secs, _MicroSecs} = now(),
+	  {MegaSecs, Secs, _MicroSecs} = os:timestamp(),
 	  TimeStamp = MegaSecs * 1000000 + Secs,
 	  Str = list_to_binary(
                   [[jlib:integer_to_binary(TimeStamp - V),

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -111,7 +111,7 @@ get_node_uptime() ->
         undefined ->
             trunc(element(1, erlang:statistics(wall_clock)) / 1000);
         StartNow ->
-            now_to_seconds(now()) - now_to_seconds(StartNow)
+            now_to_seconds(os:timestamp()) - now_to_seconds(StartNow)
     end.
 
 now_to_seconds({MegaSecs, Secs, _MicroSecs}) ->
@@ -198,7 +198,7 @@ get_last_iq(IQ, SubEl, LUser, LServer) ->
 		IQ#iq{type = error,
 		      sub_el = [SubEl, ?ERR_SERVICE_UNAVAILABLE]};
 	    {ok, TimeStamp, Status} ->
-		TimeStamp2 = now_to_seconds(now()),
+		TimeStamp2 = now_to_seconds(os:timestamp()),
 		Sec = TimeStamp2 - TimeStamp,
 		IQ#iq{type = result,
 		      sub_el =
@@ -220,7 +220,7 @@ get_last_iq(IQ, SubEl, LUser, LServer) ->
     end.
 
 on_presence_update(User, Server, _Resource, Status) ->
-    TimeStamp = now_to_seconds(now()),
+    TimeStamp = now_to_seconds(os:timestamp()),
     store_last_info(User, Server, TimeStamp, Status).
 
 store_last_info(User, Server, TimeStamp, Status) ->

--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -57,8 +57,8 @@
 
 -record(offline_msg,
 	{us = {<<"">>, <<"">>} :: {binary(), binary()},
-         timestamp = now()     :: erlang:timestamp() | '_',
-         expire = now()        :: erlang:timestamp() | never | '_',
+         timestamp = os:timestamp()     :: erlang:timestamp() | '_',
+         expire = os:timestamp()        :: erlang:timestamp() | never | '_',
          from = #jid{}         :: jid() | '_',
          to = #jid{}           :: jid() | '_',
          packet = #xmlel{}     :: xmlel() | '_'}).
@@ -236,7 +236,7 @@ store_packet(From, To, Packet) ->
 	   case check_event(From, To, Packet) of
 	     true ->
 		 #jid{luser = LUser, lserver = LServer} = To,
-		 TimeStamp = now(),
+		 TimeStamp = os:timestamp(),
 		 #xmlel{children = Els} = Packet,
 		 Expire = find_x_expire(TimeStamp, Els),
 		 gen_mod:get_module_proc(To#jid.lserver, ?PROCNAME) !
@@ -364,7 +364,7 @@ pop_offline_messages(Ls, LUser, LServer, mnesia) ->
 	end,
     case mnesia:transaction(F) of
       {atomic, Rs} ->
-	  TS = now(),
+	  TS = os:timestamp(),
 	  Ls ++
 	    lists:map(fun (R) ->
 			      offline_msg_to_route(LServer, R)
@@ -408,7 +408,7 @@ remove_expired_messages(Server) ->
 			    gen_mod:db_type(LServer, ?MODULE)).
 
 remove_expired_messages(_LServer, mnesia) ->
-    TimeStamp = now(),
+    TimeStamp = os:timestamp(),
     F = fun () ->
 		mnesia:write_lock_table(offline_msg),
 		mnesia:foldl(fun (Rec, _Acc) ->
@@ -432,7 +432,7 @@ remove_old_messages(Days, Server) ->
 			gen_mod:db_type(LServer, ?MODULE)).
 
 remove_old_messages(Days, _LServer, mnesia) ->
-    {MegaSecs, Secs, _MicroSecs} = now(),
+    {MegaSecs, Secs, _MicroSecs} = os:timestamp(),
     S = MegaSecs * 1000000 + Secs - 60 * 60 * 24 * Days,
     MegaSecs1 = S div 1000000,
     Secs1 = S rem 1000000,
@@ -763,7 +763,7 @@ get_messages_subset2(Max, Length, MsgsAll, mnesia) ->
     MsgsLastN = lists:nthtail(Length - FirstN - FirstN,
 			      Msgs2),
     NoJID = jlib:make_jid(<<"...">>, <<"...">>, <<"">>),
-    IntermediateMsg = #offline_msg{timestamp = now(),
+    IntermediateMsg = #offline_msg{timestamp = os:timestamp(),
 				   from = NoJID, to = NoJID,
 				   packet =
 				       #xmlel{name = <<"...">>, attrs = [],

--- a/src/mod_pres_counter.erl
+++ b/src/mod_pres_counter.erl
@@ -77,7 +77,7 @@ update(Server, JID, Dir) ->
     TimeInterval = gen_mod:get_module_opt(Server, ?MODULE, interval,
                                           fun(I) when is_integer(I), I>0 -> I end,
                                           60),
-    {MegaSecs, Secs, _MicroSecs} = now(),
+    {MegaSecs, Secs, _MicroSecs} = os:timestamp(),
     TimeStamp = MegaSecs * 1000000 + Secs,
     case read(Dir) of
       undefined ->

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -492,7 +492,7 @@ check_timeout(Source) ->
                         infinity
                 end, 600),
     if is_integer(Timeout) ->
-	   {MSec, Sec, _USec} = now(),
+	   {MSec, Sec, _USec} = os:timestamp(),
 	   Priority = -(MSec * 1000000 + Sec),
 	   CleanPriority = Priority + Timeout,
 	   F = fun () ->

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -210,7 +210,7 @@ write_roster_version_t(LUser, LServer) ->
     write_roster_version(LUser, LServer, true).
 
 write_roster_version(LUser, LServer, InTransaction) ->
-    Ver = sha:sha(term_to_binary(now())),
+    Ver = sha:sha(term_to_binary(os:timestamp())),
     write_roster_version(LUser, LServer, InTransaction, Ver,
 			 gen_mod:db_type(LServer, ?MODULE)),
     Ver.

--- a/src/mod_time.erl
+++ b/src/mod_time.erl
@@ -78,7 +78,7 @@ process_local_iq(_From, _To,
       set ->
 	  IQ#iq{type = error, sub_el = [SubEl, ?ERR_NOT_ALLOWED]};
       get ->
-	  Now = now(),
+	  Now = os:timestamp(),
 	  Now_universal = calendar:now_to_universal_time(Now),
 	  Now_local = calendar:now_to_local_time(Now),
 	  {UTC, UTC_diff} = jlib:timestamp_to_iso(Now_universal,

--- a/src/randoms.erl
+++ b/src/randoms.erl
@@ -36,7 +36,7 @@ start() ->
     register(random_generator, spawn(randoms, init, [])).
 
 init() ->
-    {A1, A2, A3} = now(), random:seed(A1, A2, A3), loop().
+    {A1, A2, A3} = os:timestamp(), random:seed(A1, A2, A3), loop().
 
 loop() ->
     receive

--- a/src/shaper.erl
+++ b/src/shaper.erl
@@ -59,7 +59,7 @@ new(Name) ->
 new1(none) -> none;
 new1({maxrate, MaxRate}) ->
     #maxrate{maxrate = MaxRate, lastrate = 0.0,
-	     lasttime = now_to_usec(now())}.
+	     lasttime = now_to_usec(os:timestamp())}.
 
 -spec update(maxrate(), integer()) -> {maxrate(), integer()}.
 
@@ -67,7 +67,7 @@ update(none, _Size) -> {none, 0};
 update(#maxrate{} = State, Size) ->
     MinInterv = 1000 * Size /
 		  (2 * State#maxrate.maxrate - State#maxrate.lastrate),
-    Interv = (now_to_usec(now()) - State#maxrate.lasttime) /
+    Interv = (now_to_usec(os:timestamp()) - State#maxrate.lasttime) /
 	       1000,
     ?DEBUG("State: ~p, Size=~p~nM=~p, I=~p~n",
 	   [State, Size, MinInterv, Interv]),
@@ -75,7 +75,7 @@ update(#maxrate{} = State, Size) ->
 		   1 + trunc(MinInterv - Interv);
 	       true -> 0
 	    end,
-    NextNow = now_to_usec(now()) + Pause * 1000,
+    NextNow = now_to_usec(os:timestamp()) + Pause * 1000,
     {State#maxrate{lastrate =
 		       (State#maxrate.lastrate +
 			  1000000 * Size / (NextNow - State#maxrate.lasttime))


### PR DESCRIPTION
erlang:now() locks the VM.
(see http://comments.gmane.org/gmane.comp.lang.erlang.general/67850)

os:timestamp() does not.

This patch is the first attempt to change it accross all code.
