### PR TITLE
Removed wrong option for `ejabberd_service` module (since 174c16a1)

### DIFF
--- a/src/ejabberd.cfg.example
+++ b/src/ejabberd.cfg.example
@@ -143,7 +143,6 @@
   %%{8888, ejabberd_service, [
   %%			    {access, all},
   %%			    {shaper_rule, fast},
-  %%			    {ip, {127, 0, 0, 1}},
   %%			    {hosts, ["icq.example.org", "sms.example.org"],
   %%			     [{password, "secret"}]
   %%			    }


### PR DESCRIPTION
Wrong and meaningless (according to code and documentation) option in `ejabberd.cfg.example`.

This mistake is also found in different howtos:
http://www.ejabberd.im/install-bandersnatch
http://www.ejabberd.im/node/4943
