### PR TITLE
Fix a bug when reading tuples from config

### DIFF
--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -720,7 +720,7 @@ strings_to_binary(L) when is_list(L) ->
             strings_to_binary1(L)
     end;
 strings_to_binary(T) when is_tuple(T) ->
-    list_to_tuple(strings_to_binary(tuple_to_list(T)));
+    list_to_tuple(strings_to_binary1(tuple_to_list(T)));
 strings_to_binary(X) ->
     X.
 


### PR DESCRIPTION
If the config contains a tuple of integers (for example, if a bind IP
address is specified) then strings_to_binary() calls tuple_to_list()
followed by strings_to_binary(), which then calls list_to_binary()
because the list looks like a string.  Then list_to_tuple() is called on
the returned binary, causing a crash.

This patch corrects the problem by calling strings_to_binary1() instead,
which ensures that the value that is passed into list_to_tuple() is a
list.
