### PR TITLE
Fix version check

### DIFF
--- a/m4/erlang-extra.m4
+++ b/m4/erlang-extra.m4
@@ -50,6 +50,10 @@ parse(Version) ->
 
 less_or_equal([[]], [[]]) ->
     true;
+less_or_equal([[]], _Any) ->
+    true;
+less_or_equal(_Any, [[]]) ->
+    false;
 less_or_equal([[Left| Rl]], [[Right| Rr]]) ->
     case {Left < Right, Left == Right} of
         {true, _}  ->


### PR DESCRIPTION
Not all Erlang versions are of equal length. Added clauses to handle this.
