### PR TITLE
Disable support for SSL 3 protocol in 2.1.x

### DIFF
--- a/src/tls/tls_drv.c
+++ b/src/tls/tls_drv.c
@@ -440,7 +440,7 @@ static ErlDrvSSizeT tls_drv_control(ErlDrvData handle,
 	    res = SSL_CTX_check_private_key(ctx);
 	    die_unless(res > 0, "SSL_CTX_check_private_key failed");
 
-	    SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2|SSL_OP_NO_TICKET);
+	    SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TICKET);
 
 	    SSL_CTX_set_cipher_list(ctx, CIPHERS);
 


### PR DESCRIPTION
Not sure if this'll work, but I believe it will disable negotiation for both the SSL 2 and SSL 3 protocols, leaving it to be TLS 1, 1.1, 1.2, or future versions yet to be written.

I *believe* it doesn't change the version requirements for OpenSSL, but obviously the higher the version the more available secure protocols (e.g. TLS 1.2 is available in OpenSSL 1.0.1 and later)

__Justification:__
* [A Public Statement Regarding Ubiquitous Encryption on the XMPP Network](https://github.com/stpeter/manifesto/blob/master/manifesto.txt)
* [Use of Transport Layer Security (TLS) in the Extensible Messaging and Presence Protocol (XMPP)](https://datatracker.ietf.org/doc/draft-saintandre-xmpp-tls/)
