### PR TITLE
Add missing parenthesis

### DIFF
--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -88,7 +88,7 @@
 
 -define(SUPERVISOR_START,
 	p1_fsm:start(ejabberd_s2s_in, [SockData, Opts],
-                     ?FSMOPTS ++ fsm_limit_opts(Opts)).
+                     ?FSMOPTS ++ fsm_limit_opts(Opts))).
 
 -else.
 


### PR DESCRIPTION
This fixes compilation with `./configure --enable-transient_supervisors`.
