### PR TITLE
Fix --enable-transient_supervisors flag

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -16,7 +16,7 @@ Cfg = case file:consult("vars.config") of
 Macros = lists:flatmap(
            fun({roster_gateway_workaround, true}) ->
                    [{d, 'ROSTER_GATEWAY_WORKAROUND'}];
-              ({transient_supervisors, true}) ->
+              ({transient_supervisors, false}) ->
                    [{d, 'NO_TRANSIENT_SUPERVISORS'}];
               ({nif, true}) ->
                    [{d, 'NIF'}];


### PR DESCRIPTION
Fix configure's `--{enable,disable}-transient_supervisors` option: Make sure it's enabled with `--enable` and disabled with `--disable`, not the other way round.  This also makes `--disable` the default setting, as documented.
