### PR TITLE
Add option to disable SSLv3

### DIFF
--- a/doc/guide.tex
+++ b/doc/guide.tex
@@ -869,7 +869,7 @@ The available modules, their purpose and the options allowed by each one are:
 \begin{description}
   \titem{\texttt{ejabberd\_c2s}}
     Handles c2s connections.\\
-    Options: \texttt{access}, \texttt{certfile}, \texttt{ciphers},
+    Options: \texttt{access}, \texttt{certfile}, \texttt{ciphers}, \texttt{sslv3\_disable}
     \texttt{max\_fsm\_queue},
     \texttt{max\_stanza\_size}, \texttt{shaper},
     \texttt{starttls}, \texttt{starttls\_required}, \texttt{tls},
@@ -917,6 +917,7 @@ This is a detailed description of each option allowed by the listening modules:
     To define a certificate file specific for a given domain, use the global option \term{domain\_certfile}.
   \titem{ciphers: Ciphers} OpenSSL ciphers list in the same format accepted by
   `\verb|openssl ciphers|' command.
+  \titem{sslv3\_disable: true|false} Wheater to disable SSLv3 protocol. The default value is false.
   \titem{default\_host: undefined|HostName\}}
     If the HTTP request received by ejabberd contains the HTTP header \term{Host}
     with an ambiguous virtual host that doesn't match any one defined in ejabberd (see \ref{hostnames}),
@@ -1065,6 +1066,8 @@ There are some additional global options that can be specified in the ejabberd c
   Full path to the file containing the SSL certificate for a specific domain.
   \titem{s2s\_ciphers: Ciphers} \ind{options!s2s\_ciphers} OpenSSL ciphers list
   in the same format accepted by `\verb|openssl ciphers|' command.
+  \titem{s2s\_sslv3\_disable: true|false} \ind{options!s2s\_sslv3\_disable}
+  Wheater to disable SSLv3 protocol. The default value is false.
   \titem{outgoing\_s2s\_families: [Family, ...]} \ind{options!outgoing\_s2s\_families}
   Specify which address families to try, in what order.
   By default it first tries connecting with IPv4, if that fails it tries using IPv6.

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -249,7 +249,11 @@ init([{SockMod, Socket}, Opts]) ->
                    false -> [compression_none | TLSOpts1];
                    true -> TLSOpts1
                end,
-    TLSOpts = [verify_none | TLSOpts2],
+    TLSOpts3 = case proplists:get_bool(sslv3_disable, Opts) of
+                   false -> TLSOpts2;
+                   true -> [sslv3_disable | TLSOpts2]
+               end,
+    TLSOpts = [verify_none | TLSOpts3],
     IP = peerip(SockMod, Socket),
     %% Check if IP is blacklisted:
     case is_ip_blacklisted(IP) of

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -182,9 +182,17 @@ init([{SockMod, Socket}, Opts]) ->
                    undefined -> TLSOpts1;
                    Ciphers -> [{ciphers, Ciphers} | TLSOpts1]
                end,
+    TLSOpts3 = case ejabberd_config:get_option(
+                      s2s_sslv3_disable,
+                      fun(true) -> true;
+                         (false) -> false
+                      end, false) of
+                   true -> [sslv3_disable | TLSOpts2];
+                   false -> TLSOpts2
+               end,
     TLSOpts = case proplists:get_bool(tls_compression, Opts) of
-                  false -> [compression_none | TLSOpts2];
-                  true -> TLSOpts2
+                  false -> [compression_none | TLSOpts3];
+                  true -> TLSOpts3
               end,
     Timer = erlang:start_timer(?S2STIMEOUT, self(), []),
     {ok, wait_for_stream,

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -196,13 +196,21 @@ init([From, Server, Type]) ->
                    undefined -> TLSOpts1;
                    Ciphers -> [{ciphers, Ciphers} | TLSOpts1]
                end,
+    TLSOpts3 = case ejabberd_config:get_option(
+                      s2s_sslv3_disable,
+                      fun(true) -> true;
+                         (false) -> false
+                      end, false) of
+                   true -> [sslv3_disable | TLSOpts2];
+                   false -> TLSOpts2
+               end,
     TLSOpts = case ejabberd_config:get_option(
                      {s2s_tls_compression, From},
                      fun(true) -> true;
                         (false) -> false
-                     end, true) of
-                  false -> [compression_none | TLSOpts2];
-                  true -> TLSOpts2
+                     end, false) of
+                  false -> [compression_none | TLSOpts3];
+                  true -> TLSOpts3
               end,
     {New, Verify} = case Type of
 		      {new, Key} -> {Key, false};


### PR DESCRIPTION
Add the option sslv3_disable in both c2s and s2s to enable/disable SSLv3 protocol. I've tested it in production and it works. Hope it can be merged. See https://github.com/processone/tls/commit/d669403348b10f3076b5a0ccae92bdb6e3d2876b
