### PR TITLE
Fix badarg issue on module update web site

### DIFF
--- a/src/ejabberd_web_admin.erl
+++ b/src/ejabberd_web_admin.erl
@@ -2183,7 +2183,7 @@ get_node(global, Node, [<<"update">>], Query, Lang) ->
 	       ?XCT(<<"h3">>, <<"Update script">>), FmtScript,
 	       ?XCT(<<"h3">>, <<"Low level update script">>),
 	       FmtLowLevelScript, ?XCT(<<"h3">>, <<"Script check">>),
-	       ?XC(<<"pre">>, (iolist_to_binary(Check))),
+	       ?XC(<<"pre">>, (jlib:atom_to_binary(Check))),
 	       ?BR,
 	       ?INPUTT(<<"submit">>, <<"update">>, <<"Update">>)])];
 get_node(Host, Node, NPath, Query, Lang) ->


### PR DESCRIPTION
This commit fixes the following error, triggered by accessing the `Nodes` &rarr; `$node` &rarr; `Update` page of the web interface:

```
bad argument in call to erlang:iolist_to_binary(ok) in ejabberd_web_admin:get_node/5
```

The `Check` variable always holds an atom (`ok` or `error`).
