### PR TITLE
Fix a type error

### DIFF
--- a/src/ejabberd_http.erl
+++ b/src/ejabberd_http.erl
@@ -51,7 +51,7 @@
 		request_auth,
 		request_keepalive,
 		request_content_length,
-		request_lang = "en",
+		request_lang = <<"en">>,
 		%% XXX bard: request handlers are configured in
 		%% ejabberd.cfg under the HTTP service.	 For example,
 		%% to have the module test_web handle requests with


### PR DESCRIPTION
This commit fixes a `badarg` issue in `translate:ascii_tolower/1`, called from `translate:translate/2`.
