### PR TITLE
Enable mod_carboncopy in example configuration

### DIFF
--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -514,6 +514,7 @@ modules:
     access: announce
   mod_blocking: {} # requires mod_privacy
   mod_caps: {}
+  mod_carboncopy: {}
   mod_configure: {} # requires mod_adhoc
   mod_disco: {}
   ## mod_echo: {}


### PR DESCRIPTION
XEP-0280 seems to be quite popular these days, so it would be nice if ejabberd enabled it by default.
