### PR TITLE
Fix the description of the access rules syntax in the Guide

### DIFF
--- a/doc/guide.tex
+++ b/doc/guide.tex
@@ -1784,7 +1784,7 @@ The syntax is:
 
 When a JID is checked to have access to \term{Accessname}, the server
 sequentially checks if that JID matches any of the ACLs that are named in the
-second elements of the tuples in the list. If it matches, the first element of
+first elements of the tuples in the list. If it matches, the second element of
 the first matched tuple is returned, otherwise the value `\term{deny}' is
 returned.
 


### PR DESCRIPTION
In the description of the `ACLName: allow|deny` tuple, the first element (`ACLName`) and the second element (`allow|deny`) are interchanged.
