### PR TITLE
Remove outdated comment from guide

### DIFF
--- a/doc/guide.tex
+++ b/doc/guide.tex
@@ -2521,8 +2521,7 @@ modules:
   mod_echo: {}
 \end{verbatim}
 \item In the second example the modules \modecho{}, \modtime{}, and
-  \modversion{} are loaded without options. Remark that, besides the last entry,
-  all entries end with a comma:
+  \modversion{} are loaded without options.
 \begin{verbatim}
 modules:
   mod_echo:      {}


### PR DESCRIPTION
Remove a comment that doesn't apply to the YAML configuration syntax.
