### PR TITLE
Update a URL in the guide

### DIFF
--- a/doc/guide.tex
+++ b/doc/guide.tex
@@ -920,7 +920,7 @@ This is a detailed description of each option allowed by the listening modules:
   `\verb|openssl ciphers|' command.
   \titem{protocol\_options: ProtocolOpts} \ind{options!protocol\_options}
   List of general options relating to SSL/TLS. These map to \verb|<a href="https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html">OpenSSL's set_options()</a>|.
-  For a full list of options available in ejabberd, \verb|<a href="https://github.com/processone/tls/blob/protocol_options/c_src/options.h">see the source</a>|.
+  For a full list of options available in ejabberd, \verb|<a href="https://github.com/processone/tls/blob/master/c_src/options.h">see the source</a>|.
   The default entry is: \verb|"no_sslv2"|
   \titem{default\_host: undefined|HostName\}}
     If the HTTP request received by ejabberd contains the HTTP header \term{Host}


### PR DESCRIPTION
The branch name in a GitHub URL must be updated, as the old branch (`protocol_options`) no longer exists.
