### PR TITLE
Don't log an error when "extauth_cache: false" is specified

### DIFF
--- a/src/ejabberd_auth_external.erl
+++ b/src/ejabberd_auth_external.erl
@@ -172,7 +172,9 @@ remove_user(User, Server, Password) ->
 get_cache_option(Host) ->
     case ejabberd_config:get_option(
            {extauth_cache, Host},
-           fun(I) when is_integer(I), I > 0 -> I end) of
+           fun(false) -> undefined;
+              (I) when is_integer(I), I > 0 -> I
+           end) of
         undefined -> false;
         CacheTime -> {true, CacheTime}
     end.


### PR DESCRIPTION
Don't log a "configuration problem" message if "extauth_cache: false" is
explicitly specified, as that's a valid configuration setting as per the
documentation.
