### PR TITLE
Always regenerate the configure script when running ./autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,3 @@
 # generate a new autoconf
 aclocal -I m4
-autoconf
+autoconf -f


### PR DESCRIPTION
As the version string is auto-generated from the `git-describe(1)` output, the `configure` script may need to be regenerated even if `configure.ac` wasn't modified.
