### PR TITLE
added error handling in mod_pubsub_odbc.

### DIFF
--- a/src/mod_pubsub_odbc.erl
+++ b/src/mod_pubsub_odbc.erl
@@ -885,10 +885,10 @@ unsubscribe_user(Entity, Owner) ->
     Host = host(element(2, BJID)),
     spawn(fun () ->
 		  lists:foreach(fun (PType) ->
-					{result, Subscriptions} =
-					    node_action(Host, PType,
+					case node_action(Host, PType,
 							get_entity_subscriptions,
-							[Host, Entity]),
+							[Host, Entity]) of
+						{result, Subscriptions} ->
 					lists:foreach(fun ({#pubsub_node{options
 									     =
 									     Options,
@@ -922,7 +922,10 @@ unsubscribe_user(Entity, Owner) ->
 							      end;
 							  (_) -> ok
 						      end,
-						      Subscriptions)
+						      Subscriptions);
+					Error ->
+					    ?DEBUG("Error at node_action: ~p", [Error])
+					end
 				end,
 				plugins(Host))
 	  end).


### PR DESCRIPTION
I got badmatch error in mod_pubsub_odbc.

2014-04-23 00:00:01 =ERROR REPORT====
Error in process <0.1866.4> on node 'ejabberd@localhost' with exit value: {{badmatch,{error,{xmlel,<<5 bytes>>,[{<<4 bytes>>,<<3 bytes>>},{<<4 bytes>>,<<4 bytes>>}],[{xmlel,<<21 bytes>>,[{<<5 bytes>>,<<35 bytes>>}],[]}]}}},[{mod_pubsub_odbc,'-unsubscribe_user/2-fun-1-',4,[{file,"src/mod_pubsub_odbc.erl"},{line,888}]},{lists,foreach,2,[{file,"lists.erl"},{line,1262}]}]}

I fixed so that we don't get crash.
