### PR TITLE
undefined ejabberd_socket:get_conn_type/1

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -550,8 +550,7 @@ wait_for_auth({xmlstreamelement, El}, StateData) ->
 				[StateData#state.socket,
 				 jlib:jid_to_string(JID), AuthModule]),
 			SID = {now(), self()},
-			Conn = (StateData#state.sockmod):get_conn_type(
-				    StateData#state.socket),
+			Conn = get_conn_type(StateData),
 			Info = [{ip, StateData#state.ip}, {conn, Conn},
 				    {auth_module, AuthModule}],
                         Res = jlib:make_result_iq_reply(


### PR DESCRIPTION
I got folloing crash.

2014-04-24 02:04:32 =CRASH REPORT====
  crasher:
    initial call: gen:init_it/6
    pid: <0.25234.2>
    registered_name: []
    exception exit: {{undef,[{ejabberd_socket,get_conn_type,[{socket_state,gen_tcp,#Port<0.138053>,<0.25233.2>}],[]},{ejabberd_c2s,wait_for_auth,2,[{file,"src/ejabberd_c2s.erl"},{line,540}]},{p1_fsm,handle_msg,10,[{file,"src/p1_fsm.erl"},{line,578}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,227}]}]},[{p1_fsm,terminate,7,[{file,"src/p1_fsm.erl"},{line,733}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,227}]}]}
    ancestors: [ejabberd_c2s_sup,ejabberd_sup,<0.37.0>]
    messages: [{'$gen_event',closed}]
    links: [<0.282.0>]
    dictionary: [{'$internal_queue_len',0}]
    trap_exit: false
    status: running
    heap_size: 2584
    stack_size: 24
    reductions: 2062
  neighbours:
