### PR TITLE
added get_random_pid/1 error handling

### DIFF
--- a/src/ejabberd_odbc.erl
+++ b/src/ejabberd_odbc.erl
@@ -140,9 +140,12 @@ sql_bloc(Host, F) -> sql_call(Host, {sql_bloc, F}).
 sql_call(Host, Msg) ->
     case get(?STATE_KEY) of
       undefined ->
-	  (?GEN_FSM):sync_send_event(ejabberd_odbc_sup:get_random_pid(Host),
-				     {sql_cmd, Msg, now()},
-				     ?TRANSACTION_TIMEOUT);
+        case ejabberd_odbc_sup:get_random_pid(Host) of
+          none -> ?WARNING_MSG("SQL calling unknown host: ~p~n", [Host]);
+          Pid ->
+            (?GEN_FSM):sync_send_event(Pid,{sql_cmd, Msg, now()},
+                                       ?TRANSACTION_TIMEOUT)
+          end;
       _State -> nested_op(Msg)
     end.
 

--- a/src/ejabberd_odbc_sup.erl
+++ b/src/ejabberd_odbc_sup.erl
@@ -82,8 +82,10 @@ get_pids(Host) ->
     [R#sql_pool.pid || R <- Rs].
 
 get_random_pid(Host) ->
-    Pids = get_pids(Host),
-    lists:nth(erlang:phash(now(), length(Pids)), Pids).
+    case get_pids(Host) of
+      [] -> none;
+      Pids -> lists:nth(erlang:phash(now(), length(Pids)), Pids)
+    end.
 
 add_pid(Host, Pid) ->
     F = fun () ->


### PR DESCRIPTION
I got folloing error:
2014-04-24 00:18:25.947 [error] @mod_pubsub_odbc:transaction_retry:4854 transaction return internal error: {'EXIT',{badarg,[{erlang,phash,[{1398,266305,946915},0],[]},{ejabberd_odbc_sup,get_random_pid,1,[{file,"src/ejabberd_odbc_sup.erl"},{line,87}]},{ejabberd_odbc,sql_call,2,[{file,"src/ejabberd_odbc.erl"},{line,144}]},{mod_pubsub_odbc,transaction_retry,4,[{file,"src/mod_pubsub_odbc.erl"},{line,4835}]},{mod_pubsub_odbc,'-unsubscribe_user/2-fun-2-',4,[{file,"src/mod_pubsub_odbc.erl"},{line,888}]},{lists,foreach,2,[{file,"lists.erl"},{line,1262}]}]}}

Don't specify zero to second argument of erlang:phash/2.
Thank you.
