### PR TITLE
Check TLS state before requesting SASL EXTERNAL for outgoing s2s connections

### DIFF
--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -578,7 +578,9 @@ wait_for_features({xmlstreamelement, El}, StateData) ->
 		 {next_state, stream_established,
 		  StateData#state{queue = queue:new()}};
 	     SASLEXT and StateData#state.try_auth and
-	       (StateData#state.new /= false) ->
+	       (StateData#state.new /= false) and
+		 (StateData#state.tls_enabled or
+		   not StateData#state.tls_required) ->
 		 send_element(StateData,
 			      #xmlel{name = <<"auth">>,
 				     attrs =


### PR DESCRIPTION
Make sure a remote server can't circumvent "s2s_use_starttls: required" by offering `SASL EXTERNAL` authentication over a non-TLS connection.
