### PR TITLE
Fix handling of certificate verification errors for incoming s2s connections

### DIFF
--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -297,13 +297,6 @@ wait_for_stream({xmlstreamstart, _Name, Attrs},
 			  <<(xml:element_to_binary(?SERRT_POLICY_VIOLATION(<<"en">>,
 									   CertError)))/binary,
 			    (?STREAM_TRAILER)/binary>>),
-		{atomic, Pid} =
-		    ejabberd_s2s:find_connection(jlib:make_jid(<<"">>,
-							       Server, <<"">>),
-						 jlib:make_jid(<<"">>,
-							       RemoteServer,
-							       <<"">>)),
-		ejabberd_s2s_out:stop_connection(Pid),
 		{stop, normal, StateData};
 	    {VerifyResult, RemoteServer, Msg} ->
 		{SASL, NewStateData} = case VerifyResult of


### PR DESCRIPTION
This changes the handling of certificate verification errors for incoming s2s connections in two ways:
1. A stream trailer is sent before closing the socket.
2. Outgoing connections are no longer looked up and closed, because the `ejabberd_s2s:find_connection/2` call actually created one or more _new_ connections if less than `max_s2s_connections` connections were found.   Then, no more than one of those (possibly new) connections were stopped by the `ejabberd_s2s_out:stop_connection/1` call.  This behavior doesn't make much sense, and unless I'm overlooking something, there's no reason to bother with outgoing connections here anyway.
