### PR TITLE
New ejabberd command: disconnect_user/2

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1229,6 +1229,10 @@ handle_info(replaced, StateName, StateData) ->
     Lang = StateData#state.lang,
     Xmlelement = ?SERRT_CONFLICT(Lang, <<"Replaced by new connection">>),
     handle_info({kick, replaced, Xmlelement}, StateName, StateData);
+handle_info(disconnect, StateName, StateData) ->
+    Lang = StateData#state.lang,
+    Xmlelement = ?SERRT_POLICY_VIOLATION(Lang, <<"has been kicked">>),
+    handle_info({kick, kicked_by_admin, Xmlelement}, StateName, StateData);
 handle_info({kick, Reason, Xmlelement}, _StateName, StateData) ->
     send_element(StateData, Xmlelement),
     send_trailer(StateData),

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -826,12 +826,11 @@ user_resources(User, Server) ->
     lists:sort(Resources).
 
 disconnect_user(User, Server) ->
-    Xmlelement = ?SERRT_POLICY_VIOLATION(<<"en">>, <<"has been kicked">>),
     Resources = get_user_resources(User, Server),
     lists:foreach(
 	fun(Resource) ->
 		PID = get_session_pid(User, Server, Resource),
-		PID ! {kick, kicked_by_admin, Xmlelement}
+		PID ! disconnect
 	end, Resources),
     length(Resources).
 


### PR DESCRIPTION
Add a `disconnect_user/2` command that can be called via `ejabberdctl` in order to disconnect all active sessions of the specified user on the specified host (analogous to `mod_configure`'s "End User Session" command).
