### PR TITLE
Let ejabberdctl accept binary string arguments

### DIFF
--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -418,6 +418,7 @@ is_supported_args(Args) ->
       fun({_Name, Format}) ->
 	      (Format == integer)
 		  or (Format == string)
+		      or (Format == binary)
       end,
       Args).
 


### PR DESCRIPTION
Don't let `ejabberdctl` print the following message for ejabberd commands that expect binary string arguments:

```
This command cannot be executed using ejabberdctl. Try ejabberd_xmlrpc.
```
