### PR TITLE
Update README: XEP-0227 code no longer uses exmpp

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,6 @@ To compile ejabberd you need:
  - GNU Iconv 1.8 or higher, for the IRC Transport
    (mod_irc). Optional. Not needed on systems with GNU Libc.
  - ImageMagick's Convert program. Optional. For CAPTCHA challenges.
- - exmpp 0.9.6 or higher. Optional. For import/export XEP-0227 files. 
 
 
 1. Compile and install on *nix systems


### PR DESCRIPTION
These days, `ejabberd_piefxis` doesn't use the exmpp library anymore.
