### PR TITLE
mod_register_web should response 404 instead of process crash.

### DIFF
--- a/src/mod_register_web.erl
+++ b/src/mod_register_web.erl
@@ -140,7 +140,10 @@ process([<<"change_password">>],
                 list_to_binary([?T(<<"There was an error changing the password: ">>),
                                 ?T(get_error_text(Error))]),
 	  {404, [], ErrorText}
-    end.
+    end;
+
+process(Path, _Request) ->
+    {404, [], "Not Found"}.
 
 %%%----------------------------------------------------------------------
 %%% CSS


### PR DESCRIPTION
mod_register_web may crash by unexpected request.
It's better response 404 would be good.
