### PR TITLE
fix ejabberd_system_monitor:s2s_out_info/1 error

### DIFF
--- a/src/ejabberd_system_monitor.erl
+++ b/src/ejabberd_system_monitor.erl
@@ -244,9 +244,8 @@ s2s_out_info(Pid) ->
     [<<"Process type: s2s_out">>,
      case FromTo of
        [{From, To}] ->
-	   <<"\n",
-	     (io_lib:format("S2S connection: from ~s to ~s",
-			    [From, To]))/binary>>;
+	     list_to_binary(io_lib:format("\nS2S connection: from ~s to ~s",
+			    [From, To]));
        _ -> <<"">>
      end,
      check_send_queue(Pid), <<"\n">>,


### PR DESCRIPTION
large heap watchdog does not working caused by following error:

```
Error in process <0.4634.4> on node 'ejabberd@localhost' with exit value: {badarg,[{erlang,byte_size,[[83,50,83,32,99,111,110,110,101,99,116,105,111,110,58,32,102,114,111,109,32,"conference.xmpp.jp",32,116,111,32,"tigase.im"]],[]},{ejabberd_system_monitor,s2s_out_info,1,[{file,"src/ejabberd_system_monitor.erl"},{line,248}]},{ejabberd_system_monitor,process_large_heap...
```
