### PR TITLE
test/README: Create MySQL test user on localhost

### DIFF
--- a/test/README
+++ b/test/README
@@ -12,6 +12,6 @@ template1=# CREATE DATABASE ejabberd_test;
 template1=# GRANT ALL PRIVILEGES ON DATABASE ejabberd_test TO ejabberd_test;
 
 $ mysql
-mysql> CREATE USER ejabberd_test IDENTIFIED BY 'ejabberd_test';
+mysql> CREATE USER 'ejabberd_test'@'localhost' IDENTIFIED BY 'ejabberd_test';
 mysql> CREATE DATABASE ejabberd_test;
-mysql> GRANT ALL ON ejabberd_test.* TO ejabberd_test;
+mysql> GRANT ALL ON ejabberd_test.* TO 'ejabberd_test'@'localhost';


### PR DESCRIPTION
Suggest specifying `localhost` as host name part of the MySQL test account name.  Otherwise, the anonymous user that is usually created by default for `localhost` [would take precedence](http://dev.mysql.com/doc/refman/5.7/en/adding-users.html) for local connections due to the more specific host name.
