### PR TITLE
Add Travis CI configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: erlang
+
+otp_release:
+  - 17.0
+  - R15B01
+
+before_install:
+  - sudo apt-get -qq update
+
+install:
+  - sudo apt-get -qq install libexpat1-dev libyaml-dev libpam0g-dev
+
+before_script:
+  - mysql -u root -e "CREATE USER 'ejabberd_test'@'localhost' IDENTIFIED BY 'ejabberd_test';"
+  - mysql -u root -e "CREATE DATABASE ejabberd_test;"
+  - mysql -u root -e "GRANT ALL ON ejabberd_test.* TO 'ejabberd_test'@'localhost';"
+  - psql -U postgres -c "CREATE USER ejabberd_test WITH PASSWORD 'ejabberd_test';"
+  - psql -U postgres -c "CREATE DATABASE ejabberd_test;"
+  - psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE ejabberd_test TO ejabberd_test;"
+
+script:
+  - ./autogen.sh
+  - ./configure --enable-transient_supervisors --enable-all --disable-http --disable-odbc
+  - make
+  - make test
+  - grep -q 'TEST COMPLETE, \([[:digit:]]*\) ok, .* of \1 ' logs/raw.log
+
+after_script:
+  - find logs -name suite.log -exec cat '{}' ';'
+
+after_failure:
+  - find logs -name ejabberd.log -exec cat '{}' ';'
+
+notifications:
+  email: false


### PR DESCRIPTION
Travis CI is an automatic test build service that integrates nicely with GitHub: By default, all commits and [pull requests](http://docs.travis-ci.com/user/pull-requests/) are tested.  The output can be viewed [online](https://travis-ci.org/weiss/ejabberd) (follow the "Job" links for the individual OTP releases to see [the](https://travis-ci.org/weiss/ejabberd/jobs/24484670) [details](https://travis-ci.org/weiss/ejabberd/jobs/24484671)), and pull requests are [annotated](http://blog.travis-ci.com/2012-09-04-pull-requests-just-got-even-more-awesome/) with the test results.  That's quite useful for weeding out contributions that break `make test` or don't even compile.

Automatic test builds can be enabled like this:
1. On https://travis-ci.org/, use the "Sign in with GitHub" button.
2. On https://travis-ci.org/profile, flip the switch to "on" for the `processone/ejabberd` repository.
3. Merge this pull request.

If you like, you could enable [email or other notifications](http://docs.travis-ci.com/user/notifications/) in the [.travis.yml file](http://docs.travis-ci.com/user/build-configuration/), or you could modify the [list of OTP releases](https://github.com/weiss/ejabberd/blob/add-travis-support/.travis.yml#L3) to build against.  The [`--disable-odbc`](https://github.com/weiss/ejabberd/blob/add-travis-support/.travis.yml#L23) flag could probably be removed [soon](https://github.com/travis-ci/travis-cookbooks/pull/310).
