### PR TITLE
fix mod_offline:count_offline_messages/2

### DIFF
--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -870,7 +870,7 @@ count_offline_messages(LUser, LServer) ->
     case catch odbc_queries:count_records_where(
 		 LServer, "spool",
                  <<"where username='", Username/binary, "'">>) of
-        {selected, [_], [{Res}]} ->
+        {selected, [_], [[Res]]} ->
             jlib:binary_to_integer(Res);
         _ ->
             0


### PR DESCRIPTION
mod_offline:count_offline_messages/2 always return 0 by trivial type mismatch.
It follows that max_user_offline_messages does not working.
I have tested only in mysql.
