### PR TITLE
XEP-0198: Terminate session if stanza queue becomes too large

### DIFF
--- a/doc/guide.tex
+++ b/doc/guide.tex
@@ -983,10 +983,10 @@ This is a detailed description of each option allowed by the listening modules:
   \titem{max\_ack\_queue: Size}
     This option specifies the maximum number of unacknowledged stanzas
     queued for possible retransmission if \term{stream\_management} is
-    enabled. When the limit is reached, the first stanza is dropped from
-    the queue before adding the next one. This option can be specified
-    for \term{ejabberd\_c2s} listeners. The allowed values are positive
-    integers and \term{infinity}. Default value: \term{500}.
+    enabled. When the limit is exceeded, the client session is
+    terminated. This option can be specified for \term{ejabberd\_c2s}
+    listeners. The allowed values are positive integers and
+    \term{infinity}. Default value: \term{500}.
   \titem{max\_fsm\_queue: Size}
     This option specifies the maximum number of elements in the queue of the FSM
     (Finite State Machine).


### PR DESCRIPTION
The XEP-0198 code saves a copy of each incoming stanza until the stanza is acknowledged by the client.  However, the size of the stanza queue must be limited to make sure the server won't be liable to DoS.  Currently, the oldest item is dropped from the queue if the queue length reaches some threshold (configurable via `max_ack_queue`).  This behavior renders stream management unreliable: Stanzas are dropped without a bounce, and if the session is later [resumed](http://xmpp.org/extensions/xep-0198.html#resumption), the client might miss (some of) the dropped stanzas.  Therefore, it's [probably better](http://mail.jabber.org/pipermail/standards/2014-May/thread.html#28842) to terminate the session on queue overflow.

This patch implements that by sending a `mgmt_queue_full` message to `self()`, because propagating the termination up the call stack seems a bit cumbersome.  If you don't like that, please let me know.
