### PR TITLE
Rename disconnect_user/2 command

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1364,7 +1364,7 @@ handle_info(replaced, StateName, StateData) ->
     Lang = StateData#state.lang,
     Xmlelement = ?SERRT_CONFLICT(Lang, <<"Replaced by new connection">>),
     handle_info({kick, replaced, Xmlelement}, StateName, StateData);
-handle_info(disconnect, StateName, StateData) ->
+handle_info(kick, StateName, StateData) ->
     Lang = StateData#state.lang,
     Xmlelement = ?SERRT_POLICY_VIOLATION(Lang, <<"has been kicked">>),
     handle_info({kick, kicked_by_admin, Xmlelement}, StateName, StateData);

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -54,7 +54,7 @@
 	 connected_users/0,
 	 connected_users_number/0,
 	 user_resources/2,
-	 disconnect_user/2,
+	 kick_user/2,
 	 get_session_pid/3,
 	 get_user_info/3,
 	 get_user_ip/3,
@@ -822,10 +822,10 @@ commands() ->
 			module = ?MODULE, function = user_resources,
 			args = [{user, binary}, {host, binary}],
 			result = {resources, {list, {resource, string}}}},
-     #ejabberd_commands{name = disconnect_user,
+     #ejabberd_commands{name = kick_user,
 			tags = [session],
 			desc = "Disconnect user's active sessions",
-			module = ?MODULE, function = disconnect_user,
+			module = ?MODULE, function = kick_user,
 			args = [{user, binary}, {host, binary}],
 			result = {num_resources, integer}}].
 
@@ -844,7 +844,7 @@ user_resources(User, Server) ->
     Resources = get_user_resources(User, Server),
     lists:sort(Resources).
 
-disconnect_user(User, Server) ->
+kick_user(User, Server) ->
     Resources = get_user_resources(User, Server),
     lists:foreach(
 	fun(Resource) ->


### PR DESCRIPTION
The mod_admin_extra module provides a `kick_session/4` command.  Rename the `disconnect_user/2` command to `kick_user/2` for consistency.
