### PR TITLE
Update ejabberd_xmlrpc documentation URL in the guide

### DIFF
--- a/doc/guide.tex
+++ b/doc/guide.tex
@@ -907,7 +907,7 @@ The available modules, their purpose and the options allowed by each one are:
     Options: \texttt{access\_commands}, \texttt{maxsessions}, \texttt{timeout}.\\
     You can find option explanations, example configuration in old and new format,
     and example calls in several languages in the old
-    \footahref{https://raw.github.com/processone/ejabberd-contrib/master/ejabberd\_xmlrpc/README.txt}{ejabberd\_xmlrpc README.txt}
+    \footahref{http://www.ejabberd.im/ejabberd\_xmlrpc}{ejabberd\_xmlrpc documentation}.
 \end{description}
 
 


### PR DESCRIPTION
`ejabberd-contrib/ejabberd_xmlrpc/README.txt` is gone, the contents are now available on http://www.ejabberd.im/ejabberd_xmlrpc.
