### PR TITLE
Don't use cached passwords if "extauth_cache: 0"

### DIFF
--- a/src/ejabberd_auth_external.erl
+++ b/src/ejabberd_auth_external.erl
@@ -186,6 +186,8 @@ check_password_extauth(User, Server, Password) ->
 try_register_extauth(User, Server, Password) ->
     extauth:try_register(User, Server, Password).
 
+check_password_cache(User, Server, Password, 0) ->
+    check_password_external_cache(User, Server, Password);
 check_password_cache(User, Server, Password,
 		     CacheTime) ->
     case get_last_access(User, Server) of


### PR DESCRIPTION
Regarding `extauth_cache`, the guide [says](http://www.process-one.net/docs/ejabberd/guide_en.html#htoc25):

> The integer 0 (zero) enables caching for statistics, but doesn't use that cached information to authenticate users.

Make sure the cached password isn't used even if the user is currently logged in with another resource.
