### PR TITLE
Omit XML namespace declaration for <iq/> stanzas

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1395,7 +1395,6 @@ handle_info({route, _From, _To, {broadcast, Data}},
                     fsm_next_state(StateName, StateData);
                 NewPL ->
                     PrivPushIQ = #iq{type = set,
-                                     xmlns = ?NS_PRIVACY,
                                      id = <<"push",
                                             (randoms:get_string())/binary>>,
                                      sub_el =
@@ -2557,8 +2556,7 @@ route_blocking(What, StateData) ->
 		  #xmlel{name = <<"unblock">>,
 			 attrs = [{<<"xmlns">>, ?NS_BLOCKING}], children = []}
 	    end,
-    PrivPushIQ = #iq{type = set, xmlns = ?NS_BLOCKING,
-		     id = <<"push">>, sub_el = [SubEl]},
+    PrivPushIQ = #iq{type = set, id = <<"push">>, sub_el = [SubEl]},
     PrivPushEl =
 	jlib:replace_from_to(jlib:jid_remove_resource(StateData#state.jid),
 			     StateData#state.jid, jlib:iq_to_xml(PrivPushIQ)),


### PR DESCRIPTION
Only the child elements of `<iq/>` stanzas are qualified by non-default namespaces, not the `<iq/>` stanzas themselves.

This change just clarifies the code.  It doesn't alter the behaviour, as the `<iq/>` stanzas are handed over to `jlib:iq_to_xml/1`, and that function [ignores](https://github.com/processone/ejabberd/blob/6baf3a24de429ed6cf27b267d5b91ef3d64114bf/src/jlib.erl#L453) the `xmlns` attribute anyway.
