### PR TITLE
XEP-0198: Don't exit on socket send failure

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1811,6 +1811,14 @@ send_text(StateData, Text) when StateData#state.xml_socket ->
     ?DEBUG("Send Text on stream = ~p", [Text]),
     (StateData#state.sockmod):send_xml(StateData#state.socket, 
 				       {xmlstreamraw, Text});
+send_text(StateData, Text) when StateData#state.mgmt_state == active ->
+    ?DEBUG("Send XML on stream = ~p", [Text]),
+    case catch (StateData#state.sockmod):send(StateData#state.socket, Text) of
+      {'EXIT', _} ->
+	  (StateData#state.sockmod):close(StateData#state.socket);
+      _ ->
+	  ok
+    end;
 send_text(StateData, Text) ->
     ?DEBUG("Send XML on stream = ~p", [Text]),
     (StateData#state.sockmod):send(StateData#state.socket, Text).


### PR DESCRIPTION
If stream management is enabled, don't exit the c2s process when `ejabberd_socket:send/2` fails, just close the socket instead.  This gives the client a chance to resume the session.

Thanks go to Matthias Rieber for reporting the issue, providing detailed logs, and testing the fix.
