### PR TITLE
XEP-0198: Cosmetic change: Omit redundant guard

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1170,8 +1170,7 @@ session_established({xmlstreamerror, _}, StateData) ->
     {stop, normal, StateData};
 session_established(closed, StateData)
     when StateData#state.mgmt_timeout > 0,
-	 StateData#state.mgmt_state == active orelse
-	 StateData#state.mgmt_state == pending ->
+	 StateData#state.mgmt_state == active ->
     log_pending_state(StateData),
     fsm_next_state(wait_for_resume, StateData#state{mgmt_state = pending});
 session_established(closed, StateData) ->


### PR DESCRIPTION
The stream management state is never `pending` when the c2s FSM is in the `session_established` state.
