### PR TITLE
XEP-0198: Cosmetic change: Reuse event handler

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1284,10 +1284,6 @@ wait_for_resume(Event, StateData) ->
 %%          {next_state, NextStateName, NextStateData, Timeout} |
 %%          {stop, Reason, NewStateData}
 %%----------------------------------------------------------------------
-handle_event({abort, Xmlelement}, _StateName, StateData) ->
-    send_element(StateData, Xmlelement),
-    send_trailer(StateData),
-    {stop, normal, StateData};
 handle_event(_Event, StateName, StateData) ->
     fsm_next_state(StateName, StateData).
 
@@ -2805,7 +2801,7 @@ check_queue_length(#state{mgmt_queue = Queue,
 		       [jlib:jid_to_string(StateData#state.jid)]),
 	  Lang = StateData#state.lang,
 	  Err = ?SERRT_POLICY_VIOLATION(Lang, <<"Too many unacked stanzas">>),
-	  (?GEN_FSM):send_all_state_event(self(), {abort, Err}),
+	  self() ! {kick, queue_overflow, Err},
 	  StateData#state{mgmt_resend = false}; % Don't resend the flood!
       false ->
 	  StateData


### PR DESCRIPTION
On stanza queue overflow, pass a message to `self()` using the exclamation mark operator instead of `send_all_state_event/2`.  This allows for reusing the existing handler for `kick` events.
