### PR TITLE
Log just one [info] message on successful XEP-0280 negotiation

### DIFF
--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -105,7 +105,7 @@ iq_handler1(From, To, IQ) ->
 	iq_handler(From, To, IQ, ?NS_CC_1).
 
 iq_handler(From, _To,  #iq{type=set, sub_el = #xmlel{name = Operation, children = []}} = IQ, CC)->
-    ?INFO_MSG("carbons IQ received: ~p", [IQ]),
+    ?DEBUG("carbons IQ received: ~p", [IQ]),
     {U, S, R} = jlib:jid_tolower(From),
     Result = case Operation of
         <<"enable">>->
@@ -117,10 +117,10 @@ iq_handler(From, _To,  #iq{type=set, sub_el = #xmlel{name = Operation, children 
     end,
     case Result of 
         ok ->
-	    ?INFO_MSG("carbons IQ result: ok", []),
+	    ?DEBUG("carbons IQ result: ok", []),
             IQ#iq{type=result, sub_el=[]};
 	{error,_Error} ->
-	    ?INFO_MSG("Error enabling / disabling carbons: ~p", [Result]),
+	    ?WARNING_MSG("Error enabling / disabling carbons: ~p", [Result]),
             IQ#iq{type=error,sub_el = [?ERR_BAD_REQUEST]}
     end;
 


### PR DESCRIPTION
Let `mod_carboncopy` log just [one](https://github.com/processone/ejabberd/blob/5a29d56d94ba5d8d9504a0ac9c583a17d078fd96/src/mod_carboncopy.erl#L112) instead of three `info` messages when XEP-0280 (Message Carbons) support is enabled or disabled successfully.  On failure, log an additional `warning`.
