### PR TITLE
Don't "forget" listener options

### DIFF
--- a/src/ejabberd_listener.erl
+++ b/src/ejabberd_listener.erl
@@ -595,7 +595,7 @@ transform_option({{Port, IP, Transport}, Mod, Opts}) ->
                       try
                           Mod:transform_listen_option(Opt, Acc)
                       catch error:undef ->
-                              Acc
+                              [Opt|Acc]
                       end
               end, [], Opts1),
     TransportOpt = if Transport == tcp -> [];


### PR DESCRIPTION
If a listener is started or stopped via `ejabberd_listener:add_listener/3` or `ejabberd_listener:delete_listener/3`, the configuration for all listener modules is updated using the `Module:transform_listen_option/2` function for each listener module that exports such a function.  However, for listener modules that don't provide that function (such as `ejabberd_stun`), all but one option was dropped.  This is now fixed.

The issue could be triggered e.g. by enabling `mod_proxy65` in the `modules` section.
