### PR TITLE
Mention configuration file path in error messages

### DIFF
--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -186,7 +186,9 @@ consult(File) ->
                 {ok, [Document|_]} ->
                     {ok, Document};
                 {error, Err} ->
-                    {error, p1_yaml:format_error(Err)}
+                    Msg1 = "Cannot load " ++ File ++ ": ",
+                    Msg2 = p1_yaml:format_error(Err),
+                    {error, Msg1 ++ Msg2}
             end;
         _ ->
             case file:consult(File) of


### PR DESCRIPTION
If reading or parsing a YAML configuration fails, log the full path to the configuration file (as we do for old-style ".cfg" files already).
