### PR TITLE
Use -include_lib instead of -include for esip and p1_xml

### DIFF
--- a/include/jlib.hrl
+++ b/include/jlib.hrl
@@ -19,7 +19,7 @@
 %%%----------------------------------------------------------------------
 
 -include("ns.hrl").
--include("xml.hrl").
+-include_lib("p1_xml/include/xml.hrl").
 
 -define(STANZA_ERROR(Code, Type, Condition),
 	#xmlel{name = <<"error">>,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -42,11 +42,6 @@ HiPE = case lists:keysearch(hipe, 1, Cfg) of
                []
        end,
 
-Includes = [{i, "include"},
-	    {i, filename:join(["deps", "esip", "include"])},
-	    {i, filename:join(["deps", "p1_stun", "include"])},
-            {i, filename:join(["deps", "p1_xml", "include"])}],
-
 SrcDirs = lists:foldl(
             fun({tools, true}, Acc) ->
                     [tools|Acc];
@@ -121,13 +116,12 @@ CfgPostHooks = lists:flatmap(
 
 {ok, Cwd} = file:get_cwd(),
 
-Config = [{erl_opts, Includes ++ Macros ++ HiPE ++ DebugInfo ++
+Config = [{erl_opts, Macros ++ HiPE ++ DebugInfo ++
                [{src_dirs, [asn1, src | SrcDirs]}]},
           {sub_dirs, ["rel"]},
           {keep_build_info, true},
           {ct_extra_params, "-include "
-           ++ filename:join([Cwd, "tools"]) ++ " "
-           ++ filename:join([Cwd, "deps", "p1_xml", "include"])},
+           ++ filename:join([Cwd, "tools"])},
           {post_hooks, PostHooks ++ CfgPostHooks},
           {deps, Deps ++ CfgDeps}],
 %%io:format("ejabberd configuration:~n  ~p~n", [Config]),

--- a/src/mod_sip.erl
+++ b/src/mod_sip.erl
@@ -20,7 +20,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("esip.hrl").
+-include_lib("esip/include/esip.hrl").
 
 %%%===================================================================
 %%% API

--- a/src/mod_sip_proxy.erl
+++ b/src/mod_sip_proxy.erl
@@ -21,7 +21,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("esip.hrl").
+-include_lib("esip/include/esip.hrl").
 
 -define(SIGN_LIFETIME, 300). %% in seconds.
 

--- a/src/mod_sip_registrar.erl
+++ b/src/mod_sip_registrar.erl
@@ -20,7 +20,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("esip.hrl").
+-include_lib("esip/include/esip.hrl").
 
 -define(CALL_TIMEOUT, timer:seconds(30)).
 -define(DEFAULT_EXPIRES, 3600).

--- a/test/suite.hrl
+++ b/test/suite.hrl
@@ -1,5 +1,5 @@
 -include_lib("common_test/include/ct.hrl").
--include("xml.hrl").
+-include_lib("p1_xml/include/xml.hrl").
 -include("ns.hrl").
 -include("ejabberd.hrl").
 -include("mod_proxy65.hrl").


### PR DESCRIPTION
-include_lib is used in order to find deps. Rebar include magic is not required anymore.
Rebar uses deps as library directory.
