### PR TITLE
Replace bash-specific syntax in ejabberdctl

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -127,7 +127,7 @@ else
 fi
 
 # define ejabberd environment parameters
-if [ "$EJABBERD_CONFIG_PATH" != "${EJABBERD_CONFIG_PATH/.yml/}" ] ; then
+if [ "$EJABBERD_CONFIG_PATH" != "${EJABBERD_CONFIG_PATH%.yml}" ] ; then
     rate=$(grep log_rate_limit $EJABBERD_CONFIG_PATH | cut -d':' -f2 | sed 's/ *//')
     rotate=$(grep log_rotate_size $EJABBERD_CONFIG_PATH | cut -d':' -f2 | sed 's/ *//')
     count=$(grep log_rotate_count $EJABBERD_CONFIG_PATH | cut -d':' -f2 | sed 's/ *//')


### PR DESCRIPTION
Use plain POSIX shell syntax to match `.yml` configuration file names.  This is also slightly more correct, as it matches `.yml` only at the _end_ of the file name.

The `ejabberdctl` script can now be executed with non-bash shells again, but I _didn't_ change the shebang line back to `#!/bin/sh` (in case you want to use bash-specific stuff in the future).
