### PR TITLE
Fix "s2s_access" option name in documentation

### DIFF
--- a/doc/guide.tex
+++ b/doc/guide.tex
@@ -1288,11 +1288,11 @@ access:
     all: normal
   xmlrpc_access: 
     xmlrpc_bot: allow
-  s2s_access:
+  s2s:
     trusted_servers: allow
     all: deny
 s2s_certfile: "/path/to/ssl.pem"
-s2s_policy: s2s_access
+s2s_access: s2s
 s2s_use_starttls: required_trusted
 listen: 
   - 

--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -196,7 +196,7 @@ listen:
 ##
 ## Default s2s policy for undefined hosts.
 ##
-## s2s_policy: s2s_access
+## s2s_access: s2s
 
 ##
 ## Outgoing S2S options
@@ -487,7 +487,7 @@ access:
   trusted_network: 
     loopback: allow
   ## Do not establish S2S connections with bad servers
-  ## s2s_access:
+  ## s2s: 
   ##   bad_servers: deny
   ##   all: allow
 


### PR DESCRIPTION
The option [is called](https://github.com/processone/ejabberd/blob/f19e19e2b6551eb0d3b56831be1b3532762452f8/src/ejabberd_s2s.erl#L585) `s2s_access`, not `s2s_policy`.
