### PR TITLE
doc/Makefile: Don't insist on using /bin/bash

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,6 +1,6 @@
 # $Id$
 
-SHELL = /bin/bash
+SHELL = /bin/sh
 
 CONTRIBUTED_MODULES = ""
 #ifeq ($(shell ls mod_http_bind.tex),mod_http_bind.tex)


### PR DESCRIPTION
Fix `make doc` for systems that don't have `/bin/bash`.  There's no bash-specific code in `doc/Makefile` anymore.
