### PR TITLE
Fix ejabberdctl issues

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -152,9 +152,6 @@ fi
 [ -z "$EJABBERD_OPTS" ] || EJABBERD_OPTS="-ejabberd ${EJABBERD_OPTS}"
 
 [ -d $SPOOL_DIR ] || $EXEC_CMD "mkdir -p $SPOOL_DIR"
-# then set SPOOL_DIR as ejabberd home directory by changing
-# to that directory readable by INSTALLUSER to prevent
-# "File operation error: eacces." messages
 cd $SPOOL_DIR
 
 # export global variables


### PR DESCRIPTION
Properly handle the case where the main ejabberd process is executed by a non-root user but `ejabberdctl` is called by root.  That is:
- Always use the `.erlang.cookie` file located in the home directory of the user running ejabberd, but
- don't try to create that user's home directory without root privileges.
