### PR TITLE
doc/Makefile: Replace non-portable echo(1) calls

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,16 +11,16 @@ CONTRIBUTED_MODULES = ""
 all:	release pdf html
 
 release:
-	@echo "Notes for the releaser:"
-	@echo "* Do not forget to add a link to the release notes in guide.tex"
-	@echo "* Do not forget to update the version number in ebin/ejabberd.app!"
-	@echo "* Do not forget to update the features in introduction.tex (including \new{} and \improved{} tags)."
-	@echo "Press any key to continue"
+	@printf '%s\n' "Notes for the releaser:"
+	@printf '%s\n' "* Do not forget to add a link to the release notes in guide.tex"
+	@printf '%s\n' "* Do not forget to update the version number in ebin/ejabberd.app!"
+	@printf '%s\n' "* Do not forget to update the features in introduction.tex (including \new{} and \improved{} tags)."
+	@printf '%s\n' "Press any key to continue"
 	##@read foo
-	@echo "% ejabberd version (automatically generated)." > version.tex
-	@echo "\newcommand{\version}{"`sed '/vsn/!d;s/\(.*\)"\(.*\)"\(.*\)/\2/' ../ebin/ejabberd.app`"}" >> version.tex
-	@echo -n "% Contributed modules (automatically generated)."  > contributed_modules.tex
-	@echo -e "$(CONTRIBUTED_MODULES)" >> contributed_modules.tex
+	@printf '%s\n' "% ejabberd version (automatically generated)." > version.tex
+	@printf '%s\n' "\newcommand{\version}{"`sed '/vsn/!d;s/\(.*\)"\(.*\)"\(.*\)/\2/' ../ebin/ejabberd.app`"}" >> version.tex
+	@printf '%s'   "% Contributed modules (automatically generated)." > contributed_modules.tex
+	@printf '%b\n' "$(CONTRIBUTED_MODULES)" >> contributed_modules.tex
 
 html:	guide.html dev.html features.html
 


### PR DESCRIPTION
The `echo(1)` behavior is system-dependent, the `printf(1)` behavior is not.
