### PR TITLE
XEP-0198: Don't crash if the resume ID is incorrect

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2938,7 +2938,7 @@ inherit_session_state(#state{user = U, server = S} = StateData, ResumeID) ->
 	  end;
       {term, {_WrongU, _WrongS, _R, _Time}} ->
 	  {error, <<"Previous JID doesn't match authenticated JID">>};
-      error ->
+      _ ->
 	  {error, <<"Invalid 'previd' value">>}
     end.
 


### PR DESCRIPTION
Produce a proper error message instead of crashing when the `previd` value of a `<resume/>` request is unexpected.
