### PR TITLE
XEP-0198: Create shorter session resume IDs

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -2891,7 +2891,7 @@ is_encapsulated_forward(_El) ->
 
 inherit_session_state(#state{user = U, server = S} = StateData, ResumeID) ->
     case jlib:base64_to_term(ResumeID) of
-      {term, {U, S, R, Time}} ->
+      {term, {R, Time}} ->
 	  case ejabberd_sm:get_session_pid(U, S, R) of
 	    none ->
 		{error, <<"Previous session PID not found">>};
@@ -2936,8 +2936,6 @@ inherit_session_state(#state{user = U, server = S} = StateData, ResumeID) ->
 		      {error, <<"Cannot grab session state">>}
 		end
 	  end;
-      {term, {_WrongU, _WrongS, _R, _Time}} ->
-	  {error, <<"Previous JID doesn't match authenticated JID">>};
       _ ->
 	  {error, <<"Invalid 'previd' value">>}
     end.
@@ -2947,11 +2945,7 @@ resume_session({Time, PID}) ->
 
 make_resume_id(StateData) ->
     {Time, _} = StateData#state.sid,
-    ID = {StateData#state.user,
-	  StateData#state.server,
-	  StateData#state.resource,
-	  Time},
-    jlib:term_to_base64(ID).
+    jlib:term_to_base64({StateData#state.resource, Time}).
 
 %%%----------------------------------------------------------------------
 %%% JID Set memory footprint reduction code


### PR DESCRIPTION
Omit the user and server name from the `previd` value.  We don't need them there.
