### PR TITLE
Guide: For consistency, use 'infinity' everywhere

### DIFF
--- a/doc/guide.tex
+++ b/doc/guide.tex
@@ -2023,10 +2023,10 @@ The specific configurable options are:
   \titem{turn\_max\_port: Integer}
   Together with \option{turn\_min\_port} forms port range to allocate from.
   The default is 65535. Implies \term{use\_turn}.
-  \titem{turn\_max\_allocations: Integer|unlimited}
+  \titem{turn\_max\_allocations: Integer|infinity}
   Maximum number of TURN allocations available from the particular IP address.
   The default value is 10. Implies \term{use\_turn}.
-  \titem{turn\_max\_permissions: Integer|unlimited}
+  \titem{turn\_max\_permissions: Integer|infinity}
   Maximum number of TURN permissions available from the particular IP address.
   The default value is 10. Implies \term{use\_turn}.
   \titem{auth\_type: user|anonymous}


### PR DESCRIPTION
Use `infinity` in place of `unlimited` for consistency with other settings.
