### PR TITLE
fix 404 on pep first publishing with odbc

### DIFF
--- a/src/mod_pubsub_odbc.erl
+++ b/src/mod_pubsub_odbc.erl
@@ -2315,7 +2315,7 @@ create_node(Host, ServerHost, Node, Owner, GivenType, Access, Configuration) ->
 		    {result, Reply};
 		{result, {NodeId, _SubsByDepth, Result}} ->
 		    ejabberd_hooks:run(pubsub_create_node, ServerHost, [ServerHost, Host, Node, NodeId, NodeOptions]),
-		    {result, Result};
+		    {result, Reply};
 		Error ->
 		    %% in case we change transaction to sync_dirty...
 		    %%  node_call(Type, delete_node, [Host, Node]),


### PR DESCRIPTION
With mod_pubsub_odbc first PEP publishing causes 404.
