### PR TITLE
Fix return value of mod_shared_roster:delete_group.

### DIFF
--- a/src/mod_shared_roster.erl
+++ b/src/mod_shared_roster.erl
@@ -501,7 +501,10 @@ delete_group(Host, Group, odbc) ->
 		ejabberd_odbc:sql_query_t([<<"delete from sr_user where grp='">>,
 					   SGroup, <<"';">>])
 	end,
-    ejabberd_odbc:sql_transaction(Host, F).
+    case ejabberd_odbc:sql_transaction(Host, F) of
+        {atomic,{updated,_}} -> {atomic, ok};
+        Res -> Res
+    end.
 
 get_group_opts(Host, Group) ->
     get_group_opts(Host, Group,


### PR DESCRIPTION
Fix return value of mod_shared_roster:delete_group.
Current one is not compatible with mod_admin_extra because it expects {atomic, ok}.
