### PR TITLE
Travis CI: Remove unused configure flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
 
 script:
   - ./autogen.sh
-  - ./configure --enable-all --disable-http --disable-odbc
+  - ./configure --enable-all --disable-odbc
   - make
   - ERL_LIBS=$PWD make test
   - grep -q 'TEST COMPLETE, \([[:digit:]]*\) ok, .* of \1 ' logs/raw.log


### PR DESCRIPTION
The `--disable-http` option no longer exists, so it adds a warning to the Travis CI output these days.
