### PR TITLE
added p1_utils to reltool.config resolving treap:empty() undefined error

### DIFF
--- a/rel/reltool.config.script
+++ b/rel/reltool.config.script
@@ -28,7 +28,7 @@ ConfiguredOTPApps = lists:flatmap(
 
 OTPApps = RequiredOTPApps ++ ConfiguredOTPApps,
 
-DepRequiredApps = [p1_cache_tab, p1_tls, p1_stringprep, p1_xml, p1_yaml, xmlrpc],
+DepRequiredApps = [p1_cache_tab, p1_tls, p1_stringprep, p1_xml, p1_yaml, xmlrpc, p1_utils],
 
 DepConfiguredApps = lists:flatmap(
                       fun({mysql, true}) -> [p1_mysql];


### PR DESCRIPTION
- Steps to recreate
  -- `make rel`
  -- `./rel/ejabberd/bin/ejabberdctl live
- What should happen
  -- stable run
- What does happen
  -- crashes due to and undefined reference to `treap:empty()` in `ejabberd_captcha.erl`
