### PR TITLE
Rename deref_aliases back to ldap_deref_aliases

### DIFF
--- a/src/eldap_utils.erl
+++ b/src/eldap_utils.erl
@@ -228,13 +228,28 @@ get_config(Host, Opts) ->
     Base = get_opt({ldap_base, Host}, Opts,
                    fun iolist_to_binary/1,
                    <<"">>),
-    DerefAliases = get_opt({deref_aliases, Host}, Opts,
-                           fun(never) -> never;
-                              (searching) -> searching;
-                              (finding) -> finding;
-                              (always) -> always
-                           end, never),
-    #eldap_config{servers = Servers,
+    OldDerefAliases = get_opt({deref_aliases, Host}, Opts,
+                              fun(never) -> never;
+                                 (searching) -> searching;
+                                 (finding) -> finding;
+                                 (always) -> always
+                              end, unspecified),
+    DerefAliases =
+        if OldDerefAliases == unspecified ->
+                get_opt({ldap_deref_aliases, Host}, Opts,
+                        fun(never) -> never;
+                           (searching) -> searching;
+                           (finding) -> finding;
+                           (always) -> always
+                        end, never);
+           true ->
+                ?WARNING_MSG("Option 'deref_aliases' is deprecated. "
+                             "The option is still supported "
+                             "but it is better to fix your config: "
+                             "use 'ldap_deref_aliases' instead.", []),
+                OldDerefAliases
+        end,
+   #eldap_config{servers = Servers,
                   backups = Backups,
                   tls_options = [{encrypt, Encrypt},
                                  {tls_verify, TLSVerify},


### PR DESCRIPTION
The `ldap_deref_aliases` option has [accidentally](https://github.com/processone/ejabberd/commit/9deb294328bb3f9eb6bd2c0e7cd500732e9b5830) been renamed to `deref_aliases`.  Revert that change (but accept both names for a while), so that the option name now matches the [documentation](http://www.process-one.net/docs/ejabberd/guide_en.html#ldap) again.

Thanks to Adi Kriegisch for noting the issue!
