### PR TITLE
Offer CSI stream feature only if mod_client_state is enabled

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -479,10 +479,6 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData) ->
 					      false ->
 						  []
 					    end,
-					ClientStateFeature =
-					    [#xmlel{name = <<"csi">>,
-						    attrs = [{<<"xmlns">>, ?NS_CLIENT_STATE}],
-						    children = []}],
 					StreamFeatures = [#xmlel{name = <<"bind">>,
 								attrs = [{<<"xmlns">>, ?NS_BIND}],
 								children = []},
@@ -492,7 +488,6 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData) ->
 							    ++
 							    RosterVersioningFeature ++
 							    StreamManagementFeature ++
-							    ClientStateFeature ++
 							    ejabberd_hooks:run_fold(c2s_post_auth_features,
 								Server, [], [Server]) ++
 							    ejabberd_hooks:run_fold(c2s_stream_features,

--- a/src/mod_client_state.erl
+++ b/src/mod_client_state.erl
@@ -28,7 +28,8 @@
 
 -behavior(gen_mod).
 
--export([start/2, stop/1, filter_presence/2, filter_chat_states/2]).
+-export([start/2, stop/1, add_stream_feature/2, filter_presence/2,
+	 filter_chat_states/2]).
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
@@ -39,14 +40,19 @@ start(Host, Opts) ->
 				    fun(true) -> true end, false),
     DropChatStates = gen_mod:get_opt(drop_chat_states, Opts,
 				     fun(true) -> true end, false),
-    if QueuePresence ->
-	   ejabberd_hooks:add(csi_filter_stanza, Host, ?MODULE,
-			      filter_presence, 50);
-       true -> ok
-    end,
-    if DropChatStates ->
-	   ejabberd_hooks:add(csi_filter_stanza, Host, ?MODULE,
-			      filter_chat_states, 50);
+    if QueuePresence; DropChatStates ->
+	   ejabberd_hooks:add(c2s_post_auth_features, Host, ?MODULE,
+			      add_stream_feature, 50),
+	   if QueuePresence ->
+		  ejabberd_hooks:add(csi_filter_stanza, Host, ?MODULE,
+				     filter_presence, 50);
+	      true -> ok
+	   end,
+	   if DropChatStates ->
+		  ejabberd_hooks:add(csi_filter_stanza, Host, ?MODULE,
+				     filter_chat_states, 50);
+	      true -> ok
+	   end;
        true -> ok
     end,
     ok.
@@ -56,7 +62,15 @@ stop(Host) ->
 			  filter_presence, 50),
     ejabberd_hooks:delete(csi_filter_stanza, Host, ?MODULE,
 			  filter_chat_states, 50),
+    ejabberd_hooks:delete(c2s_post_auth_features, Host, ?MODULE,
+			  add_stream_feature, 50),
     ok.
+
+add_stream_feature(Features, _Host) ->
+    Feature = #xmlel{name = <<"csi">>,
+		     attrs = [{<<"xmlns">>, ?NS_CLIENT_STATE}],
+		     children = []},
+    [Feature | Features].
 
 filter_presence(_Action, #xmlel{name = <<"presence">>, attrs = Attrs}) ->
     case xml:get_attr(<<"type">>, Attrs) of


### PR DESCRIPTION
Don't offer the XEP-0352 stream feature when `mod_client_state` isn't actually configured to filter stanzas.  This makes sure clients won't send CSI tags that end up being ignored.
