### PR TITLE
Let Git ignore the "rel/ejabberd" directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 /ejabberd.init
 /ejabberdctl.example
 /include/XmppAddr.hrl
+/rel/ejabberd/
 /src/XmppAddr.asn1db
 /src/XmppAddr.erl
 /src/ejabberd.app.src


### PR DESCRIPTION
`make rel` creates a `rel/ejabberd` directory which should be ignored by Git.
