### PR TITLE
Use 'request' record definition from header file

### DIFF
--- a/src/mod_http_fileserver.erl
+++ b/src/mod_http_fileserver.erl
@@ -48,16 +48,11 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
+-include("ejabberd_http.hrl").
 
 -include("jlib.hrl").
 
 -include_lib("kernel/include/file.hrl").
-
-%%-include("ejabberd_http.hrl").
-%% TODO: When ejabberd-modules SVN gets the new ejabberd_http.hrl, delete this code:
--record(request,
-	{method, path, q = [], us, auth, lang = <<"">>,
-	 data = <<"">>, ip, host, port, tp, headers}).
 
 -record(state,
 	{host, docroot, accesslog, accesslogfd,


### PR DESCRIPTION
This fixes a `badrecord` crash in `mod_http_fileserver`.
