### PR TITLE
fix odbc_keepalive_interval configuration bug

### DIFF
--- a/src/ejabberd_odbc.erl
+++ b/src/ejabberd_odbc.erl
@@ -204,7 +204,7 @@ decode_term(Bin) ->
 %%%----------------------------------------------------------------------
 init([Host, StartInterval]) ->
     case ejabberd_config:get_option(
-           {keepalive_interval, Host},
+           {odbc_keepalive_interval, Host},
            fun(I) when is_integer(I), I>0 -> I end) of
         undefined ->
             ok;


### PR DESCRIPTION
In ejabberd 14.07 guide, page 56, odbc_keepalive_interval is used to configure an interval to make a dummy SQL request. But the source code utilizes keepalive_interval atom. 
