### PR TITLE
refactor: more understandable way to generate correct community version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,9 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.53)
-AC_INIT(ejabberd, m4_esyscmd([echo `git describe --tags 2>/dev/null || echo community` | sed 's/-g.*//' | tr -d '\012']), [ejabberd@process-one.net], [ejabberd])
+m4_define([community_version], [community-])dnl
+m4_append([community_version], [m4_esyscmd([git describe --always --tags | tr -d ',\n'])])dnl
+AC_INIT(ejabberd, m4_normalize(community_version), [ejabberd@process-one.net], [ejabberd])
 REQUIRE_ERLANG_MIN="5.9.1 (Erlang/OTP R15B01)"
 REQUIRE_ERLANG_MAX="9.0.0 (No Max)"
 


### PR DESCRIPTION
The community version problem was introduced in Aug30, 2013

https://github.com/easemob/ejabberd/commit/8cbbe4a3ebe5f30c3cbf433e5a53ed3c2561bf0b#diff-67e997bcfdac55191033d57a16d1408a

in which the whitespace will make the command 'make rel' generate an incorrect package.

I do find it was partially fixed by a trivial shell command, 

https://github.com/easemob/ejabberd/commit/790201afc026c5c24596f5209694de5c135752c1#diff-67e997bcfdac55191033d57a16d1408a

and deem it should be fixed in a more understandable way.

The new command will also delete comma symbol which will mess the AC_INIT parameters.
