### PR TITLE
Return an empty <vCard/> element in an IQ-result when no vCard exists.

### DIFF
--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -186,6 +186,11 @@ process_sm_iq(From, To,
 	    error ->
 		IQ#iq{type = error,
 		      sub_el = [SubEl, ?ERR_INTERNAL_SERVER_ERROR]};
+	    [] ->
+		IQ#iq{type = result,
+		      sub_el = [#xmlel{name = <<"vCard">>,
+			        attrs = [{<<"xmlns">>, ?NS_VCARD}],
+			        children = []}]};
 	    Els -> IQ#iq{type = result, sub_el = Els}
 	  end
     end.


### PR DESCRIPTION
According to XEP-0054, if no vCard exists, the server MUST return a stanza
error (which SHOULD be `<item-not-found/>`) or an IQ-result containing an
empty `<vCard/>` element.

Signed-off-by: Gu Feng flygoast@126.com
