### PR TITLE
Fix "make install" without JSON support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -161,7 +161,7 @@ install: all
 	# Binary system libraries
 	$(INSTALL) -d $(SODIR)
 	$(INSTALL) -m 644 $(DLLs) $(SODIR)
-	[ -f $(SODIR)/jiffy.so ] && (cd $(PRIVDIR); ln -s lib/jiffy.so; true)
+	-[ -f $(SODIR)/jiffy.so ] && (cd $(PRIVDIR); ln -s lib/jiffy.so; true)
 	#
 	# Translated strings
 	$(INSTALL) -d $(MSGSDIR)


### PR DESCRIPTION
Don't bail out during `make install` when `./configure` was called without `--enable-json`.
