### PR TITLE
Used current working home as base directory to config relative path.

### DIFF
--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -210,9 +210,8 @@ get_absolute_path(File) ->
 	absolute ->
 	    File;
 	relative ->
-	    Config_path = get_ejabberd_config_path(),
-	    Config_dir = filename:dirname(Config_path),
-	    filename:absname_join(Config_dir, File)
+	    {ok, Dir} = file:get_cwd(),
+	    filename:absname_join(Dir, File)
     end.
 
 


### PR DESCRIPTION
When a config relative path specified, `get_absolute_path` would not
return an absolute path. The patch fixed it using current working
home as base directory.

Signed-off-by: Gu Feng flygoast@126.com
