### PR TITLE
Don't duplicate last published PEP items

### DIFF
--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -1179,8 +1179,12 @@ presence_probe(#jid{luser = U, lserver = S}, #jid{luser = U, lserver = S}, _Pid)
     %% ignore presence_probe from my other ressources
     %% to not get duplicated last items
     ok;
-presence_probe(#jid{luser = U, lserver = S, lresource = R}, #jid{lserver = Host} = JID, _Pid) ->
-    presence(Host, {presence, U, S, [R], JID}).
+presence_probe(#jid{luser = U, lserver = S, lresource = R}, #jid{lserver = S} = JID, _Pid) ->
+    presence(S, {presence, U, S, [R], JID});
+presence_probe(_Host, _JID, _Pid) ->
+    %% ignore presence_probe from remote contacts,
+    %% those are handled via caps_update
+    ok.
 
 presence(ServerHost, Presence) ->
     SendLoop = case

--- a/src/mod_pubsub_odbc.erl
+++ b/src/mod_pubsub_odbc.erl
@@ -830,8 +830,12 @@ presence_probe(#jid{luser = U, lserver = S}, #jid{luser = U, lserver = S}, _Pid)
     %% ignore presence_probe from my other ressources
     %% to not get duplicated last items
     ok;
-presence_probe(#jid{luser = U, lserver = S, lresource = R}, #jid{lserver = Host} = JID, _Pid) ->
-    presence(Host, {presence, U, S, [R], JID}).
+presence_probe(#jid{luser = U, lserver = S, lresource = R}, #jid{lserver = S} = JID, _Pid) ->
+    presence(S, {presence, U, S, [R], JID});
+presence_probe(_Host, _JID, _Pid) ->
+    %% ignore presence_probe from remote contacts,
+    %% those are handled via caps_update
+    ok.
 
 presence(ServerHost, Presence) ->
     SendLoop = case


### PR DESCRIPTION
When a contact becomes available, usually both the `caps_update` hook and the `presence_probe_hook` are called.  For remote contacts, both hooks triggered PEP notifications, so each item was sent twice.  Fix this by ignoring the `presence_probe_hook` for remote contacts.
