### PR TITLE
Respect privacy lists for incoming PEP messages

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1755,7 +1755,13 @@ handle_info({send_filtered, Feature, From, To, Packet}, StateName, StateData) ->
 			  FinalPacket = jlib:replace_from_to(From, To, Packet),
 			  case StateData#state.jid of
 			    To ->
-				send_packet(StateData, FinalPacket);
+				case privacy_check_packet(StateData, From, To,
+							  FinalPacket, in) of
+				  deny ->
+				      StateData;
+				  allow ->
+				      send_stanza(StateData, FinalPacket)
+				end;
 			    _ ->
 				ejabberd_router:route(From, To, FinalPacket),
 				StateData


### PR DESCRIPTION
Check the recipients privacy lists before accepting incoming PEP messages.

Just by the way: I didn't add privacy list checking for _outgoing_ messages, because that wouldn't work for PEP notifications from offline contacts (when `ignore_pep_from_offline` is set to `false`), and I guess consistent behavior is preferable over having it work _sometimes_.
