### PR TITLE
Fix parsing of "ldap_dn_filter" option

### DIFF
--- a/src/ejabberd_auth_ldap.erl
+++ b/src/ejabberd_auth_ldap.erl
@@ -387,7 +387,7 @@ parse_options(Host) ->
 				       [{<<"%u">>, <<"*">>}]),
     {DNFilter, DNFilterAttrs} =
         eldap_utils:get_opt({ldap_dn_filter, Host}, [],
-                            fun({DNF, DNFA}) ->
+                            fun([{DNF, DNFA}]) ->
                                     NewDNFA = case DNFA of
                                                   undefined ->
                                                       [];


### PR DESCRIPTION
Without this fix, the following configuration snippet ([suggested](http://www.process-one.net/docs/ejabberd/guide_en.html#ldapauth) in the guide) ...

```
ldap_dn_filter:
  "(&(name=%s)(owner=%D)(user=%u@%d))": ["sn"]
```

... leads to the following error message:

```
** Option: {ldap_dn_filter,global}
** Invalid value: [{"(&(name=%s)(owner=%D)(user=%u@%d))",["sn"]}]
** Using as fallback: {undefined,[]}
```
