### PR TITLE
Fix mod_client_state's configuration parsing

### DIFF
--- a/src/mod_client_state.erl
+++ b/src/mod_client_state.erl
@@ -37,9 +37,13 @@
 
 start(Host, Opts) ->
     QueuePresence = gen_mod:get_opt(queue_presence, Opts,
-				    fun(true) -> true end, false),
+				    fun(true) -> true;
+				       (false) -> false
+				    end, false),
     DropChatStates = gen_mod:get_opt(drop_chat_states, Opts,
-				     fun(true) -> true end, false),
+				     fun(true) -> true;
+				        (false) -> false
+				     end, false),
     if QueuePresence; DropChatStates ->
 	   ejabberd_hooks:add(c2s_post_auth_features, Host, ?MODULE,
 			      add_stream_feature, 50),


### PR DESCRIPTION
Don't log an "invalid value" message when `queue_presence` or `drop_chat_states` is set to `false`.
