### PR TITLE
Give temporary processes a little time to stop cleanly

### DIFF
--- a/src/ejabberd_tmp_sup.erl
+++ b/src/ejabberd_tmp_sup.erl
@@ -36,4 +36,4 @@ init(Module) ->
     {ok,
      {{simple_one_for_one, 10, 1},
       [{undefined, {Module, start_link, []}, temporary,
-	brutal_kill, worker, [Module]}]}}.
+	1000, worker, [Module]}]}}.


### PR DESCRIPTION
Allow temporary processes to perform some final actions when shutting down.  For example, `moc_muc_room:terminate/3` fails to [send 'unavailable' presence][1] to the room participants when killed immediately.

[1]: https://github.com/processone/ejabberd/blob/cc958f7787a824f9d541a05fdbd37f4c3047ee7d/src/mod_muc_room.erl#L865