### PR TITLE
checking stringprep in scram authentication

### DIFF
--- a/src/cyrsasl_scram.erl
+++ b/src/cyrsasl_scram.erl
@@ -76,9 +76,11 @@ mech_step(#state{step = 2} = State, ClientIn) ->
 		  UserName ->
 		      case parse_attribute(ClientNonceAttribute) of
 			{$r, ClientNonce} ->
-			    case (State#state.get_password)(UserName) of
+			    {Ret, _AuthModule} = (State#state.get_password)(UserName),
+			    case {Ret, jlib:resourceprep(Ret)} of
 			      {false, _} -> {error, <<"not-authorized">>, UserName};
-			      {Ret, _AuthModule} ->
+			      {_, error} -> ?WARNING_MSG("invalid password", []), {error, <<"not-authorized">>, UserName};
+			      {Ret, _} ->
 				  {StoredKey, ServerKey, Salt, IterationCount} =
 				      if is_tuple(Ret) -> Ret;
 					 true ->


### PR DESCRIPTION
I often got following process crash:

~~~
2015-01-08 13:38:56.944 [error] <0.27684.37> gen_fsm <0.27684.37> in state wait_for_feature_request terminated with reason: bad argument in call to crypto:sha_mac_n(error, <<156,208,118,112,95,2,60,245,73,165,115,32,136,219,48,33,0,0,0,1>>, 20) in scram:hi/3 line 73
2015-01-08 13:38:56.944 [error] <0.27684.37> CRASH REPORT Process <0.27684.37> with 0 neighbours exited with reason: bad argument in call to crypto:sha_mac_n(error, <<156,208,118,112,95,2,60,245,73,165,115,32,136,219,48,33,0,0,0,1>>, 20) in scram:hi/3 line 73 in p1_fsm:terminate/8 line 759
~~~
This issue caused by jlib:resourceprep returned error when password contain non-ascii letters, such as '\n'.
in scram.erl:
~~~
salted_password(Password, Salt, IterationCount) ->
    hi(jlib:resourceprep(Password), Salt, IterationCount).
~~~
The rejecting non-ascii password that is correct behavior in SCRAM authentication but crash is no good.
If process crashed, Client will not be able to try on to other mechanisms(plain, digest).
