### PR TITLE
Fix spec comment and remove useless case block

### DIFF
--- a/src/ejabberd_auth_internal.erl
+++ b/src/ejabberd_auth_internal.erl
@@ -77,10 +77,7 @@ update_reg_users_counter_table(Server) ->
     mnesia:sync_dirty(F).
 
 plain_password_required() ->
-    case is_scrammed() of
-      false -> false;
-      true -> true
-    end.
+    is_scrammed().
 
 store_type() ->
     case is_scrammed() of
@@ -150,7 +147,7 @@ set_password(User, Server, Password) ->
 	   ok
     end.
 
-%% @spec (User, Server, Password) -> {atomic, ok} | {atomic, exists} | {error, invalid_jid} | {aborted, Reason}
+%% @spec (User, Server, Password) -> {atomic, ok} | {atomic, exists} | {error, invalid_jid} | {error, not_allowed} | {error, Reason}
 try_register(User, Server, PasswordList) ->
     LUser = jlib:nodeprep(User),
     LServer = jlib:nameprep(Server),


### PR DESCRIPTION
Minor cleanup :
- Remove useless `case` block
- Fix spec comment for `try_register/3` since previous `{aborted, Reason}` would throw case clause error.