### PR TITLE
correct fix for #396

### DIFF
--- a/src/cyrsasl_scram.erl
+++ b/src/cyrsasl_scram.erl
@@ -79,7 +79,7 @@ mech_step(#state{step = 2} = State, ClientIn) ->
 			    {Ret, _AuthModule} = (State#state.get_password)(UserName),
 			    case {Ret, jlib:resourceprep(Ret)} of
 			      {false, _} -> {error, <<"not-authorized">>, UserName};
-			      {_, error} -> ?WARNING_MSG("invalid password", []), {error, <<"not-authorized">>, UserName};
+			      {_, error} when is_list(Ret) -> ?WARNING_MSG("invalid plain password", []), {error, <<"not-authorized">>, UserName};
 			      {Ret, _} ->
 				  {StoredKey, ServerKey, Salt, IterationCount} =
 				      if is_tuple(Ret) -> Ret;


### PR DESCRIPTION
#396 issue occur only when stored plain password.
In storead scram hash, no need the error handling.