### PR TITLE
Enable transient supervisors by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,7 @@ AC_ARG_ENABLE(roster_gateway_workaround,
 esac],[roster_gateway_workaround=false])
 
 AC_ARG_ENABLE(transient_supervisors,
-[AC_HELP_STRING([--disable-transient_supervisors], [disable Erlang supervision for transient process (default: no)])],
+[AC_HELP_STRING([--disable-transient-supervisors], [disable Erlang supervision for transient processes (default: no)])],
 [case "${enableval}" in
   yes) transient_supervisors=true ;;
   no)  transient_supervisors=false ;;

--- a/configure.ac
+++ b/configure.ac
@@ -82,12 +82,12 @@ AC_ARG_ENABLE(roster_gateway_workaround,
 esac],[roster_gateway_workaround=false])
 
 AC_ARG_ENABLE(transient_supervisors,
-[AC_HELP_STRING([--enable-transient_supervisors], [use Erlang supervision for transient process (default: no)])],
+[AC_HELP_STRING([--disable-transient_supervisors], [disable Erlang supervision for transient process (default: no)])],
 [case "${enableval}" in
   yes) transient_supervisors=true ;;
   no)  transient_supervisors=false ;;
   *) AC_MSG_ERROR(bad value ${enableval} for --enable-transient_supervisors) ;;
-esac],[transient_supervisors=false])
+esac],[transient_supervisors=true])
 
 AC_ARG_ENABLE(full_xml,
 [AC_HELP_STRING([--enable-full-xml], [use XML features in XMPP stream (ex: CDATA) (default: no, requires XML compliant clients)])],


### PR DESCRIPTION
Some features (e.g., `ejabberdctl incoming_s2s_number`) don't work with transient supervisors disabled.