### PR TITLE
Fix overflow in XEP-0203 delay: if microseconds exceeded 999499, *** was...

### DIFF
--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -717,7 +717,11 @@ now_to_utc_string({MegaSecs, Secs, MicroSecs}, Precision) ->
     {{Year, Month, Day}, {Hour, Minute, Second}} =
 	calendar:now_to_universal_time({MegaSecs, Secs,
 					MicroSecs}),
-    FracOfSec = round(MicroSecs / math:pow(10, 6 - Precision)),
+    Max = math:pow(10, Precision),
+    FracOfSec = case round(MicroSecs / math:pow(10, 6 - Precision)) of
+        Max -> Max - 1; % don't overflow io_lib:format
+        X -> X
+    end,
     list_to_binary(io_lib:format("~4..0B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0B.~*."
                                  ".0BZ",
                                  [Year, Month, Day, Hour, Minute, Second,


### PR DESCRIPTION
... put in the formatted timestamp