### PR TITLE
Fix timestamp formatting

### DIFF
--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -717,7 +717,11 @@ now_to_utc_string({MegaSecs, Secs, MicroSecs}, Precision) ->
     {{Year, Month, Day}, {Hour, Minute, Second}} =
 	calendar:now_to_universal_time({MegaSecs, Secs,
 					MicroSecs}),
-    FracOfSec = round(MicroSecs / math:pow(10, 6 - Precision)),
+    Max = math:pow(10, Precision),
+    FracOfSec = case round(MicroSecs / math:pow(10, 6 - Precision)) of
+        Max -> Max - 1; % don't overflow io_lib:format
+        X -> X
+    end,
     list_to_binary(io_lib:format("~4..0B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0B.~*."
                                  ".0BZ",
                                  [Year, Month, Day, Hour, Minute, Second,

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -717,7 +717,7 @@ now_to_utc_string({MegaSecs, Secs, MicroSecs}, Precision) ->
     {{Year, Month, Day}, {Hour, Minute, Second}} =
 	calendar:now_to_universal_time({MegaSecs, Secs,
 					MicroSecs}),
-    Max = math:pow(10, Precision),
+    Max = round(math:pow(10, Precision)),
     FracOfSec = case round(MicroSecs / math:pow(10, 6 - Precision)) of
         Max -> Max - 1; % don't overflow io_lib:format
         X -> X

--- a/src/jlib.erl
+++ b/src/jlib.erl
@@ -718,14 +718,15 @@ now_to_utc_string({MegaSecs, Secs, MicroSecs}, Precision) ->
 	calendar:now_to_universal_time({MegaSecs, Secs,
 					MicroSecs}),
     Max = round(math:pow(10, Precision)),
-    FracOfSec = case round(MicroSecs / math:pow(10, 6 - Precision)) of
-        Max -> Max - 1; % don't overflow io_lib:format
-        X -> X
-    end,
-    list_to_binary(io_lib:format("~4..0B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0B.~*."
-                                 ".0BZ",
-                                 [Year, Month, Day, Hour, Minute, Second,
-                                  Precision, FracOfSec])).
+    case round(MicroSecs / math:pow(10, 6 - Precision)) of
+      Max ->
+	  now_to_utc_string({MegaSecs, Secs + 1, 0}, Precision);
+      FracOfSec ->
+	  list_to_binary(io_lib:format("~4..0B-~2..0B-~2..0BT"
+				       "~2..0B:~2..0B:~2..0B.~*..0BZ",
+				       [Year, Month, Day, Hour, Minute, Second,
+					Precision, FracOfSec]))
+    end.
 
 -spec now_to_local_string(erlang:timestamp()) -> binary().
 


### PR DESCRIPTION
Update the fix provided in PR #412 as [described there][1].

[1]: https://github.com/processone/ejabberd/pull/412#issuecomment-70815256