### PR TITLE
Migration of scram passwords with piefxis (riak and internal only)

### DIFF
--- a/src/ejabberd_auth_internal.erl
+++ b/src/ejabberd_auth_internal.erl
@@ -151,7 +151,10 @@ set_password(User, Server, Password) ->
 try_register(User, Server, PasswordList) ->
     LUser = jlib:nodeprep(User),
     LServer = jlib:nameprep(Server),
-    Password = iolist_to_binary(PasswordList),
+    Password = if is_list(PasswordList); is_binary(PasswordList) ->
+      iolist_to_binary(PasswordList);
+      true -> PasswordList
+    end,
     US = {LUser, LServer},
     if (LUser == error) or (LServer == error) ->
 	   {error, invalid_jid};

--- a/src/ejabberd_auth_riak.erl
+++ b/src/ejabberd_auth_riak.erl
@@ -125,7 +125,10 @@ set_password(User, Server, Password) ->
 try_register(User, Server, PasswordList) ->
     LUser = jlib:nodeprep(User),
     LServer = jlib:nameprep(Server),
-    Password = iolist_to_binary(PasswordList),
+    Password = if is_list(PasswordList); is_binary(PasswordList) ->
+      iolist_to_binary(PasswordList);
+      true -> PasswordList
+    end,
     US = {LUser, LServer},
     if (LUser == error) or (LServer == error) ->
 	   {error, invalid_jid};

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2454,6 +2454,8 @@ add_message_to_history(FromNick, FromJID, Packet, StateData) ->
     Q1 = lqueue_in({FromNick, TSPacket, HaveSubject,
 		    calendar:now_to_universal_time(TimeStamp), Size},
 		   StateData#state.history),
+    ejabberd_hooks:run(offline_group_message_hook, StateData#state.server_host,
+					       [FromJID, FromNick, StateData#state.jid, Packet]),
     add_to_log(text, {FromNick, Packet}, StateData),
     StateData#state{history = Q1}.
 


### PR DESCRIPTION
Current version is throwing `badxml` exception when trying to export password in SCRAM format. 
Added encoding/decoding password to binary format and handling non `iostring` passwords in `try_register` for `internal` and `riak` auth. 