### PR TITLE
MUC admins should be able to kick other admins

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2955,6 +2955,9 @@ can_change_ra(owner, _FRole, admin, _TRole, affiliation,
 can_change_ra(owner, _FRole, owner, _TRole, affiliation,
 	      _Affiliation, _ServiceAf) ->
     check_owner;
+can_change_ra(admin, _FRole, admin, _TRole, role,
+	      _Role, _ServiceAf) ->
+    true;
 can_change_ra(_FAffiliation, _FRole, _TAffiliation,
 	      _TRole, affiliation, _Value, _ServiceAf) ->
     false;


### PR DESCRIPTION
Opening this to start a discussion.

[According to XEP-0045](http://xmpp.org/extensions/xep-0045.html#affil-priv):

> ** As noted, a moderator SHOULD NOT be allowed to revoke moderation privileges from someone with a higher affiliation than themselves (i.e., an unaffiliated moderator SHOULD NOT be allowed to revoke moderation privileges from an admin or an owner, and an admin SHOULD NOT be allowed to revoke moderation privileges from an owner).

The XEP doesn't take a stance on changing the role of members with the same affiliation. Until now, ejabberd's stance has been that this exclusion should apply in the case of equal affiliation also. This change allows admins to change other admin's affiliations because this is required by one of our applications; all room members must be moderators since anyone should be allowed to kick anyone else from the room, and the only way to automatically get the moderator role on joining a room is to have the admin affiliation.

I'd appreciate comments on this, even if they are "this is insane". I'm happy to make this configurable somehow if that's deemed necessary, or to expand the rules.