### PR TITLE
Use Elixir's 'v1.0' branch

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -97,7 +97,9 @@ CfgDeps = lists:flatmap(
                     [{jiffy, ".*", {git, "git://github.com/davisp/jiffy"}}];
                ({elixir, true}) ->
                     [{rebar_elixir_plugin, ".*", {git, "git://github.com/yrashk/rebar_elixir_plugin"}},
-                     {elixir, "1.1.*", {git, "git://github.com/elixir-lang/elixir"}}];
+                     {elixir, ".*",
+                      {git, "git://github.com/elixir-lang/elixir",
+                       {branch, "v1.0"}}}];
                ({iconv, true}) ->
                     [{p1_iconv, ".*", {git, "git://github.com/processone/eiconv"}}];
                ({lager, true}) ->


### PR DESCRIPTION
The stable Elixir releases are currently built from the [`v1.0` branch][1], so let's use that.

[1]: https://github.com/elixir-lang/elixir/commits/v1.0