### PR TITLE
Test file can be compiled under R16

### DIFF
--- a/test/elixir_SUITE.erl
+++ b/test/elixir_SUITE.erl
@@ -53,7 +53,9 @@ undefined_function(Module, Func, Args) ->
 run_elixir_test(Func) ->
     'Elixir.ExUnit':start([]),
     'Elixir.Code':load_file(list_to_binary(filename:join(test_dir(), atom_to_list(Func)))),
-    #{failures := 0} = 'Elixir.ExUnit':run().
+    %% I did not use map syntax, so that this file can still be build under R16
+    ResultMap = 'Elixir.ExUnit':run(),
+    {ok, 0} = maps:find(failures, ResultMap).
 
 test_dir() ->
     {ok, CWD} = file:get_cwd(),


### PR DESCRIPTION
Fixes test failing under R16 due to elixir_suite build syntax error.

The test will never be run under r16 as Elixir requires r17 and map
anyway.
Solves Travis-CI failing for #441 and #460