### PR TITLE
change mod_offline restart type

### DIFF
--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -92,7 +92,7 @@ start_link(Host, Opts) ->
 start(Host, Opts) ->
     Proc = gen_mod:get_module_proc(Host, ?PROCNAME),
     ChildSpec = {Proc, {?MODULE, start_link, [Host, Opts]},
-		 temporary, 1000, worker, [?MODULE]},
+		 transient, 1000, worker, [?MODULE]},
     supervisor:start_child(ejabberd_sup, ChildSpec).
 
 stop(Host) ->


### PR DESCRIPTION
Occasionally I got mod_offline(odbc) process crash and I need restart the module.
It happened when occured database error such as sql timeout.
We may need to change restart type for gen_server.
Thank you.