### PR TITLE
ejabberdctl: Escape whitespace in ERL_OPTIONS

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -112,6 +112,7 @@ ERL_CRASH_DUMP=$LOGS_DIR/erl_crash_$DATETIME.dump
 ERL_INETRC=$ETC_DIR/inetrc
 
 # define erl parameters
+ERL_OPTIONS=$(echo $ERL_OPTIONS | sed 's/ /\\ /g')
 ERLANG_OPTS="+K $POLL -smp $SMP +P $ERL_PROCESSES $ERL_OPTIONS"
 KERNEL_OPTS=""
 if [ "$FIREWALL_WINDOW" != "" ] ; then


### PR DESCRIPTION
If `ERL_OPTIONS="-opt arg"` is specified, make sure the space character between `-opt` and `arg` is retained.

Fixes #143.