### PR TITLE
Add sqlite support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *~
 \#*#
 .#*
+.edts
 /Makefile
 /config.log
 /config.status

--- a/configure.ac
+++ b/configure.ac
@@ -17,8 +17,8 @@ fi
 
 # Checks Erlang runtime and compiler
 AC_ARG_WITH(erlang,
-	AC_HELP_STRING([--with-erlang=dir],
-		[search for erlang in dir]),
+    AC_HELP_STRING([--with-erlang=dir],
+        [search for erlang in dir]),
 [if test "$withval" = "yes" -o "$withval" = "no" -o "X$with_erlang" = "X"; then
     extra_erl_path=""
 else
@@ -34,14 +34,14 @@ AC_ERLANG_NEED_ERLC
 
 AC_ARG_ENABLE(erlang-version-check,
 [AC_HELP_STRING([--enable-erlang-version-check],
-	[Check Erlang/OTP version @<:@default=yes@:>@])])
+    [Check Erlang/OTP version @<:@default=yes@:>@])])
 case "$enable_erlang_version_check" in
-	yes|'')
-		ERLANG_VERSION_CHECK([$REQUIRE_ERLANG_MIN],[$REQUIRE_ERLANG_MAX])
-		;;
-	no)
-		ERLANG_VERSION_CHECK([$REQUIRE_ERLANG_MIN],[$REQUIRE_ERLANG_MAX],[warn])
-		;;
+    yes|'')
+        ERLANG_VERSION_CHECK([$REQUIRE_ERLANG_MIN],[$REQUIRE_ERLANG_MAX])
+        ;;
+    no)
+        ERLANG_VERSION_CHECK([$REQUIRE_ERLANG_MIN],[$REQUIRE_ERLANG_MAX],[warn])
+        ;;
 esac
 
 # Checks and sets ERLANG_ROOT_DIR and ERLANG_LIB_DIR variable
@@ -106,10 +106,10 @@ AC_ARG_ENABLE(mssql,
 esac],[db_type=generic])
 
 AC_ARG_ENABLE(all,
-[AC_HELP_STRING([--enable-all], [same as --enable-nif --enable-odbc --enable-mysql --enable-pgsql --enable-pam --enable-zlib --enable-riak --enable-redis --enable-json --enable-elixir --enable-iconv --enable-debug --enable-lager --enable-tools (useful for Dialyzer checks, default: no)])],
+[AC_HELP_STRING([--enable-all], [same as --enable-nif --enable-odbc --enable-mysql --enable-pgsql --enable-sqlite --enable-pam --enable-zlib --enable-riak --enable-json --enable-elixir --enable-iconv --enable-debug --enable-lager --enable-tools (useful for Dialyzer checks, default: no)])],
 [case "${enableval}" in
-  yes) nif=true odbc=true mysql=true pgsql=true pam=true zlib=true riak=true redis=true json=true elixir=true iconv=true debug=true lager=true tools=true ;;
-  no) nif=false odbc=false mysql=false pgsql=false pam=false zlib=false riak=false redis=false json=false elixir=false iconv=false debug=false lager=false tools=false ;;
+  yes) nif=true odbc=true mysql=true pgsql=true pam=true zlib=true riak=true json=true elixir=true iconv=true debug=true lager=true tools=true ;;
+  no) nif=false odbc=false mysql=false pgsql=false sqlite=false pam=false zlib=false riak=false json=false elixir=false iconv=false debug=false lager=false tools=false ;;
   *) AC_MSG_ERROR(bad value ${enableval} for --enable-all) ;;
 esac],[])
 
@@ -153,6 +153,14 @@ AC_ARG_ENABLE(pgsql,
   *) AC_MSG_ERROR(bad value ${enableval} for --enable-pgsql) ;;
 esac],[if test "x$pgsql" = "x"; then pgsql=false; fi])
 
+AC_ARG_ENABLE(sqlite,
+[AC_HELP_STRING([--enable-sqlite], [enable SQLite 3 support (default: no)])],
+[case "${enableval}" in
+yes) sqlite=true ;;
+no)  sqlite=false ;;
+*) AC_MSG_ERROR(bad value ${enableval} for --enable-sqlite) ;;
+esac],[if test "x$sqlite" = "x"; then sqlite=false; fi])
+
 AC_ARG_ENABLE(pam,
 [AC_HELP_STRING([--enable-pam], [enable PAM support (default: no)])],
 [case "${enableval}" in
@@ -176,14 +184,6 @@ AC_ARG_ENABLE(riak,
   no)  riak=false ;;
   *) AC_MSG_ERROR(bad value ${enableval} for --enable-riak) ;;
 esac],[if test "x$riak" = "x"; then riak=false; fi])
-
-AC_ARG_ENABLE(redis,
-[AC_HELP_STRING([--enable-redis], [enable Redis support (default: no)])],
-[case "${enableval}" in
-  yes) redis=true ;;
-  no)  redis=false ;;
-  *) AC_MSG_ERROR(bad value ${enableval} for --enable-redis) ;;
-esac],[if test "x$redis" = "x"; then redis=false; fi])
 
 AC_ARG_ENABLE(json,
 [AC_HELP_STRING([--enable-json], [enable JSON support for mod_bosh (default: no)])],
@@ -226,8 +226,8 @@ AC_ARG_ENABLE(lager,
 esac],[if test "x$lager" = "x"; then lager=true; fi])
 
 AC_CONFIG_FILES([Makefile
-		 vars.config
-		 src/ejabberd.app.src])
+         vars.config
+         src/ejabberd.app.src])
 
 ENABLEUSER=""
 AC_ARG_ENABLE(user,
@@ -254,10 +254,10 @@ AC_SUBST(db_type)
 AC_SUBST(odbc)
 AC_SUBST(mysql)
 AC_SUBST(pgsql)
+AC_SUBST(sqlite)
 AC_SUBST(pam)
 AC_SUBST(zlib)
 AC_SUBST(riak)
-AC_SUBST(redis)
 AC_SUBST(json)
 AC_SUBST(elixir)
 AC_SUBST(iconv)

--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -79,7 +79,7 @@ log_rate_limit: 100
 ##
 ## hosts: Domains served by ejabberd.
 ## You can define one or several, for example:
-## hosts: 
+## hosts:
 ##   - "example.net"
 ##   - "example.com"
 ##   - "example.org"
@@ -101,8 +101,8 @@ hosts:
 ## listen: The ports ejabberd will listen on, which service each is handled
 ## by and what options to start it with.
 ##
-listen: 
-  - 
+listen:
+  -
     port: 5222
     module: ejabberd_c2s
     ##
@@ -126,13 +126,13 @@ listen:
     max_stanza_size: 65536
     shaper: c2s_shaper
     access: c2s
-  - 
+  -
     port: 5269
     module: ejabberd_s2s_in
   ##
   ## ejabberd_service: Interact with external components (transports, ...)
   ##
-  ## - 
+  ## -
   ##   port: 8888
   ##   module: ejabberd_service
   ##   access: all
@@ -147,7 +147,7 @@ listen:
   ##
   ## ejabberd_stun: Handles STUN Binding requests
   ##
-  ## - 
+  ## -
   ##   port: 3478
   ##   transport: udp
   ##   module: ejabberd_stun
@@ -155,10 +155,10 @@ listen:
   ##
   ## To handle XML-RPC requests that provide admin credentials:
   ##
-  ## - 
+  ## -
   ##   port: 4560
   ##   module: ejabberd_xmlrpc
-  - 
+  -
     port: 5280
     module: ejabberd_http
     ## request_handlers:
@@ -350,6 +350,12 @@ auth_method: internal
 ## odbc_server: "DSN=ejabberd;UID=ejabberd;PWD=ejabberd"
 
 ##
+## SQLite:
+##
+## odbc_type: sqlite
+## odbc_database: "/path/to/database.db"
+
+##
 ## Number of connections to open to the database for each virtual host
 ##
 ## odbc_pool_size: 10
@@ -401,7 +407,7 @@ acl:
 
   ## Local users: don't modify this.
   ##
-  local: 
+  local:
     user_regexp: ""
 
   ##
@@ -446,60 +452,60 @@ acl:
 ###   ACCESS RULES
 access:
   ## Maximum number of simultaneous sessions allowed for a single user:
-  max_user_sessions: 
+  max_user_sessions:
     all: 10
   ## Maximum number of offline messages that users can have:
-  max_user_offline_messages: 
+  max_user_offline_messages:
     admin: 5000
     all: 100
   ## This rule allows access only for local users:
-  local: 
+  local:
     local: allow
   ## Only non-blocked users can use c2s connections:
-  c2s: 
+  c2s:
     blocked: deny
     all: allow
   ## For C2S connections, all users except admins use the "normal" shaper
-  c2s_shaper: 
+  c2s_shaper:
     admin: none
     all: normal
   ## All S2S connections use the "fast" shaper
-  s2s_shaper: 
+  s2s_shaper:
     all: fast
   ## Only admins can send announcement messages:
-  announce: 
+  announce:
     admin: allow
   ## Only admins can use the configuration interface:
-  configure: 
+  configure:
     admin: allow
   ## Admins of this server are also admins of the MUC service:
-  muc_admin: 
+  muc_admin:
     admin: allow
   ## Only accounts of the local ejabberd server can create rooms:
-  muc_create: 
+  muc_create:
     local: allow
   ## All users are allowed to use the MUC service:
-  muc: 
+  muc:
     all: allow
   ## Only accounts on the local ejabberd server can create Pubsub nodes:
-  pubsub_createnode: 
+  pubsub_createnode:
     local: allow
   ## In-band registration allows registration of any possible username.
   ## To disable in-band registration, replace 'allow' with 'deny'.
-  register: 
+  register:
     all: allow
   ## Only allow to register from localhost
-  trusted_network: 
+  trusted_network:
     loopback: allow
   ## Do not establish S2S connections with bad servers
-  ## s2s: 
+  ## s2s:
   ##   bad_servers: deny
   ##   all: allow
 
 ## By default the frequency of account registrations from the same IP
 ## is limited to 1 account every 10 minutes. To disable, specify: infinity
 ## registration_timeout: 600
-  
+
 ##
 ## Define specific Access Rules in a virtual host.
 ##
@@ -551,7 +557,7 @@ language: "en"
 ##
 ## Modules enabled in all ejabberd virtual hosts.
 ##
-modules: 
+modules:
   mod_adhoc: {}
   mod_announce: # recommends mod_adhoc
     access: announce
@@ -570,14 +576,14 @@ modules:
   ##   docroot: "/var/www"
   ##   accesslog: "/var/log/ejabberd/access.log"
   mod_last: {}
-  mod_muc: 
+  mod_muc:
     ## host: "conference.@HOST@"
     access: muc
     access_create: muc_create
     access_persistent: muc_create
     access_admin: muc_admin
   ## mod_muc_log: {}
-  mod_offline: 
+  mod_offline:
     access_max_user_messages: max_user_offline_messages
   mod_ping: {}
   ## mod_pres_counter:
@@ -586,18 +592,18 @@ modules:
   mod_privacy: {}
   mod_private: {}
   ## mod_proxy65: {}
-  mod_pubsub: 
+  mod_pubsub:
     access_createnode: pubsub_createnode
     ## reduces resource comsumption, but XEP incompliant
     ignore_pep_from_offline: true
     ## XEP compliant, but increases resource comsumption
     ## ignore_pep_from_offline: false
     last_item_cache: false
-    plugins: 
+    plugins:
       - "flat"
       - "hometree"
       - "pep" # pep requires mod_caps
-  mod_register: 
+  mod_register:
     ##
     ## Protect In-Band account registrations with CAPTCHA.
     ##
@@ -612,7 +618,7 @@ modules:
     ## After successful registration, the user receives
     ## a message with this subject and body.
     ##
-    welcome_message: 
+    welcome_message:
       subject: "Welcome!"
       body: |-
         Hi.
@@ -651,14 +657,6 @@ modules:
 ##     modules:
 ##       mod_echo:
 ##         host: "mirror.localhost"
-
-##
-## Enable modules management via ejabberdctl for installation and
-## uninstallation of public/private contributed modules
-## (enabled by default)
-##
-
-allow_contrib_modules: true
 
 ### Local Variables:
 ### mode: yaml

--- a/include/ejabberd.hrl
+++ b/include/ejabberd.hrl
@@ -31,6 +31,10 @@
 
 -define(MSGS_DIR, filename:join(["priv", "msgs"])).
 
+-define(SQL_DIR, filename:join(["priv", "sql"])).
+
+-define(SQLITE_DB, ejabberd_sqlite).
+
 -define(CONFIG_PATH, <<"ejabberd.cfg">>).
 
 -define(LOG_PATH, <<"ejabberd.log">>).

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -87,6 +87,8 @@ CfgDeps = lists:flatmap(
                     [{p1_mysql, ".*", {git, "git://github.com/processone/mysql"}}];
                ({pgsql, true}) ->
                     [{p1_pgsql, ".*", {git, "git://github.com/processone/pgsql"}}];
+               ({sqlite, true}) ->
+                    [{sqlite3, ".*", {git, "git://github.com/alexeyr/erlang-sqlite3"}}];
                ({pam, true}) ->
                     [{p1_pam, ".*", {git, "git://github.com/processone/epam"}}];
                ({zlib, true}) ->
@@ -106,8 +108,6 @@ CfgDeps = lists:flatmap(
                     [{p1_logger, ".*", {git, "git://github.com/processone/p1_logger"}}];
                ({tools, true}) ->
                     [{meck, "0.*", {git, "https://github.com/eproxus/meck"}}];
-	       ({redis, true}) ->
-		    [{eredis, ".*", {git, "git://github.com/wooga/eredis"}}];
                (_) ->
                     []
             end, Cfg),

--- a/sql/lite.sql
+++ b/sql/lite.sql
@@ -1,0 +1,272 @@
+--
+-- ejabberd, Copyright (C) 2002-2015   ProcessOne
+--
+-- This program is free software; you can redistribute it and/or
+-- modify it under the terms of the GNU General Public License as
+-- published by the Free Software Foundation; either version 2 of the
+-- License, or (at your option) any later version.
+--
+-- This program is distributed in the hope that it will be useful,
+-- but WITHOUT ANY WARRANTY; without even the implied warranty of
+-- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-- General Public License for more details.
+--
+-- You should have received a copy of the GNU General Public License along
+-- with this program; if not, write to the Free Software Foundation, Inc.,
+-- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+--
+
+CREATE TABLE users (
+    username text PRIMARY KEY,
+    password text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+
+CREATE TABLE last (
+    username text PRIMARY KEY,
+    seconds text NOT NULL,
+    state text NOT NULL
+);
+
+
+CREATE TABLE rosterusers (
+    username text NOT NULL,
+    jid text NOT NULL,
+    nick text NOT NULL,
+    subscription character(1) NOT NULL,
+    ask character(1) NOT NULL,
+    askmessage text NOT NULL,
+    server character(1) NOT NULL,
+    subscribe text,
+    type text,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX i_rosteru_user_jid ON rosterusers (username, jid);
+CREATE INDEX i_rosteru_username ON rosterusers (username);
+CREATE INDEX i_rosteru_jid ON rosterusers (jid);
+
+
+CREATE TABLE rostergroups (
+    username text NOT NULL,
+    jid text NOT NULL,
+    grp text NOT NULL
+);
+
+CREATE INDEX pk_rosterg_user_jid ON rostergroups (username, jid);
+
+CREATE TABLE sr_group (
+    name text NOT NULL,
+    opts text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE sr_user (
+    jid text NOT NULL,
+    grp text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX i_sr_user_jid_grp ON sr_user (jid, grp);
+CREATE INDEX i_sr_user_jid ON sr_user (jid);
+CREATE INDEX i_sr_user_grp ON sr_user (grp);
+
+CREATE TABLE spool (
+    username text NOT NULL,
+    xml text NOT NULL,
+    seq SERIAL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX i_despool ON spool (username);
+
+
+CREATE TABLE vcard (
+    username text PRIMARY KEY,
+    vcard text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE vcard_xupdate (
+    username text PRIMARY KEY,
+    hash text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE vcard_search (
+    username text NOT NULL,
+    lusername text PRIMARY KEY,
+    fn text NOT NULL,
+    lfn text NOT NULL,
+    family text NOT NULL,
+    lfamily text NOT NULL,
+    given text NOT NULL,
+    lgiven text NOT NULL,
+    middle text NOT NULL,
+    lmiddle text NOT NULL,
+    nickname text NOT NULL,
+    lnickname text NOT NULL,
+    bday text NOT NULL,
+    lbday text NOT NULL,
+    ctry text NOT NULL,
+    lctry text NOT NULL,
+    locality text NOT NULL,
+    llocality text NOT NULL,
+    email text NOT NULL,
+    lemail text NOT NULL,
+    orgname text NOT NULL,
+    lorgname text NOT NULL,
+    orgunit text NOT NULL,
+    lorgunit text NOT NULL
+);
+
+CREATE INDEX i_vcard_search_lfn       ON vcard_search(lfn);
+CREATE INDEX i_vcard_search_lfamily   ON vcard_search(lfamily);
+CREATE INDEX i_vcard_search_lgiven    ON vcard_search(lgiven);
+CREATE INDEX i_vcard_search_lmiddle   ON vcard_search(lmiddle);
+CREATE INDEX i_vcard_search_lnickname ON vcard_search(lnickname);
+CREATE INDEX i_vcard_search_lbday     ON vcard_search(lbday);
+CREATE INDEX i_vcard_search_lctry     ON vcard_search(lctry);
+CREATE INDEX i_vcard_search_llocality ON vcard_search(llocality);
+CREATE INDEX i_vcard_search_lemail    ON vcard_search(lemail);
+CREATE INDEX i_vcard_search_lorgname  ON vcard_search(lorgname);
+CREATE INDEX i_vcard_search_lorgunit  ON vcard_search(lorgunit);
+
+CREATE TABLE privacy_default_list (
+    username text PRIMARY KEY,
+    name text NOT NULL
+);
+
+CREATE TABLE privacy_list (
+    username text NOT NULL,
+    name text NOT NULL,
+    id SERIAL UNIQUE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX i_privacy_list_username ON privacy_list (username);
+CREATE UNIQUE INDEX i_privacy_list_username_name ON privacy_list (username, name);
+
+CREATE TABLE privacy_list_data (
+    id bigint REFERENCES privacy_list(id) ON DELETE CASCADE,
+    t character(1) NOT NULL,
+    value text NOT NULL,
+    action character(1) NOT NULL,
+    ord NUMERIC NOT NULL,
+    match_all boolean NOT NULL,
+    match_iq boolean NOT NULL,
+    match_message boolean NOT NULL,
+    match_presence_in boolean NOT NULL,
+    match_presence_out boolean NOT NULL
+);
+
+CREATE TABLE private_storage (
+    username text NOT NULL,
+    namespace text NOT NULL,
+    data text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX i_private_storage_username ON private_storage (username);
+CREATE UNIQUE INDEX i_private_storage_username_namespace ON private_storage (username, namespace);
+
+
+CREATE TABLE roster_version (
+    username text PRIMARY KEY,
+    version text NOT NULL
+);
+
+CREATE TABLE pubsub_node (
+  host text,
+  node text,
+  parent text,
+  type text,
+  nodeid SERIAL UNIQUE
+);
+CREATE INDEX i_pubsub_node_parent ON pubsub_node (parent);
+CREATE UNIQUE INDEX i_pubsub_node_tuple ON pubsub_node (host, node);
+
+CREATE TABLE pubsub_node_option (
+  nodeid bigint REFERENCES pubsub_node(nodeid) ON DELETE CASCADE,
+  name text,
+  val text
+);
+CREATE INDEX i_pubsub_node_option_nodeid ON pubsub_node_option (nodeid);
+
+CREATE TABLE pubsub_node_owner (
+  nodeid bigint REFERENCES pubsub_node(nodeid) ON DELETE CASCADE,
+  owner text
+);
+CREATE INDEX i_pubsub_node_owner_nodeid ON pubsub_node_owner (nodeid);
+
+CREATE TABLE pubsub_state (
+  nodeid bigint REFERENCES pubsub_node(nodeid) ON DELETE CASCADE,
+  jid text,
+  affiliation character(1),
+  subscriptions text,
+  stateid SERIAL UNIQUE
+);
+CREATE INDEX i_pubsub_state_jid ON pubsub_state (jid);
+CREATE UNIQUE INDEX i_pubsub_state_tuple ON pubsub_state (nodeid, jid);
+
+CREATE TABLE pubsub_item (
+  nodeid bigint REFERENCES pubsub_node(nodeid) ON DELETE CASCADE,
+  itemid text,
+  publisher text,
+  creation text,
+  modification text,
+  payload text
+);
+CREATE INDEX i_pubsub_item_itemid ON pubsub_item (itemid);
+CREATE UNIQUE INDEX i_pubsub_item_tuple ON pubsub_item (nodeid, itemid);
+
+ CREATE TABLE pubsub_subscription_opt (
+  subid text,
+  opt_name varchar(32),
+  opt_value text
+);
+CREATE UNIQUE INDEX i_pubsub_subscription_opt ON pubsub_subscription_opt (subid, opt_name);
+
+CREATE TABLE muc_room (
+    name text NOT NULL,
+    host text NOT NULL,
+    opts text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX i_muc_room_name_host ON muc_room (name, host);
+
+CREATE TABLE muc_registered (
+    jid text NOT NULL,
+    host text NOT NULL,
+    nick text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX i_muc_registered_nick ON muc_registered (nick);
+CREATE UNIQUE INDEX i_muc_registered_jid_host ON muc_registered (jid, host);
+
+CREATE TABLE irc_custom (
+    jid text NOT NULL,
+    host text NOT NULL,
+    data text NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX i_irc_custom_jid_host ON irc_custom (jid, host);
+
+CREATE TABLE motd (
+    username text PRIMARY KEY,
+    xml text,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE caps_features (
+    node text NOT NULL,
+    subnode text NOT NULL,
+    feature text,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX i_caps_features_node_subnode ON caps_features (node, subnode);

--- a/src/ejabberd_odbc.erl
+++ b/src/ejabberd_odbc.erl
@@ -58,7 +58,7 @@
 
 -record(state,
 	{db_ref = self()                     :: pid(),
-         db_type = odbc                      :: pgsql | mysql | odbc,
+         db_type = odbc                      :: pgsql | mysql | odbc | sqlite,
          start_interval = 0                  :: non_neg_integer(),
          host = <<"">>                       :: binary(),
 	 max_pending_requests_len            :: non_neg_integer(),
@@ -224,7 +224,8 @@ init([Host, StartInterval]) ->
 connecting(connect, #state{host = Host} = State) ->
     ConnectRes = case db_opts(Host) of
 		   [mysql | Args] -> apply(fun mysql_connect/5, Args);
-		   [pgsql | Args] -> apply(fun pgsql_connect/5, Args);
+           [pgsql | Args] -> apply(fun pgsql_connect/5, Args);
+           [sqlite | Args] -> apply(fun sqlite_connect/1, Args);
 		   [odbc | Args] -> apply(fun odbc_connect/1, Args)
 		 end,
     {_, PendingRequests} = State#state.pending_requests,
@@ -441,22 +442,25 @@ execute_bloc(F) ->
 sql_query_internal(Query) ->
     State = get(?STATE_KEY),
     Res = case State#state.db_type of
-	    odbc ->
-		to_odbc(odbc:sql_query(State#state.db_ref, Query,
-                                       (?TRANSACTION_TIMEOUT) - 1000));
-	    pgsql ->
-		pgsql_to_odbc(pgsql:squery(State#state.db_ref, Query));
-	    mysql ->
-		?DEBUG("MySQL, Send query~n~p~n", [Query]),  
-		%%squery to be able to specify result_type = binary
-		%%[Query] because p1_mysql_conn expect query to be a list (elements can be binaries, or iolist)
-		%%        but doesn't accept just a binary
-		R = mysql_to_odbc(p1_mysql_conn:squery(State#state.db_ref,
-						   [Query], self(),
-						   [{timeout, (?TRANSACTION_TIMEOUT) - 1000},
-						    {result_type, binary}])),
-		%% ?INFO_MSG("MySQL, Received result~n~p~n", [R]),
-		R
+              odbc ->
+                  to_odbc(odbc:sql_query(State#state.db_ref, Query,
+                                         (?TRANSACTION_TIMEOUT) - 1000));
+              pgsql ->
+                  pgsql_to_odbc(pgsql:squery(State#state.db_ref, Query));
+              mysql ->
+                  ?DEBUG("MySQL, Send query~n~p~n", [Query]),
+                  %%squery to be able to specify result_type = binary
+                  %%[Query] because p1_mysql_conn expect query
+                  %%to be a list (elements can be binaries, or iolist)
+                  %%        but doesn't accept just a binary
+                  R = mysql_to_odbc(p1_mysql_conn:squery(State#state.db_ref,
+                                                         [Query], self(),
+                                                         [{timeout, (?TRANSACTION_TIMEOUT) - 1000},
+                                                          {result_type, binary}])),
+                  %% ?INFO_MSG("MySQL, Received result~n~p~n", [R]),
+                  R;
+              sqlite ->
+                  sqlite_to_odbc(sqlite3:sql_exec(?SQLITE_DB, Query))
 	  end,
     case Res of
       {error, <<"No SQL-driver information available.">>} ->
@@ -487,6 +491,34 @@ abort_on_driver_error(Reply, From) ->
 odbc_connect(SQLServer) ->
     ejabberd:start_app(odbc),
     odbc:connect(binary_to_list(SQLServer), [{scrollable_cursors, off}]).
+
+%% == Native SQLite code
+
+%% part of init/1
+%% Open a database connection to SQLite
+
+sqlite_connect(DB) ->
+    process_flag(trap_exit, true),
+    case sqlite3:open(?SQLITE_DB, [{file, binary_to_list(DB)}]) of
+        {ok, Ref} ->
+            {ok, Ref};
+        {error, {already_started, Ref}} ->
+            {ok, Ref};
+        {'EXIT', Reason} ->
+            {error, Reason}
+    end.
+
+%% Convert SQLite query result to Erlang ODBC result formalism
+sqlite_to_odbc(ok) ->
+    {updated, sqlite3:changes(?SQLITE_DB)};
+sqlite_to_odbc({rowid, _}) ->
+    {updated, sqlite3:changes(?SQLITE_DB)};
+sqlite_to_odbc([{columns, Columns}, {rows, Rows}]) ->
+    {selected, [list_to_binary(C) || C <- Columns], [tuple_to_list(Row) || Row <- Rows]};
+sqlite_to_odbc({error, _Code, Reason}) ->
+    {error, Reason};
+sqlite_to_odbc(_) ->
+    {updated, undefined}.
 
 %% == Native PostgreSQL code
 
@@ -584,6 +616,7 @@ db_opts(Host) ->
     Type = ejabberd_config:get_option({odbc_type, Host},
                                       fun(mysql) -> mysql;
                                          (pgsql) -> pgsql;
+                                         (sqlite) -> sqlite;
                                          (odbc) -> odbc
                                       end, odbc),
     Server = ejabberd_config:get_option({odbc_server, Host},
@@ -592,6 +625,11 @@ db_opts(Host) ->
     case Type of
         odbc ->
             [odbc, Server];
+        sqlite ->
+            DB = ejabberd_config:get_option({odbc_database, Host},
+                                            fun iolist_to_binary/1,
+                                            <<"/tmp/ejabberd.db">>),
+            [sqlite, DB];
         _ ->
             Port = ejabberd_config:get_option(
                      {odbc_port, Host},

--- a/src/ejabberd_odbc_sup.erl
+++ b/src/ejabberd_odbc_sup.erl
@@ -67,6 +67,23 @@ init([Host]) ->
                       {odbc_start_interval, Host},
                       fun(I) when is_integer(I), I>0 -> I end,
                       ?DEFAULT_ODBC_START_INTERVAL),
+
+    Type = ejabberd_config:get_option({odbc_type, Host},
+                                      fun(mysql) -> mysql;
+                                         (pgsql) -> pgsql;
+                                         (sqlite) -> sqlite;
+                                         (odbc) -> odbc
+                                      end, odbc),
+    case Type of
+        sqlite ->
+            DB = ejabberd_config:get_option({odbc_database, Host},
+                                            fun iolist_to_binary/1,
+                                            <<"/tmp/ejabberd.db">>),
+            check_sqlite_db(DB);
+        _ ->
+            ok
+    end,
+
     {ok,
      {{one_for_one, PoolSize * 10, 1},
       lists:map(fun (I) ->
@@ -113,5 +130,39 @@ transform_options({odbc_server, {mysql, Server, DB, User, Pass}}, Opts) ->
     transform_options({odbc_server, {mysql, Server, ?MYSQL_PORT, DB, User, Pass}}, Opts);
 transform_options({odbc_server, {pgsql, Server, DB, User, Pass}}, Opts) ->
     transform_options({odbc_server, {pgsql, Server, ?PGSQL_PORT, DB, User, Pass}}, Opts);
+transform_options({odbc_server, {sqlite, DB}}, Opts) ->
+    transform_options({odbc_server, {sqlite, DB}}, Opts);
 transform_options(Opt, Opts) ->
     [Opt|Opts].
+
+check_sqlite_db(DB) ->
+    case sqlite3:open(?SQLITE_DB, [{file, binary_to_list(DB)}]) of
+        {ok, _Ref} -> ok;
+        {error, {already_started, _Ref}} -> ok
+    end,
+
+    case sqlite3:list_tables(?SQLITE_DB) of
+        [] ->
+            create_sqlite_tables(),
+            sqlite3:close(?SQLITE_DB),
+            ok;
+        [_H | _] ->
+            ok
+    end.
+
+create_sqlite_tables() ->
+    SqlDir = case code:priv_dir(ejabberd) of
+                 {error, _} ->
+                     ?SQL_DIR;
+                 PrivDir ->
+                     filename:join(PrivDir, "sql")
+             end,
+    Path = filename:join(SqlDir, "lite.sql"),
+    case file:read_file(Path) of
+        {ok, Data} ->
+            ok = sqlite3:sql_exec(?SQLITE_DB, "begin"),
+            ok = sqlite3:sql_exec(?SQLITE_DB, Data),
+            ok = sqlite3:sql_exec(?SQLITE_DB, "commit");
+        {error, _} ->
+            throw(sql_not_found)
+    end.

--- a/src/ejabberd_rdbms.erl
+++ b/src/ejabberd_rdbms.erl
@@ -74,10 +74,12 @@ needs_odbc(Host) ->
     case ejabberd_config:get_option({odbc_type, LHost},
                                     fun(mysql) -> mysql;
                                        (pgsql) -> pgsql;
+                                       (sqlite) -> sqlite;
                                        (odbc) -> odbc
                                     end, undefined) of
         mysql -> {true, p1_mysql};
         pgsql -> {true, p1_pgsql};
+        sqlite -> {true, sqlite3};
         odbc -> {true, odbc};
         undefined -> false
     end.

--- a/src/odbc_queries.erl
+++ b/src/odbc_queries.erl
@@ -126,7 +126,7 @@ update(LServer, Table, Fields, Vals, Where) ->
 		case Res of
 			{updated,1} -> ok;
 			_ -> Res
-		end		   
+		end
     end.
 
 %% F can be either a fun or a list of queries
@@ -229,6 +229,7 @@ users_number(LServer) ->
     Type = ejabberd_config:get_option({odbc_type, LServer},
                                       fun(pgsql) -> pgsql;
                                          (mysql) -> mysql;
+                                         (sqlite) -> sqlite;
                                          (odbc) -> odbc
                                       end, odbc),
     case Type of

--- a/test/ejabberd_SUITE.erl
+++ b/test/ejabberd_SUITE.erl
@@ -300,6 +300,7 @@ groups() ->
      {mnesia, [sequence], db_tests(mnesia)},
      {mysql, [sequence], db_tests(mysql)},
      {pgsql, [sequence], db_tests(pgsql)},
+     {sqlite, [sequence], db_tests(sqlite)},
      {riak, [sequence], db_tests(riak)}].
 
 all() ->
@@ -308,6 +309,7 @@ all() ->
      {group, mnesia},
      {group, mysql},
      {group, pgsql},
+     {group, sqlite},
      {group, extauth},
      {group, riak},
      stop_ejabberd].
@@ -1369,7 +1371,7 @@ muc_register_nick(Config, MUC, PrevNick, Nick) ->
 	send_recv(Config, #iq{type = get, to = MUC,
 			      sub_els = [#register{}]}),
     #xdata_field{type = 'text-single', var = <<"nick">>,
-		 values = [Nick]} = 
+		 values = [Nick]} =
 	lists:keyfind(<<"nick">>, #xdata_field.var, FsWithNick).
 
 muc_register_master(Config) ->
@@ -1636,7 +1638,9 @@ create_sql_tables(Type, BaseDir) ->
                         mysql ->
                             {?MYSQL_VHOST, "mysql.sql"};
                         pgsql ->
-                            {?PGSQL_VHOST, "pg.sql"}
+                            {?PGSQL_VHOST, "pg.sql"};
+                        sqlite ->
+                            {?SQLITE_VHOST, "lite.sql"}
                     end,
     SQLFile = filename:join([BaseDir, "sql", File]),
     CreationQueries = read_sql_queries(SQLFile),

--- a/test/ejabberd_SUITE_data/ejabberd.cfg
+++ b/test/ejabberd_SUITE_data/ejabberd.cfg
@@ -1,6 +1,7 @@
 {loglevel, 4}.
 {hosts, ["localhost",
          "mnesia.localhost",
+         "sqlite.localhost",
          "mysql.localhost",
          "pgsql.localhost",
          "extauth.localhost",
@@ -79,6 +80,25 @@
                                     {plugins, ["flat", "hometree", "pep"]}]},
                     {mod_roster,   [{db_type, internal}]},
                     {mod_vcard,    [{db_type, internal}]}]}
+ ]}.
+{host_config, "sqlite.localhost",
+ [{auth_method, odbc},
+  {odbc_pool_size, 1},
+  {odbc_server, {sqlite, "/tmp/ejabberd_test.db"}},
+  {{add, modules}, [{mod_announce,    [{db_type, odbc}]},
+                    {mod_blocking,    [{db_type, odbc}]},
+                    {mod_caps,        [{db_type, odbc}]},
+                    {mod_last,        [{db_type, odbc}]},
+                    {mod_muc,         [{db_type, odbc}]},
+                    {mod_offline,     [{db_type, odbc}]},
+                    {mod_privacy,     [{db_type, odbc}]},
+                    {mod_private,     [{db_type, odbc}]},
+                    {mod_pubsub_odbc, [{access_createnode, pubsub_createnode},
+                                       {ignore_pep_from_offline, true},
+                                       {last_item_cache, false},
+                                       {plugins, ["flat", "hometree", "pep"]}]},
+                    {mod_roster,      [{db_type, odbc}]},
+                    {mod_vcard,       [{db_type, odbc}]}]}
  ]}.
 {host_config, "mysql.localhost",
  [{auth_method, odbc},

--- a/test/ejabberd_SUITE_data/ejabberd.yml
+++ b/test/ejabberd_SUITE_data/ejabberd.yml
@@ -1,5 +1,5 @@
-host_config: 
-  "pgsql.localhost": 
+host_config:
+  "pgsql.localhost":
     odbc_username: "ejabberd_test"
     odbc_type: pgsql
     odbc_server: "localhost"
@@ -8,29 +8,29 @@ host_config:
     odbc_password: "ejabberd_test"
     odbc_database: "ejabberd_test"
     auth_method: odbc
-    modules: 
-      mod_announce: 
+    modules:
+      mod_announce:
         db_type: odbc
         access: local
-      mod_blocking: 
+      mod_blocking:
         db_type: odbc
-      mod_caps: 
+      mod_caps:
         db_type: odbc
-      mod_last: 
+      mod_last:
         db_type: odbc
-      mod_muc: 
+      mod_muc:
         db_type: odbc
-      mod_offline: 
+      mod_offline:
         db_type: odbc
-      mod_privacy: 
+      mod_privacy:
         db_type: odbc
-      mod_private: 
+      mod_private:
         db_type: odbc
-      mod_pubsub_odbc: 
+      mod_pubsub_odbc:
         access_createnode: pubsub_createnode
         ignore_pep_from_offline: true
         last_item_cache: false
-        plugins: 
+        plugins:
           - "flat"
           - "hometree"
           - "pep"
@@ -38,7 +38,7 @@ host_config:
         versioning: true
         store_current_id: true
         db_type: odbc
-      mod_vcard: 
+      mod_vcard:
         db_type: odbc
       mod_vcard_xupdate:
         db_type: odbc
@@ -47,15 +47,15 @@ host_config:
       mod_disco: []
       mod_ping: []
       mod_proxy65: []
-      mod_register: 
-        welcome_message: 
+      mod_register:
+        welcome_message:
           subject: "Welcome!"
           body: "Hi.
 Welcome to this XMPP server."
       mod_stats: []
       mod_time: []
       mod_version: []
-  "mysql.localhost": 
+  "mysql.localhost":
     odbc_username: "ejabberd_test"
     odbc_type: mysql
     odbc_server: "localhost"
@@ -64,37 +64,37 @@ Welcome to this XMPP server."
     odbc_password: "ejabberd_test"
     odbc_database: "ejabberd_test"
     auth_method: odbc
-    modules: 
-      mod_announce: 
+    modules:
+      mod_announce:
         db_type: odbc
         access: local
-      mod_blocking: 
+      mod_blocking:
         db_type: odbc
-      mod_caps: 
+      mod_caps:
         db_type: odbc
-      mod_last: 
+      mod_last:
         db_type: odbc
-      mod_muc: 
+      mod_muc:
         db_type: odbc
-      mod_offline: 
+      mod_offline:
         db_type: odbc
-      mod_privacy: 
+      mod_privacy:
         db_type: odbc
-      mod_private: 
+      mod_private:
         db_type: odbc
-      mod_pubsub_odbc: 
+      mod_pubsub_odbc:
         access_createnode: pubsub_createnode
         ignore_pep_from_offline: true
         last_item_cache: false
-        plugins: 
+        plugins:
           - "flat"
           - "hometree"
           - "pep"
-      mod_roster: 
+      mod_roster:
         versioning: true
         store_current_id: true
         db_type: odbc
-      mod_vcard: 
+      mod_vcard:
         db_type: odbc
       mod_vcard_xupdate:
         db_type: odbc
@@ -103,47 +103,99 @@ Welcome to this XMPP server."
       mod_disco: []
       mod_ping: []
       mod_proxy65: []
-      mod_register: 
-        welcome_message: 
+      mod_register:
+        welcome_message:
           subject: "Welcome!"
           body: "Hi.
 Welcome to this XMPP server."
       mod_stats: []
       mod_time: []
       mod_version: []
-  "mnesia.localhost": 
-    auth_method: internal
-    modules: 
-      mod_announce: 
-        db_type: internal
+  "sqlite.localhost":
+    odbc_type: sqlite
+    odbc_pool_size: 1
+    odbc_database: "/tmp/ejabberd_test.db"
+    auth_method: odbc
+    modules:
+      mod_announce:
+        db_type: odbc
         access: local
-      mod_blocking: 
-        db_type: internal
-      mod_caps: 
-        db_type: internal
-      mod_last: 
-        db_type: internal
-      mod_muc: 
-        db_type: internal
-      mod_offline: 
-        db_type: internal
-      mod_privacy: 
-        db_type: internal
-      mod_private: 
-        db_type: internal
-      mod_pubsub: 
+      mod_blocking:
+        db_type: odbc
+      mod_caps:
+        db_type: odbc
+      mod_last:
+        db_type: odbc
+      mod_muc:
+        db_type: odbc
+      mod_offline:
+        db_type: odbc
+      mod_privacy:
+        db_type: odbc
+      mod_private:
+        db_type: odbc
+      mod_pubsub_odbc:
         access_createnode: pubsub_createnode
         ignore_pep_from_offline: true
         last_item_cache: false
-        plugins: 
+        plugins:
           - "flat"
           - "hometree"
           - "pep"
-      mod_roster: 
+      mod_roster:
+        versioning: true
+        store_current_id: true
+        db_type: odbc
+      mod_vcard:
+        db_type: odbc
+      mod_vcard_xupdate:
+        db_type: odbc
+      mod_adhoc: []
+      mod_configure: []
+      mod_disco: []
+      mod_ping: []
+      mod_proxy65: []
+      mod_register:
+        welcome_message:
+          subject: "Welcome!"
+          body: "Hi.
+Welcome to this XMPP server."
+      mod_stats: []
+      mod_time: []
+      mod_version: []
+  "mnesia.localhost":
+    auth_method: internal
+    modules:
+      mod_announce:
+        db_type: internal
+        access: local
+      mod_blocking:
+        db_type: internal
+      mod_caps:
+        db_type: internal
+      mod_last:
+        db_type: internal
+      mod_muc:
+        db_type: internal
+      mod_offline:
+        db_type: internal
+      mod_privacy:
+        db_type: internal
+      mod_private:
+        db_type: internal
+      mod_pubsub:
+        access_createnode: pubsub_createnode
+        ignore_pep_from_offline: true
+        last_item_cache: false
+        plugins:
+          - "flat"
+          - "hometree"
+          - "pep"
+      mod_roster:
         versioning: true
         store_current_id: true
         db_type: internal
-      mod_vcard: 
+      mod_vcard:
         db_type: internal
       mod_vcard_xupdate:
         db_type: internal
@@ -157,39 +209,39 @@ Welcome to this XMPP server."
       mod_disco: []
       mod_ping: []
       mod_proxy65: []
-      mod_register: 
-        welcome_message: 
+      mod_register:
+        welcome_message:
           subject: "Welcome!"
           body: "Hi.
 Welcome to this XMPP server."
       mod_stats: []
       mod_time: []
       mod_version: []
-  "riak.localhost": 
+  "riak.localhost":
     auth_method: riak
-    modules: 
-      mod_announce: 
+    modules:
+      mod_announce:
         db_type: riak
         access: local
-      mod_blocking: 
+      mod_blocking:
         db_type: riak
-      mod_caps: 
+      mod_caps:
         db_type: riak
-      mod_last: 
+      mod_last:
         db_type: riak
-      mod_muc: 
+      mod_muc:
         db_type: riak
-      mod_offline: 
+      mod_offline:
         db_type: riak
-      mod_privacy: 
+      mod_privacy:
         db_type: riak
-      mod_private: 
+      mod_private:
         db_type: riak
-      mod_roster: 
+      mod_roster:
         versioning: true
         store_current_id: true
         db_type: riak
-      mod_vcard: 
+      mod_vcard:
         db_type: riak
       mod_vcard_xupdate:
         db_type: riak
@@ -198,43 +250,43 @@ Welcome to this XMPP server."
       mod_disco: []
       mod_ping: []
       mod_proxy65: []
-      mod_register: 
-        welcome_message: 
+      mod_register:
+        welcome_message:
           subject: "Welcome!"
           body: "Hi.
 Welcome to this XMPP server."
       mod_stats: []
       mod_time: []
       mod_version: []
-  "localhost": 
+  "localhost":
     auth_method: internal
-  "ldap.localhost": 
-    ldap_servers: 
+  "ldap.localhost":
+    ldap_servers:
       - "localhost"
     ldap_rootdn: "cn=admin,dc=localhost"
     ldap_port: 1389
     ldap_password: "password"
     ldap_base: "ou=users,dc=localhost"
     auth_method: ldap
-    modules: 
+    modules:
       mod_vcard_ldap: []
       mod_adhoc: []
       mod_configure: []
       mod_disco: []
       mod_ping: []
       mod_proxy65: []
-      mod_register: 
-        welcome_message: 
+      mod_register:
+        welcome_message:
           subject: "Welcome!"
           body: "Hi.
 Welcome to this XMPP server."
       mod_stats: []
       mod_time: []
       mod_version: []
-  "extauth.localhost": 
+  "extauth.localhost":
     extauth_program: "python extauth.py"
     auth_method: external
-hosts: 
+hosts:
   - "localhost"
   - "mnesia.localhost"
   - "mysql.localhost"
@@ -242,44 +294,44 @@ hosts:
   - "extauth.localhost"
   - "ldap.localhost"
   - "riak.localhost"
-access: 
-  announce: 
+access:
+  announce:
     admin: allow
-  c2s: 
+  c2s:
     blocked: deny
     all: allow
-  c2s_shaper: 
+  c2s_shaper:
     admin: none
     all: normal
-  configure: 
+  configure:
     admin: allow
-  local: 
+  local:
     local: allow
-  max_user_offline_messages: 
+  max_user_offline_messages:
     admin: 5000
     all: 100
-  max_user_sessions: 
+  max_user_sessions:
     all: 10
-  muc: 
+  muc:
     all: allow
-  muc_admin: 
+  muc_admin:
     admin: allow
-  muc_create: 
+  muc_create:
     local: allow
-  pubsub_createnode: 
+  pubsub_createnode:
     local: allow
-  register: 
+  register:
     all: allow
-  s2s_shaper: 
+  s2s_shaper:
     all: fast
-acl: 
-  local: 
+acl:
+  local:
     user_regexp: ""
-define_macro: 
+define_macro:
   CERTFILE: "cert.pem"
 language: "en"
-listen: 
-  - 
+listen:
+  -
     port: 5222
     module: ejabberd_c2s
     max_stanza_size: 65536
@@ -288,23 +340,23 @@ listen:
     starttls: true
     shaper: c2s_shaper
     access: c2s
-  - 
+  -
     port: 5269
     module: ejabberd_s2s_in
-  - 
+  -
     port: 5280
     module: ejabberd_http
     captcha: true
 loglevel: 4
 max_fsm_queue: 1000
-modules: 
+modules:
   mod_adhoc: []
   mod_configure: []
   mod_disco: []
   mod_ping: []
   mod_proxy65: []
-  mod_register: 
-    welcome_message: 
+  mod_register:
+    welcome_message:
       subject: "Welcome!"
       body: "Hi.
 Welcome to this XMPP server."
@@ -312,6 +364,6 @@ Welcome to this XMPP server."
   mod_time: []
   mod_version: []
 registration_timeout: infinity
-shaper: 
+shaper:
   fast: 50000
   normal: 1000

--- a/test/suite.hrl
+++ b/test/suite.hrl
@@ -59,6 +59,7 @@
 -define(MNESIA_VHOST, <<"mnesia.localhost">>).
 -define(MYSQL_VHOST, <<"mysql.localhost">>).
 -define(PGSQL_VHOST, <<"pgsql.localhost">>).
+-define(SQLITE_VHOST, <<"sqlite.localhost">>).
 -define(LDAP_VHOST, <<"ldap.localhost">>).
 -define(EXTAUTH_VHOST, <<"extauth.localhost">>).
 -define(RIAK_VHOST, <<"riak.localhost">>).

--- a/vars.config.in
+++ b/vars.config.in
@@ -27,6 +27,7 @@
 {pam, @pam@}.
 {zlib, @zlib@}.
 {riak, @riak@}.
+{redis, @redis@}.
 {json, @json@}.
 {elixir, @elixir@}.
 {lager, @lager@}.

--- a/vars.config.in
+++ b/vars.config.in
@@ -23,10 +23,10 @@
 {odbc, @odbc@}.
 {mysql, @mysql@}.
 {pgsql, @pgsql@}.
+{sqlite, @sqlite@}.
 {pam, @pam@}.
 {zlib, @zlib@}.
 {riak, @riak@}.
-{redis, @redis@}.
 {json, @json@}.
 {elixir, @elixir@}.
 {lager, @lager@}.


### PR DESCRIPTION
Hi.
I added support SQLite3. But I have one question: for this case "Provide empty sqlite file structure as a starting point to use ejabberd with SQLite" (from issue #459), also need install sql/lite.sql. Path $PREFIX/lib/ejabberd/priv/sql/lite.sql it's ok?