### PR TITLE
export CONTRIB_MODULES_PATH

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -167,6 +167,7 @@ export ERL_EPMD_ADDRESS
 export ERL_INETRC
 export ERL_MAX_PORTS
 export ERL_MAX_ETS_TABLES
+export CONTRIB_MODULES_PATH
 
 # start server
 start()


### PR DESCRIPTION
Should be exported to be usable in ext_mod.