### PR TITLE
Update ejabberd_sm's routing rules as per RFC 6121

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -516,7 +516,18 @@ do_route(From, To, #xmlel{} = Packet) ->
 				     PResources);
 		   true -> ok
 		end;
-	    <<"message">> -> route_message(From, To, Packet);
+	    <<"message">> ->
+		case xml:get_attr_s(<<"type">>, Attrs) of
+		  <<"chat">> -> route_message(From, To, Packet);
+		  <<"headline">> -> route_message(From, To, Packet);
+		  <<"error">> -> ok;
+		  <<"groupchat">> ->
+		      Err = jlib:make_error_reply(Packet,
+						  ?ERR_SERVICE_UNAVAILABLE),
+		      ejabberd_router:route(To, From, Err);
+		  _ ->
+		      route_message(From, To, Packet)
+		end;
 	    <<"iq">> -> process_iq(From, To, Packet);
 	    _ -> ok
 	  end;

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -518,15 +518,15 @@ do_route(From, To, #xmlel{} = Packet) ->
 		end;
 	    <<"message">> ->
 		case xml:get_attr_s(<<"type">>, Attrs) of
-		  <<"chat">> -> route_message(From, To, Packet);
-		  <<"headline">> -> route_message(From, To, Packet);
+		  <<"chat">> -> route_message(From, To, Packet, chat);
+		  <<"headline">> -> route_message(From, To, Packet, headline);
 		  <<"error">> -> ok;
 		  <<"groupchat">> ->
 		      Err = jlib:make_error_reply(Packet,
 						  ?ERR_SERVICE_UNAVAILABLE),
 		      ejabberd_router:route(To, From, Err);
 		  _ ->
-		      route_message(From, To, Packet)
+		      route_message(From, To, Packet, normal)
 		end;
 	    <<"iq">> -> process_iq(From, To, Packet);
 	    _ -> ok
@@ -538,7 +538,7 @@ do_route(From, To, #xmlel{} = Packet) ->
 		case Name of
 		  <<"message">> ->
 		      case xml:get_attr_s(<<"type">>, Attrs) of
-			<<"chat">> -> route_message(From, To, Packet);
+			<<"chat">> -> route_message(From, To, Packet, chat);
 			<<"error">> -> ok;
 			_ ->
 			    Err = jlib:make_error_reply(Packet,
@@ -587,14 +587,15 @@ is_privacy_allow(From, To, Packet, PrivacyList) ->
 			      [User, Server, PrivacyList, {From, To, Packet},
 			       in]).
 
-route_message(From, To, Packet) ->
+route_message(From, To, Packet, Type) ->
     LUser = To#jid.luser,
     LServer = To#jid.lserver,
     PrioRes = get_user_present_resources(LUser, LServer),
     case catch lists:max(PrioRes) of
       {Priority, _R}
 	  when is_integer(Priority), Priority >= 0 ->
-	  lists:foreach(fun ({P, R}) when P == Priority ->
+	  lists:foreach(fun ({P, R}) when P == Priority;
+					  (P >= 0) and (Type == headline) ->
 				LResource = jlib:resourceprep(R),
 				Mod = get_sm_backend(),
 				case Mod:get_sessions(LUser, LServer,
@@ -612,11 +613,10 @@ route_message(From, To, Packet) ->
 			end,
 			PrioRes);
       _ ->
-	  case xml:get_tag_attr_s(<<"type">>, Packet) of
-	    <<"error">> -> ok;
-	    <<"groupchat">> ->
-		bounce_offline_message(From, To, Packet);
-	    <<"headline">> ->
+	  case Type of
+	    error -> ok;
+	    headline -> ok;
+	    groupchat ->
 		bounce_offline_message(From, To, Packet);
 	    _ ->
 		case ejabberd_auth:is_user_exists(LUser, LServer) of

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -525,7 +525,15 @@ do_route(From, To, #xmlel{} = Packet) ->
 	  case Mod:get_sessions(LUser, LServer, LResource) of
 	    [] ->
 		case Name of
-		  <<"message">> -> route_message(From, To, Packet);
+		  <<"message">> ->
+		      case xml:get_attr_s(<<"type">>, Attrs) of
+			<<"chat">> -> route_message(From, To, Packet);
+			<<"error">> -> ok;
+			_ ->
+			    Err = jlib:make_error_reply(Packet,
+							?ERR_SERVICE_UNAVAILABLE),
+			    ejabberd_router:route(To, From, Err)
+		      end;
 		  <<"iq">> ->
 		      case xml:get_attr_s(<<"type">>, Attrs) of
 			<<"error">> -> ok;

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -74,8 +74,7 @@
 	 on_user_offline/3, remove_user/2,
 	 disco_local_identity/5, disco_local_features/5,
 	 disco_local_items/5, disco_sm_identity/5,
-	 disco_sm_features/5, disco_sm_items/5,
-	 drop_pep_error/4]).
+	 disco_sm_features/5, disco_sm_items/5]).
 
 %% exported iq handlers
 -export([iq_sm/3]).
@@ -345,8 +344,6 @@ init([ServerHost, Opts]) ->
 			     ?MODULE, disco_sm_features, 75),
 	  ejabberd_hooks:add(disco_sm_items, ServerHost, ?MODULE,
 			     disco_sm_items, 75),
-	  ejabberd_hooks:add(c2s_filter_packet_in, ServerHost, ?MODULE,
-			     drop_pep_error, 75),
 	  gen_iq_handler:add_iq_handler(ejabberd_sm, ServerHost,
 					?NS_PUBSUB, ?MODULE, iq_sm, IQDisc),
 	  gen_iq_handler:add_iq_handler(ejabberd_sm, ServerHost,
@@ -1332,33 +1329,6 @@ unsubscribe_user(Entity, Owner) ->
 	  end).
 
 %% -------
-%% packet receive hook handling function
-%%
-
-drop_pep_error(#xmlel{name = <<"message">>, attrs = Attrs} = Packet, _JID, From,
-	       #jid{lresource = <<"">>} = To) ->
-    case xml:get_attr_s(<<"type">>, Attrs) of
-      <<"error">> ->
-	  case xml:get_subtag(Packet, <<"event">>) of
-	    #xmlel{attrs = EventAttrs} ->
-		case xml:get_attr_s(<<"xmlns">>, EventAttrs) of
-		  ?NS_PUBSUB_EVENT ->
-		      ?DEBUG("Dropping PEP error message from ~s to ~s",
-			     [jlib:jid_to_string(From),
-			      jlib:jid_to_string(To)]),
-		      drop;
-		  _ ->
-		      Packet
-		end;
-	    false ->
-		Packet
-	  end;
-      _ ->
-	  Packet
-    end;
-drop_pep_error(Acc, _JID, _From, _To) -> Acc.
-
-%% -------
 %% user remove hook handling function
 %%
 
@@ -1498,8 +1468,6 @@ terminate(_Reason,
 				?MODULE, disco_sm_features, 75),
 	  ejabberd_hooks:delete(disco_sm_items, ServerHost,
 				?MODULE, disco_sm_items, 75),
-	  ejabberd_hooks:delete(c2s_filter_packet_in, ServerHost,
-				?MODULE, drop_pep_error, 75),
 	  gen_iq_handler:remove_iq_handler(ejabberd_sm,
 					   ServerHost, ?NS_PUBSUB),
 	  gen_iq_handler:remove_iq_handler(ejabberd_sm,

--- a/src/mod_pubsub_odbc.erl
+++ b/src/mod_pubsub_odbc.erl
@@ -74,8 +74,7 @@
 	 on_user_offline/3, remove_user/2,
 	 disco_local_identity/5, disco_local_features/5,
 	 disco_local_items/5, disco_sm_identity/5,
-	 disco_sm_features/5, disco_sm_items/5,
-	 drop_pep_error/4]).
+	 disco_sm_features/5, disco_sm_items/5]).
 
 %% exported iq handlers
 -export([iq_sm/3]).
@@ -345,8 +344,6 @@ init([ServerHost, Opts]) ->
 			     ?MODULE, disco_sm_features, 75),
 	  ejabberd_hooks:add(disco_sm_items, ServerHost, ?MODULE,
 			     disco_sm_items, 75),
-	  ejabberd_hooks:add(c2s_filter_packet_in, ServerHost, ?MODULE,
-			     drop_pep_error, 75),
 	  gen_iq_handler:add_iq_handler(ejabberd_sm, ServerHost,
 					?NS_PUBSUB, ?MODULE, iq_sm, IQDisc),
 	  gen_iq_handler:add_iq_handler(ejabberd_sm, ServerHost,
@@ -942,33 +939,6 @@ unsubscribe_user(Entity, Owner) ->
 	  end).
 
 %% -------
-%% packet receive hook handling function
-%%
-
-drop_pep_error(#xmlel{name = <<"message">>, attrs = Attrs} = Packet, _JID, From,
-	       #jid{lresource = <<"">>} = To) ->
-    case xml:get_attr_s(<<"type">>, Attrs) of
-      <<"error">> ->
-	  case xml:get_subtag(Packet, <<"event">>) of
-	    #xmlel{attrs = EventAttrs} ->
-		case xml:get_attr_s(<<"xmlns">>, EventAttrs) of
-		  ?NS_PUBSUB_EVENT ->
-		      ?DEBUG("Dropping PEP error message from ~s to ~s",
-			     [jlib:jid_to_string(From),
-			      jlib:jid_to_string(To)]),
-		      drop;
-		  _ ->
-		      Packet
-		end;
-	    false ->
-		Packet
-	  end;
-      _ ->
-	  Packet
-    end;
-drop_pep_error(Acc, _JID, _From, _To) -> Acc.
-
-%% -------
 %% user remove hook handling function
 %%
 
@@ -1108,8 +1078,6 @@ terminate(_Reason,
 				?MODULE, disco_sm_features, 75),
 	  ejabberd_hooks:delete(disco_sm_items, ServerHost,
 				?MODULE, disco_sm_items, 75),
-	  ejabberd_hooks:delete(c2s_filter_packet_in, ServerHost,
-				?MODULE, drop_pep_error, 75),
 	  gen_iq_handler:remove_iq_handler(ejabberd_sm,
 					   ServerHost, ?NS_PUBSUB),
 	  gen_iq_handler:remove_iq_handler(ejabberd_sm,


### PR DESCRIPTION
These commits apply a few changes to `ejabberd_sm`'s routing logic.  The new rules were [not yet specified in RFC 3921][1] but are [defined in RFC 6121][2].

For example, incoming groupchat messages sent to an unavailable resource are no longer rerouted to another resource, but an error stanza is returned instead.  This should fix some occasional MUC glitches.

As another example, incoming error messages sent to a bare JID are dropped, so they no longer have to be filtered out later in the chain (the last commit of this PR drops the [PEP error filtering][3] and the `c2s_filter_packet_in` hook which was not used anywhere else).

[1]: https://tools.ietf.org/html/rfc3921#section-11.1
[2]: https://tools.ietf.org/html/rfc6121#section-8.5
[3]: https://github.com/processone/ejabberd/commit/30687c40ef681b82da42a86bbeab249ddba120fd