### PR TITLE
ejabberd_websocket: Ignore case of HTTP header values

### DIFF
--- a/src/ejabberd_websocket.erl
+++ b/src/ejabberd_websocket.erl
@@ -73,9 +73,10 @@ check(_Path, Headers) ->
 		  {_, HVal} ->
 		      case Val of
 			ignore -> false; % ignore value -> ok, remove from list
-			HVal -> false;   % expected val -> ok, remove from list
 			_ ->
-			    true         % val is different, keep in list
+			    % expected value -> ok, remove from list (false)
+			    % value is different, keep in list (true)
+			    str:to_lower(HVal) /= Val
                       end
                 end
         end,


### PR DESCRIPTION
[RFC 6455][1] says that the client's opening handshake includes an `Upgrade` header field "containing the value 'websocket', treated as an ASCII case-insensitive value."

Closes #510.

[1]: https://tools.ietf.org/html/rfc6455