### PR TITLE
fix otp version check in ejabberd_listener.erl listen_tcp/5

### DIFF
--- a/src/ejabberd_listener.erl
+++ b/src/ejabberd_listener.erl
@@ -195,9 +195,11 @@ listen_tcp(PortIP, Module, SockOpts, Port, IPS) ->
 	    ets:delete(listen_sockets, Port),
 	    ListenSocket;
 	_ ->
-	    SockOpts2 = try erlang:system_info(otp_release) >= "R13B" of
-			    true -> [{send_timeout_close, true} | SockOpts];
-			    false -> SockOpts
+	    SockOpts2 = try erlang:system_info(otp_release) of
+			    EVsn when EVsn >= "R13B"; EVsn >= "17" -> 
+                    [{send_timeout_close, true} | SockOpts];
+			    _ -> 
+                    SockOpts
 			catch
 			    _:_ -> []
 			end,


### PR DESCRIPTION
Starting from otp 17.0, function erlang:system_info(otp_release) only returns the main version.