### PR TITLE
Use SASL authzid as client identity if auth module permits it

### DIFF
--- a/src/cyrsasl.erl
+++ b/src/cyrsasl.erl
@@ -128,7 +128,7 @@ register_mechanism(Mechanism, Module, PasswordType) ->
 %%    end.
 
 check_credentials(_State, Props) ->
-    User = proplists:get_value(username, Props, <<>>),
+    User = proplists:get_value(authzid, Props, <<>>),
     case jlib:nodeprep(User) of
       error -> {error, <<"not-authorized">>};
       <<"">> -> {error, <<"not-authorized">>};

--- a/src/cyrsasl_digest.erl
+++ b/src/cyrsasl_digest.erl
@@ -80,9 +80,7 @@ mech_step(#state{step = 3, nonce = Nonce} = State,
       bad -> {error, <<"bad-protocol">>};
       KeyVals ->
 	  DigestURI = proplists:get_value(<<"digest-uri">>, KeyVals, <<>>),
-	  %DigestURI = xml:get_attr_s(<<"digest-uri">>, KeyVals),
 	  UserName = proplists:get_value(<<"username">>, KeyVals, <<>>),
-	  %UserName = xml:get_attr_s(<<"username">>, KeyVals),
 	  case is_digesturi_valid(DigestURI, State#state.host,
 				  State#state.hostfqdn)
 	      of
@@ -94,13 +92,11 @@ mech_step(#state{step = 3, nonce = Nonce} = State,
 		{error, <<"not-authorized">>, UserName};
 	    true ->
 		AuthzId = proplists:get_value(<<"authzid">>, KeyVals, <<>>),
-		%AuthzId = xml:get_attr_s(<<"authzid">>, KeyVals),
 		case (State#state.get_password)(UserName) of
 		  {false, _} -> {error, <<"not-authorized">>, UserName};
 		  {Passwd, AuthModule} ->
 		      case (State#state.check_password)(UserName, <<"">>,
 		                    proplists:get_value(<<"response">>, KeyVals, <<>>),
-							%xml:get_attr_s(<<"response">>, KeyVals),
 							fun (PW) ->
 								response(KeyVals,
 									 UserName,

--- a/src/cyrsasl_digest.erl
+++ b/src/cyrsasl_digest.erl
@@ -47,7 +47,7 @@
                 username = <<"">> :: binary(),
                 authzid = <<"">> :: binary(),
                 get_password = fun(_) -> {false, <<>>} end :: get_password_fun(),
-                check_password = fun(_, _, _, _) -> false end :: check_password_fun(),
+                check_password = fun(_, _, _, _, _) -> false end :: check_password_fun(),
                 auth_module :: atom(),
                 host = <<"">> :: binary(),
                 hostfqdn = <<"">> :: binary()}).
@@ -95,7 +95,7 @@ mech_step(#state{step = 3, nonce = Nonce} = State,
 		case (State#state.get_password)(UserName) of
 		  {false, _} -> {error, <<"not-authorized">>, UserName};
 		  {Passwd, AuthModule} ->
-		      case (State#state.check_password)(UserName, <<"">>,
+		      case (State#state.check_password)(UserName, UserName, <<"">>,
 		                    proplists:get_value(<<"response">>, KeyVals, <<>>),
 							fun (PW) ->
 								response(KeyVals,
@@ -123,7 +123,11 @@ mech_step(#state{step = 5, auth_module = AuthModule,
 		 username = UserName, authzid = AuthzId},
 	  <<"">>) ->
     {ok,
-     [{username, UserName}, {authzid, AuthzId},
+     [{username, UserName}, {authzid, case AuthzId of
+        <<"">> -> UserName;
+        _ -> AuthzId
+      end
+    },
       {auth_module, AuthModule}]};
 mech_step(A, B) ->
     ?DEBUG("SASL DIGEST: A ~p B ~p", [A, B]),

--- a/src/cyrsasl_plain.erl
+++ b/src/cyrsasl_plain.erl
@@ -45,7 +45,7 @@ mech_new(_Host, _GetPassword, CheckPassword, _CheckPasswordDigest) ->
 mech_step(State, ClientIn) ->
     case prepare(ClientIn) of
       [AuthzId, User, Password] ->
-	  case (State#state.check_password)(User, Password) of
+	  case (State#state.check_password)(User, AuthzId, Password) of
 	    {true, AuthModule} ->
 		{ok,
 		 [{username, User}, {authzid, AuthzId},
@@ -60,12 +60,17 @@ prepare(ClientIn) ->
       [<<"">>, UserMaybeDomain, Password] ->
 	  case parse_domain(UserMaybeDomain) of
 	    %% <NUL>login@domain<NUL>pwd
-	    [User, _Domain] -> [UserMaybeDomain, User, Password];
+	    [User, _Domain] -> [User, User, Password];
 	    %% <NUL>login<NUL>pwd
-	    [User] -> [<<"">>, User, Password]
+	    [User] -> [User, User, Password]
 	  end;
-      %% login@domain<NUL>login<NUL>pwd
-      [AuthzId, User, Password] -> [AuthzId, User, Password];
+      [AuthzId, User, Password] ->
+      case parse_domain(AuthzId) of
+        %% login@domain<NUL>login<NUL>pwd
+        [AuthzUser, _Domain] -> [AuthzUser, User, Password];
+        %% login<NUL>login<NUL>pwd
+        [AuthzUser] -> [AuthzUser, User, Password]
+      end;
       _ -> error
     end.
 

--- a/src/ejabberd_auth_anonymous.erl
+++ b/src/ejabberd_auth_anonymous.erl
@@ -38,8 +38,8 @@
 
 
 %% Function used by ejabberd_auth:
--export([login/2, set_password/3, check_password/3,
-	 check_password/5, try_register/3,
+-export([login/2, set_password/3, check_password/4,
+	 check_password/6, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
          get_vh_registered_users/2, get_vh_registered_users_number/1,
          get_vh_registered_users_number/2, get_password_s/2,
@@ -174,11 +174,11 @@ purge_hook(true, LUser, LServer) ->
 
 %% When anonymous login is enabled, check the password for permenant users
 %% before allowing access
-check_password(User, Server, Password) ->
-    check_password(User, Server, Password, undefined,
+check_password(User, AuthzId, Server, Password) ->
+    check_password(User, AuthzId, Server, Password, undefined,
 		   undefined).
 
-check_password(User, Server, _Password, _Digest,
+check_password(User, _AuthzId, Server, _Password, _Digest,
 	       _DigestGen) ->
     case
       ejabberd_auth:is_user_exists_in_other_modules(?MODULE,

--- a/src/ejabberd_auth_internal.erl
+++ b/src/ejabberd_auth_internal.erl
@@ -30,8 +30,8 @@
 -behaviour(ejabberd_auth).
 
 %% External exports
--export([start/1, set_password/3, check_password/3,
-	 check_password/5, try_register/3,
+-export([start/1, set_password/3, check_password/4,
+	 check_password/6, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
 	 get_vh_registered_users/2,
 	 get_vh_registered_users_number/1,
@@ -85,45 +85,53 @@ store_type() ->
       true -> scram %% allows: PLAIN SCRAM
     end.
 
-check_password(User, Server, Password) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
-    US = {LUser, LServer},
-    case catch mnesia:dirty_read({passwd, US}) of
-      [#passwd{password = Password}]
-	  when is_binary(Password) ->
-	  Password /= <<"">>;
-      [#passwd{password = Scram}]
-	  when is_record(Scram, scram) ->
-	  is_password_scram_valid(Password, Scram);
-      _ -> false
+check_password(User, AuthzId, Server, Password) ->
+    if AuthzId /= <<>> andalso AuthzId /= User ->
+        false;
+    true ->
+        LUser = jlib:nodeprep(User),
+        LServer = jlib:nameprep(Server),
+        US = {LUser, LServer},
+        case catch mnesia:dirty_read({passwd, US}) of
+          [#passwd{password = Password}]
+    	  when is_binary(Password) ->
+    	  Password /= <<"">>;
+          [#passwd{password = Scram}]
+    	  when is_record(Scram, scram) ->
+    	  is_password_scram_valid(Password, Scram);
+          _ -> false
+        end
     end.
 
-check_password(User, Server, Password, Digest,
+check_password(User, AuthzId, Server, Password, Digest,
 	       DigestGen) ->
-    LUser = jlib:nodeprep(User),
-    LServer = jlib:nameprep(Server),
-    US = {LUser, LServer},
-    case catch mnesia:dirty_read({passwd, US}) of
-      [#passwd{password = Passwd}] when is_binary(Passwd) ->
-	  DigRes = if Digest /= <<"">> ->
-			  Digest == DigestGen(Passwd);
-		      true -> false
-		   end,
-	  if DigRes -> true;
-	     true -> (Passwd == Password) and (Password /= <<"">>)
-	  end;
-      [#passwd{password = Scram}]
-	  when is_record(Scram, scram) ->
-	  Passwd = jlib:decode_base64(Scram#scram.storedkey),
-	  DigRes = if Digest /= <<"">> ->
-			  Digest == DigestGen(Passwd);
-		      true -> false
-		   end,
-	  if DigRes -> true;
-	     true -> (Passwd == Password) and (Password /= <<"">>)
-	  end;
-      _ -> false
+    if AuthzId /= <<>> andalso AuthzId /= User ->
+        false;
+    true ->
+        LUser = jlib:nodeprep(User),
+        LServer = jlib:nameprep(Server),
+        US = {LUser, LServer},
+        case catch mnesia:dirty_read({passwd, US}) of
+          [#passwd{password = Passwd}] when is_binary(Passwd) ->
+    	  DigRes = if Digest /= <<"">> ->
+    			  Digest == DigestGen(Passwd);
+    		      true -> false
+    		   end,
+    	  if DigRes -> true;
+    	     true -> (Passwd == Password) and (Password /= <<"">>)
+    	  end;
+          [#passwd{password = Scram}]
+    	  when is_record(Scram, scram) ->
+    	  Passwd = jlib:decode_base64(Scram#scram.storedkey),
+    	  DigRes = if Digest /= <<"">> ->
+    			  Digest == DigestGen(Passwd);
+    		      true -> false
+    		   end,
+    	  if DigRes -> true;
+    	     true -> (Passwd == Password) and (Password /= <<"">>)
+    	  end;
+          _ -> false
+        end
     end.
 
 %% @spec (User::string(), Server::string(), Password::string()) ->

--- a/src/ejabberd_auth_ldap.erl
+++ b/src/ejabberd_auth_ldap.erl
@@ -36,7 +36,7 @@
 
 %% External exports
 -export([start/1, stop/1, start_link/1, set_password/3,
-	 check_password/3, check_password/5, try_register/3,
+	 check_password/4, check_password/6, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
          get_vh_registered_users/2,
          get_vh_registered_users_number/1,
@@ -115,19 +115,23 @@ plain_password_required() -> true.
 
 store_type() -> external.
 
-check_password(User, Server, Password) ->
-    if Password == <<"">> -> false;
-       true ->
-	   case catch check_password_ldap(User, Server, Password)
-	       of
-	     {'EXIT', _} -> false;
-	     Result -> Result
-	   end
+check_password(User, AuthzId, Server, Password) ->
+    if AuthzId /= <<>> andalso AuthzId /= User ->
+        false;
+    true ->
+        if Password == <<"">> -> false;
+           true ->
+    	   case catch check_password_ldap(User, Server, Password)
+    	       of
+    	     {'EXIT', _} -> false;
+    	     Result -> Result
+    	   end
+        end
     end.
 
-check_password(User, Server, Password, _Digest,
+check_password(User, AuthzId, Server, Password, _Digest,
 	       _DigestGen) ->
-    check_password(User, Server, Password).
+    check_password(User, AuthzId, Server, Password).
 
 set_password(User, Server, Password) ->
     {ok, State} = eldap_utils:get_state(Server, ?MODULE),

--- a/src/ejabberd_auth_pam.erl
+++ b/src/ejabberd_auth_pam.erl
@@ -32,8 +32,8 @@
 %%====================================================================
 %% API
 %%====================================================================
--export([start/1, set_password/3, check_password/3,
-	 check_password/5, try_register/3,
+-export([start/1, set_password/3, check_password/4,
+	 check_password/6, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
          get_vh_registered_users/2, get_vh_registered_users_number/1,
          get_vh_registered_users_number/2,
@@ -47,21 +47,25 @@ start(_Host) ->
 set_password(_User, _Server, _Password) ->
     {error, not_allowed}.
 
-check_password(User, Server, Password, _Digest,
+check_password(User, AuthzId, Server, Password, _Digest,
 	       _DigestGen) ->
-    check_password(User, Server, Password).
+    check_password(User, AuthzId, Server, Password).
 
-check_password(User, Host, Password) ->
-    Service = get_pam_service(Host),
-    UserInfo = case get_pam_userinfotype(Host) of
-		 username -> User;
-		 jid -> <<User/binary, "@", Host/binary>>
-	       end,
-    case catch epam:authenticate(Service, UserInfo,
-				 Password)
-	of
-      true -> true;
-      _ -> false
+check_password(User, AuthzId, Host, Password) ->
+    if AuthzId /= <<>> andalso AuthzId /= User ->
+        false;
+    true ->
+        Service = get_pam_service(Host),
+        UserInfo = case get_pam_userinfotype(Host) of
+    		 username -> User;
+    		 jid -> <<User/binary, "@", Host/binary>>
+    	       end,
+        case catch epam:authenticate(Service, UserInfo,
+    				 Password)
+    	of
+          true -> true;
+          _ -> false
+        end
     end.
 
 try_register(_User, _Server, _Password) ->

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -397,13 +397,13 @@ wait_for_stream({xmlstreamstart, _Name, Attrs}, StateData) ->
 						  ejabberd_auth:get_password_with_authmodule(
 						    U, Server)
 					  end,
-					  fun(U, P) ->
+					  fun(U, AuthzId, P) ->
 						  ejabberd_auth:check_password_with_authmodule(
-						    U, Server, P)
+						    U, AuthzId, Server, P)
 					  end,
-					  fun(U, P, D, DG) ->
+					  fun(U, AuthzId, P, D, DG) ->
 						  ejabberd_auth:check_password_with_authmodule(
-						    U, Server, P, D, DG)
+						    U, AuthzId, Server, P, D, DG)
 					  end),
 				    Mechs =
 					case TLSEnabled or not TLSRequired of
@@ -635,7 +635,7 @@ wait_for_auth({xmlstreamelement, El}, StateData) ->
 		DGen = fun (PW) ->
 			       p1_sha:sha(<<(StateData#state.streamid)/binary, PW/binary>>)
 		       end,
-		case ejabberd_auth:check_password_with_authmodule(U,
+		case ejabberd_auth:check_password_with_authmodule(U, U,
 								  StateData#state.server,
 								  P, D, DGen)
 		    of
@@ -753,9 +753,7 @@ wait_for_feature_request({xmlstreamelement, El},
 	      of
 	    {ok, Props} ->
 		(StateData#state.sockmod):reset_stream(StateData#state.socket),
-		%U = xml:get_attr_s(username, Props),
-		U = proplists:get_value(username, Props, <<>>),
-		%AuthModule = xml:get_attr_s(auth_module, Props),
+		U = identity(Props),
 		AuthModule = proplists:get_value(auth_module, Props, undefined),
 		?INFO_MSG("(~w) Accepted authentication for ~s "
 			  "by ~p from ~s",
@@ -906,9 +904,7 @@ wait_for_sasl_response({xmlstreamelement, El},
 	    {ok, Props} ->
 		catch
 		  (StateData#state.sockmod):reset_stream(StateData#state.socket),
-%		U = xml:get_attr_s(username, Props),
-		U = proplists:get_value(username, Props, <<>>),
-%		AuthModule = xml:get_attr_s(auth_module, Props),
+		U = identity(Props),
 		AuthModule = proplists:get_value(auth_module, Props, <<>>),
 		?INFO_MSG("(~w) Accepted authentication for ~s "
 			  "by ~p from ~s",
@@ -929,9 +925,7 @@ wait_for_sasl_response({xmlstreamelement, El},
 						user = U});
 	    {ok, Props, ServerOut} ->
 		(StateData#state.sockmod):reset_stream(StateData#state.socket),
-%		U = xml:get_attr_s(username, Props),
-		U = proplists:get_value(username, Props, <<>>),
-%		AuthModule = xml:get_attr_s(auth_module, Props),
+		U = identity(Props),
 		AuthModule = proplists:get_value(auth_module, Props, undefined),
 		?INFO_MSG("(~w) Accepted authentication for ~s "
 			  "by ~p from ~s",
@@ -3126,3 +3120,9 @@ pack_string(String, Pack) ->
 
 transform_listen_option(Opt, Opts) ->
     [Opt|Opts].
+
+identity(Props) ->
+	case proplists:get_value(authzid, Props, <<>>) of
+		<<>> -> proplists:get_value(username, Props, <<>>);
+		AuthzId -> AuthzId
+	end.

--- a/src/ejabberd_commands.erl
+++ b/src/ejabberd_commands.erl
@@ -397,7 +397,7 @@ check_auth(noauth) ->
     no_auth_provided;
 check_auth({User, Server, Password}) ->
     %% Check the account exists and password is valid
-    case ejabberd_auth:check_password(User, Server, Password) of
+    case ejabberd_auth:check_password(User, <<"">>, Server, Password) of
 	true -> {ok, User, Server};
 	_ -> throw({error, invalid_account_data})
     end.

--- a/src/ejabberd_web_admin.erl
+++ b/src/ejabberd_web_admin.erl
@@ -263,7 +263,7 @@ get_auth_admin(Auth, HostHTTP, RPath, Method) ->
 
 get_auth_account(HostOfRule, AccessRule, User, Server,
 		 Pass) ->
-    case ejabberd_auth:check_password(User, Server, Pass) of
+    case ejabberd_auth:check_password(User, <<"">>, Server, Pass) of
       true ->
 	  case is_acl_match(HostOfRule, AccessRule,
 			    jlib:make_jid(User, Server, <<"">>))

--- a/src/mod_proxy65_stream.erl
+++ b/src/mod_proxy65_stream.erl
@@ -154,7 +154,7 @@ wait_for_auth(Packet,
 	      #state{socket = Socket, host = Host} = StateData) ->
     case mod_proxy65_lib:unpack_auth_request(Packet) of
       {User, Pass} ->
-	  Result = ejabberd_auth:check_password(User, Host, Pass),
+	  Result = ejabberd_auth:check_password(User, <<"">>, Host, Pass),
 	  gen_tcp:send(Socket,
 		       mod_proxy65_lib:make_auth_reply(Result)),
 	  case Result of

--- a/src/mod_register_web.erl
+++ b/src/mod_register_web.erl
@@ -437,7 +437,7 @@ check_account_exists(Username, Host) ->
     end.
 
 check_password(Username, Host, Password) ->
-    case ejabberd_auth:check_password(Username, Host,
+    case ejabberd_auth:check_password(Username, <<"">>, Host,
 				      Password)
 	of
       true -> password_correct;


### PR DESCRIPTION
This allows the authentication modules to perform SASL proxy authentication. It puts the onus on them to authorize the authcid to masquerade as the authzid. Doesn't currently implement such functionality in existing auth modules, since they cannot currently codify a relationship between the two identities. Does not permit the authzid to use a domain differently from the one of the connection.

Note: digest might not work, but I have no interest in it, being deprecated.