### PR TITLE
Fix service discovery handling for account JIDs

### DIFF
--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -352,21 +352,19 @@ get_sm_items(empty, From, To, _Node, _Lang) ->
       _ -> {error, ?ERR_NOT_ALLOWED}
     end.
 
-is_presence_subscribed(#jid{luser = User,
-			    lserver = Server},
+is_presence_subscribed(#jid{luser = User, lserver = Server},
 		       #jid{luser = User, lserver = Server}) -> true;
-is_presence_subscribed(#jid{luser = User,
-			    lserver = Server},
-		       #jid{luser = LUser, lserver = LServer}) ->
-    lists:any(fun (#roster{jid = {TUser, TServer, _},
-			   subscription = S}) ->
-		      if User == TUser, Server == TServer, S /= none ->
-			     true;
-			 true -> false
-		      end
+is_presence_subscribed(#jid{luser = FromUser, lserver = FromServer},
+		       #jid{luser = ToUser, lserver = ToServer}) ->
+    lists:any(fun (#roster{jid = {SubUser, SubServer, _}, subscription = Sub})
+		      when FromUser == SubUser, FromServer == SubServer,
+			   Sub /= none ->
+		      true;
+		  (_RosterEntry) ->
+		      false
 	      end,
-	      ejabberd_hooks:run_fold(roster_get, LServer, [],
-				      [{LUser, LServer}])).
+	      ejabberd_hooks:run_fold(roster_get, ToServer, [],
+				      [{ToUser, ToServer}])).
 
 process_sm_iq_info(From, To,
 		   #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ) ->

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -357,13 +357,13 @@ is_presence_subscribed(#jid{luser = User,
 		       #jid{luser = LUser, lserver = LServer}) ->
     lists:any(fun (#roster{jid = {TUser, TServer, _},
 			   subscription = S}) ->
-		      if LUser == TUser, LServer == TServer, S /= none ->
+		      if User == TUser, Server == TServer, S /= none ->
 			     true;
 			 true -> false
 		      end
 	      end,
-	      ejabberd_hooks:run_fold(roster_get, Server, [],
-				      [{User, Server}]))
+	      ejabberd_hooks:run_fold(roster_get, LServer, [],
+				      [{LUser, LServer}]))
       orelse User == LUser andalso Server == LServer.
 
 process_sm_iq_info(From, To,

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -354,6 +354,9 @@ get_sm_items(empty, From, To, _Node, _Lang) ->
 
 is_presence_subscribed(#jid{luser = User,
 			    lserver = Server},
+		       #jid{luser = User, lserver = Server}) -> true;
+is_presence_subscribed(#jid{luser = User,
+			    lserver = Server},
 		       #jid{luser = LUser, lserver = LServer}) ->
     lists:any(fun (#roster{jid = {TUser, TServer, _},
 			   subscription = S}) ->
@@ -363,8 +366,7 @@ is_presence_subscribed(#jid{luser = User,
 		      end
 	      end,
 	      ejabberd_hooks:run_fold(roster_get, LServer, [],
-				      [{LUser, LServer}]))
-      orelse User == LUser andalso Server == LServer.
+				      [{LUser, LServer}])).
 
 process_sm_iq_info(From, To,
 		   #iq{type = Type, lang = Lang, sub_el = SubEl} = IQ) ->


### PR DESCRIPTION
`mod_disco` [makes sure][1] that service discovery information for account JIDs is only returned to subscribed contacts.  However, the [check whether the peer is subscribed][2] only works for local contacts, as the *contact's* roster is checked instead of the own one.

These commits fix this issue, and they also try to make the check a little more efficient and readable.

[1]: https://github.com/processone/ejabberd/commit/55dbdf5dbaa606569e655485b525dc1e9c739337
[2]: https://github.com/processone/ejabberd/blob/9c85cb5f250f141688e69116d5740c0c8f5973c6/src/mod_disco.erl#L355