### PR TITLE
Add a Vagrant development VM template suitable for running the test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .#*
 .edts
 *.dump
+.vagrant
 /Makefile
 /config.log
 /config.status

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update -y
+    curl https://packagecloud.io/install/repositories/basho/riak/script.deb.sh | sudo bash
+    sudo apt-get install -y build-essential autoconf erlang libexpat1-dev libyaml-dev libpam0g-dev libsqlite3-dev riak mysql-server postgresql postgresql-contrib git
+
+    sudo mysql -u root -e "CREATE USER 'ejabberd_test'@'localhost' IDENTIFIED BY 'ejabberd_test';"
+    sudo mysql -u root -e "CREATE DATABASE ejabberd_test;"
+    sudo mysql -u root -e "GRANT ALL ON ejabberd_test.* TO 'ejabberd_test'@'localhost';"
+    sudo -u postgres psql -U postgres -c "CREATE USER ejabberd_test WITH PASSWORD 'ejabberd_test';"
+    sudo -u postgres psql -U postgres -c "CREATE DATABASE ejabberd_test;"
+    sudo -u postgres psql -U postgres -c "GRANT ALL PRIVILEGES ON DATABASE ejabberd_test TO ejabberd_test;"
+
+    cd /vagrant
+    ./autogen.sh
+    ./configure --enable-all --disable-odbc --disable-elixir
+    make xref
+  SHELL
+end


### PR DESCRIPTION
Unfortunately, running the tests, I consistently get the following:

```
--- Test run on 2015/05/05 02:12:02 ---
Converting "/vagrant/." to "/vagrant" and re-inserting with add_patha/1


Common Test v1.7.4 starting (cwd is /vagrant)


Common Test: Running make in test directories...
Including the following directories:
"/vagrant/include"
"/vagrant/tools"

CWD set to: "/vagrant/logs/ct_run.test@vagrant-ubuntu-trusty-64.2015-05-05_02.12.03"

TEST INFO: 1 test(s), 158 case(s) in 1 suite(s)

Testing vagrant: Starting test, 158 test cases

=INFO REPORT==== 5-May-2015::02:12:05 ===
LDIF tree loaded, ready to accept connections
- - - - - - - - - - - - - - - - - - - - - - - - - -
ejabberd_SUITE:init_per_suite failed
Reason: {badmatch,{error,{bad_return,{{ejabberd_app,start,[normal|.....}
- - - - - - - - - - - - - - - - - - - - - - - - - -

Testing vagrant: *** FAILED {ejabberd_SUITE,init_per_suite} ***
Testing vagrant: TEST COMPLETE, 0 ok, 0 failed, 158 skipped of 158 test cases

Updating /vagrant/logs/index.html... done
Updating /vagrant/logs/all_runs.html... done
```

How might I get a full stack trace here so that I can debug?