### PR TITLE
Tag private MUC messages with muc#user namespace

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -570,7 +570,10 @@ normal_state({route, From, ToNick,
 				   FromNickJID =
 				       jlib:jid_replace_resource(StateData#state.jid,
 								 FromNick),
-				   [ejabberd_router:route(FromNickJID, ToJID, Packet)
+				   X = #xmlel{name = <<"x">>,
+					      attrs = [{<<"xmlns">>, ?NS_MUC_USER}]},
+				   PrivMsg = xml:append_subtags(Packet, [X]),
+				   [ejabberd_router:route(FromNickJID, ToJID, PrivMsg)
 				    || ToJID <- ToJIDs];
 			       true ->
 				   ErrText =


### PR DESCRIPTION
Make it possible for clients to identify private MUC messages.  One use case would be to filter out undesired carbon copies of those.

This has been suggested [on the standards list][1] by the authors of [Yaxim][2] and [Conversations][3].

[1]: http://mail.jabber.org/pipermail/standards/2015-May/thread.html#29819
[2]: http://mail.jabber.org/pipermail/standards/2015-May/029819.html
[3]: http://mail.jabber.org/pipermail/standards/2015-May/029821.html