### PR TITLE
Add max_user_presence option to mod_muc option

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -44,7 +44,7 @@
 	 handle_info/3,
 	 terminate/3,
 	 code_change/4]).
--define(LAGER,1).
+
 -include("ejabberd.hrl").
 -include("logger.hrl").
 


### PR DESCRIPTION
This is to to prevent server high CPU & RAM usage when joining a room with large member. In the ejabberd config file, just add a max_user_presence option in mod_muc config with a number (default is 100). Because when there are a lot of member in a conference (for example more than 1000 user), ejabberd will consume a lot of CPU & RAM of server. So, setup a max_user_presence to prevent this problem.
Ejabberd will stop sending presence packet to all member when the number of user in conference reach the max_user_presence.
Example of the use: https://www.ejabberd.im/node/5055

This make MUC will become these kind:
- Normal MUC: where user can see others presence
- Public MUC: where there is a large number of user in a conference, user don't care about others presence