### PR TITLE
Update send_element error checking (EJAB-1739)

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1891,7 +1891,7 @@ send_text(StateData, Text) when StateData#state.mgmt_state == active ->
     case catch (StateData#state.sockmod):send(StateData#state.socket, Text) of
       {'EXIT', _} ->
 	  (StateData#state.sockmod):close(StateData#state.socket),
-	  error;
+	  {error, closed};
       _ ->
 	  ok
     end;
@@ -1915,7 +1915,7 @@ send_stanza(StateData, Stanza) when StateData#state.mgmt_state == active ->
     NewStateData = case send_stanza_and_ack_req(StateData, Stanza) of
 		     ok ->
 			 StateData;
-		     error ->
+		     _Error ->
 			 StateData#state{mgmt_state = pending}
 		   end,
     mgmt_queue_add(NewStateData, Stanza);
@@ -2833,8 +2833,8 @@ send_stanza_and_ack_req(StateData, Stanza) ->
     case send_element(StateData, Stanza) of
       ok ->
 	  send_element(StateData, AckReq);
-      error ->
-	  error
+      Error ->
+	  Error
     end.
 
 mgmt_queue_add(StateData, El) ->


### PR DESCRIPTION
Let `send_text/2` and (therefore) `send_element/2` return `{error, Reason}` instead of `error`, and let `send_stanza_and_ack_req/2` interpret any non-`ok` value as an error.  ([EJAB-1739][1])

[1]: https://support.process-one.net/browse/EJAB-1739