### PR TITLE
fixed erl_prettypr in encode_term

### DIFF
--- a/src/ejabberd_odbc.erl
+++ b/src/ejabberd_odbc.erl
@@ -193,7 +193,8 @@ to_bool(_) -> false.
 
 encode_term(Term) ->
     escape(list_to_binary(
-             erl_prettypr:format(erl_syntax:abstract(Term)))).
+             erl_prettypr:format(erl_syntax:abstract(Term),
+                                 [{paper, 65535}, {ribbon, 65535}]))).
 
 decode_term(Bin) ->
     Str = binary_to_list(<<Bin/binary, ".">>),


### PR DESCRIPTION
At least in combination with [NuoDB](http://www.nuodb.com/) encode_term/1 adds a newline after more or less 65 characters, which breaks the decoding. I set the maximum number of characters to a sufficient high value.

