### PR TITLE
Fix some string/binary issues with non-native ODBC drivers

### DIFF
--- a/src/ejabberd_odbc.erl
+++ b/src/ejabberd_odbc.erl
@@ -510,7 +510,8 @@ abort_on_driver_error(Reply, From) ->
 %% Open an ODBC database connection
 odbc_connect(SQLServer) ->
     ejabberd:start_app(odbc),
-    odbc:connect(binary_to_list(SQLServer), [{scrollable_cursors, off}]).
+    odbc:connect(binary_to_list(SQLServer), [{scrollable_cursors, off},
+                                             {binary_strings, on}]).
 
 %% == Native SQLite code
 
@@ -635,7 +636,7 @@ mysql_item_to_odbc(Columns, Recs) ->
     {selected, [element(2, Column) || Column <- Columns], Recs}.
 
 to_odbc({selected, Columns, Recs}) ->
-    {selected, Columns, [tuple_to_list(Rec) || Rec <- Recs]};
+    {selected, [list_to_binary(Column) || Column <- Columns], [tuple_to_list(Rec) || Rec <- Recs]};
 to_odbc(Res) ->
     Res.
 


### PR DESCRIPTION
1. Configure the odbc connection to return values as binary.
2. Change table names to binary.