### PR TITLE
New options: dhfile and s2s_dhfile

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -292,6 +292,7 @@ init([{SockMod, Socket}, Opts]) ->
 	    StartTLSRequired orelse TLSEnabled,
     TLSOpts1 = lists:filter(fun ({certfile, _}) -> true;
 				({ciphers, _}) -> true;
+				({dhfile, _}) -> true;
 				(_) -> false
 			    end,
 			    Opts),

--- a/src/ejabberd_http.erl
+++ b/src/ejabberd_http.erl
@@ -95,6 +95,7 @@ init({SockMod, Socket}, Opts) ->
     TLSEnabled = proplists:get_bool(tls, Opts),
     TLSOpts1 = lists:filter(fun ({certfile, _}) -> true;
 				({ciphers, _}) -> true;
+				({dhfile, _}) -> true;
 				(_) -> false
 			    end,
 			    Opts),

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -184,9 +184,14 @@ init([{SockMod, Socket}, Opts]) ->
                    undefined -> TLSOpts2;
                    ProtocolOpts -> [{protocol_options, ProtocolOpts} | TLSOpts2]
                end,
+    TLSOpts4 = case ejabberd_config:get_option(
+                      s2s_dhfile, fun iolist_to_binary/1) of
+                   undefined -> TLSOpts3;
+                   DHFile -> [{dhfile, DHFile} | TLSOpts3]
+               end,
     TLSOpts = case proplists:get_bool(tls_compression, Opts) of
-                  false -> [compression_none | TLSOpts3];
-                  true -> TLSOpts3
+                  false -> [compression_none | TLSOpts4];
+                  true -> TLSOpts4
               end,
     Timer = erlang:start_timer(?S2STIMEOUT, self(), []),
     {ok, wait_for_stream,

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -207,13 +207,18 @@ init([From, Server, Type]) ->
                    undefined -> TLSOpts2;
                    ProtocolOpts -> [{protocol_options, ProtocolOpts} | TLSOpts2]
                end,
+    TLSOpts4 = case ejabberd_config:get_option(
+                      s2s_dhfile, fun iolist_to_binary/1) of
+                   undefined -> TLSOpts3;
+                   DHFile -> [{dhfile, DHFile} | TLSOpts3]
+               end,
     TLSOpts = case ejabberd_config:get_option(
                      {s2s_tls_compression, From},
                      fun(true) -> true;
                         (false) -> false
                      end, true) of
-                  false -> [compression_none | TLSOpts3];
-                  true -> TLSOpts3
+                  false -> [compression_none | TLSOpts4];
+                  true -> TLSOpts4
               end,
     {New, Verify} = case Type of
 		      {new, Key} -> {Key, false};


### PR DESCRIPTION
Let admins specify a file that contains custom parameters for Diffie-Hellman key exchange (see [EJAB-1697][1]).

This requires processone/tls#11.

[1]: https://support.process-one.net/browse/EJAB-1697