### PR TITLE
PubSub: Check for node subscription of bare JID

### DIFF
--- a/src/node_hometree.erl
+++ b/src/node_hometree.erl
@@ -373,7 +373,8 @@ publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload) ->
     end,
     Affiliation = GenState#pubsub_state.affiliation,
     Subscribed = case PublishModel of
-	subscribers -> is_subscribed(SubState#pubsub_state.subscriptions);
+	subscribers -> is_subscribed(GenState#pubsub_state.subscriptions) orelse
+		       is_subscribed(SubState#pubsub_state.subscriptions);
 	_ -> undefined
     end,
     if not ((PublishModel == open) or
@@ -738,8 +739,10 @@ get_items(Nidx, JID, AccessModel, PresenceSubscription, RosterGroup, _SubId, _RS
     GenState = get_state(Nidx, GenKey),
     SubState = get_state(Nidx, SubKey),
     Affiliation = GenState#pubsub_state.affiliation,
-    Subscriptions = SubState#pubsub_state.subscriptions,
-    Whitelisted = can_fetch_item(Affiliation, Subscriptions),
+    BareSubscriptions = GenState#pubsub_state.subscriptions,
+    FullSubscriptions = SubState#pubsub_state.subscriptions,
+    Whitelisted = can_fetch_item(Affiliation, BareSubscriptions) orelse
+		  can_fetch_item(Affiliation, FullSubscriptions),
     if %%SubId == "", ?? ->
 	%% Entity has multiple subscriptions to the node but does not specify a subscription ID
 	%{error, ?ERR_EXTENDED(?ERR_BAD_REQUEST, "subid-required")};


### PR DESCRIPTION
Don't just check whether the full JID is subscribed when a node subscription is required to list or publish items.  If the bare JID is subscribed, these requests are now also accepted.

The issue I'm trying to fix here was introduced with commit 967bbe7f032e6f7b2fd51e88a139bbabf0006f4c, which was submitted in order to fix [EJAB-701][1].  Before that commit, only bare JID subscriptions worked as expected.  After that commit, only full JID subscriptions work as they should (when publishing/listing items).  I guess that wasn't the intention.

[1]: https://support.process-one.net/browse/EJAB-701