### PR TITLE
Omit warning message regarding non-anonymous MUC room

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -1853,31 +1853,6 @@ add_new_user(From, Nick,
 		NewState = add_user_presence(From, Packet,
 					     add_online_user(From, Nick, Role,
 							     StateData)),
-		if not (NewState#state.config)#config.anonymous ->
-		       WPacket = #xmlel{name = <<"message">>,
-					attrs = [{<<"type">>, <<"groupchat">>}],
-					children =
-					    [#xmlel{name = <<"body">>,
-						    attrs = [],
-						    children =
-							[{xmlcdata,
-							  translate:translate(Lang,
-									      <<"This room is not anonymous">>)}]},
-					     #xmlel{name = <<"x">>,
-						    attrs =
-							[{<<"xmlns">>,
-							  ?NS_MUC_USER}],
-						    children =
-							[#xmlel{name =
-								    <<"status">>,
-								attrs =
-								    [{<<"code">>,
-								      <<"100">>}],
-								children =
-								    []}]}]},
-		       ejabberd_router:route(StateData#state.jid, From, WPacket);
-		   true -> ok
-		end,
 		send_existing_presences(From, NewState),
 		send_new_presence(From, NewState),
 		Shift = count_stanza_shift(Nick, Els, NewState),


### PR DESCRIPTION
Previous versions of XEP-0045 suggested sending a warning message to new occupants of a non-anonymous MUC room.  The current revision (1.25) [says][1] that a status code of "100" must be returned with the user's initial presence, instead.  We already [do this][2] (in addition to generating the warning message).

Receiving the warning message each time the client joins the room can become annoying, especially when reconnections occur frequently (e.g., on mobile devices).  So, let's omit it.

[1]: http://xmpp.org/extensions/xep-0045.html#security-anon
[2]: https://github.com/processone/ejabberd/blob/4ae1b4db03f4cea0fd1d7639ac58eb58cbb19efd/src/mod_muc_room.erl#L2197