### PR TITLE
Also send PEP notifications when local contact updates CAPS

### DIFF
--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -685,6 +685,15 @@ disco_items(Host, Node, From) ->
 
 caps_update(#jid{luser = U, lserver = S, lresource = R}, #jid{lserver = Host} = JID, _Features)
 	when Host =/= S ->
+    %% When a remote contact goes online while the local user is offline, the
+    %% remote contact won't receive last items from the local user even if
+    %% ignore_pep_from_offline is set to false. To work around this issue a bit,
+    %% we'll also send the last items to remote contacts when the local user
+    %% connects. That's the reason to use the caps_update hook instead of the
+    %% presence_probe_hook for remote contacts: The latter is only called when a
+    %% contact becomes available; the former also is also executed when the
+    %% local user goes online (because that triggers the contact to send a
+    %% presence packet with CAPS).
     presence(Host, {presence, U, S, [R], JID});
 caps_update(_From, _To, _Feature) ->
     ok.

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -62,7 +62,7 @@
 -define(PEPNODE, <<"pep">>).
 
 %% exports for hooks
--export([presence_probe/3, caps_update/3,
+-export([presence_probe/3, caps_add/3, caps_update/3,
     in_subscription/6, out_subscription/4,
     on_user_offline/3, remove_user/2,
     disco_local_identity/5, disco_local_features/5,
@@ -293,6 +293,8 @@ init([ServerHost, Opts]) ->
 	?MODULE, remove_user, 50),
     case lists:member(?PEPNODE, Plugins) of
 	true ->
+	    ejabberd_hooks:add(caps_add, ServerHost,
+		?MODULE, caps_add, 80),
 	    ejabberd_hooks:add(caps_update, ServerHost,
 		?MODULE, caps_update, 80),
 	    ejabberd_hooks:add(disco_sm_identity, ServerHost,
@@ -683,20 +685,23 @@ disco_items(Host, Node, From) ->
 %% presence hooks handling functions
 %%
 
-caps_update(#jid{luser = U, lserver = S, lresource = R}, #jid{lserver = Host} = JID, _Features)
+caps_add(#jid{luser = U, lserver = S, lresource = R}, #jid{lserver = Host} = JID, _Features)
 	when Host =/= S ->
     %% When a remote contact goes online while the local user is offline, the
     %% remote contact won't receive last items from the local user even if
     %% ignore_pep_from_offline is set to false. To work around this issue a bit,
     %% we'll also send the last items to remote contacts when the local user
-    %% connects. That's the reason to use the caps_update hook instead of the
+    %% connects. That's the reason to use the caps_add hook instead of the
     %% presence_probe_hook for remote contacts: The latter is only called when a
-    %% contact becomes available; the former also is also executed when the
-    %% local user goes online (because that triggers the contact to send a
-    %% presence packet with CAPS).
+    %% contact becomes available; the former is also executed when the local
+    %% user goes online (because that triggers the contact to send a presence
+    %% packet with CAPS).
     presence(Host, {presence, U, S, [R], JID});
-caps_update(_From, _To, _Feature) ->
+caps_add(_From, _To, _Feature) ->
     ok.
+
+caps_update(#jid{luser = U, lserver = S, lresource = R}, #jid{lserver = Host} = JID, _Features) ->
+    presence(Host, {presence, U, S, [R], JID}).
 
 presence_probe(#jid{luser = U, lserver = S, lresource = R} = JID, JID, Pid) ->
     presence(S, {presence, JID, Pid}),
@@ -709,7 +714,7 @@ presence_probe(#jid{luser = U, lserver = S, lresource = R}, #jid{lserver = S} = 
     presence(S, {presence, U, S, [R], JID});
 presence_probe(_Host, _JID, _Pid) ->
     %% ignore presence_probe from remote contacts,
-    %% those are handled via caps_update
+    %% those are handled via caps_add
     ok.
 
 presence(ServerHost, Presence) ->
@@ -881,6 +886,8 @@ terminate(_Reason,
     ejabberd_router:unregister_route(Host),
     case lists:member(?PEPNODE, Plugins) of
 	true ->
+	    ejabberd_hooks:delete(caps_add, ServerHost,
+		?MODULE, caps_add, 80),
 	    ejabberd_hooks:delete(caps_update, ServerHost,
 		?MODULE, caps_update, 80),
 	    ejabberd_hooks:delete(disco_sm_identity, ServerHost,


### PR DESCRIPTION
When a contact of a local user becomes available, the contact should receive any last PEP items of the local user the contact is interested in. We currently use two different hooks for this:

- `presence_probe_hook`  
This hook is executed when a contact becomes available.  `mod_pubsub` only [uses it][1] when a *local* contact goes online.  For remote contacts, it [is ignored][2].

- `caps_update`  
This hook is executed when the local user receives a new [CAPS hash][3] from a contact.  This (usually) happens when a contact becomes available, *and also when the local user becomes available*. (Because in both cases, the contact will usually send a presence packet with such a hash.)  `mod_pubsub` only [uses it][4] for *remote* contacts.  For local contacts, it [is ignored][5].

So, for *local* contacts, last PEP items are only generated when the contact becomes available.  For *remote* contacts, they are also generated when the local user becomes available.  The latter behavior would usually be undesired, but it makes sense as a workaround to the issue that setting `ignore_pep_from_offline: false` doesn't work for remote contacts: They will never receive last items from local *offline* users.  To mitigate this problem a bit, they will also receive last items when the local user goes online again.  This is the reason to use the `caps_update` hook instead of the `presence_probe_hook` for remote users.

As a side effect of using the `caps_update` hook, remote clients might also receive the last PEP items if they just update their CAPS hash (because the user enabled PEP, for example).  This did *not* work for local contacts.

This PR changes things so that local users also receive last PEP items if they send a new CAPS hash, and it clarifies the code a bit.

[1]: https://github.com/processone/ejabberd/blob/0770252e9bb773a041dc3853b92c6026bdcd46be/src/mod_pubsub.erl#L699
[2]: https://github.com/processone/ejabberd/blob/0770252e9bb773a041dc3853b92c6026bdcd46be/src/mod_pubsub.erl#L701 
[3]: http://xmpp.org/extensions/xep-0115.html
[4]: https://github.com/processone/ejabberd/blob/0770252e9bb773a041dc3853b92c6026bdcd46be/src/mod_pubsub.erl#L686
[5]: https://github.com/processone/ejabberd/blob/0770252e9bb773a041dc3853b92c6026bdcd46be/src/mod_pubsub.erl#L689