### PR TITLE
Remove --enable-nif flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,10 +108,10 @@ AC_ARG_ENABLE(mssql,
 esac],[db_type=generic])
 
 AC_ARG_ENABLE(all,
-[AC_HELP_STRING([--enable-all], [same as --enable-nif --enable-odbc --enable-mysql --enable-pgsql --enable-sqlite --enable-pam --enable-zlib --enable-riak --enable-redis --enable-json --enable-elixir --enable-iconv --enable-debug --enable-lager --enable-tools (useful for Dialyzer checks, default: no)])],
+[AC_HELP_STRING([--enable-all], [same as --enable-odbc --enable-mysql --enable-pgsql --enable-sqlite --enable-pam --enable-zlib --enable-riak --enable-redis --enable-json --enable-elixir --enable-iconv --enable-debug --enable-lager --enable-tools (useful for Dialyzer checks, default: no)])],
 [case "${enableval}" in
-  yes) nif=true odbc=true mysql=true pgsql=true sqlite=true pam=true zlib=true riak=true redis=true json=true elixir=true iconv=true debug=true lager=true tools=true ;;
-  no) nif=false odbc=false mysql=false pgsql=false sqlite=false pam=false zlib=false riak=false redis=false json=false elixir=false iconv=false debug=false lager=false tools=false ;;
+  yes) odbc=true mysql=true pgsql=true sqlite=true pam=true zlib=true riak=true redis=true json=true elixir=true iconv=true debug=true lager=true tools=true ;;
+  no) odbc=false mysql=false pgsql=false sqlite=false pam=false zlib=false riak=false redis=false json=false elixir=false iconv=false debug=false lager=false tools=false ;;
   *) AC_MSG_ERROR(bad value ${enableval} for --enable-all) ;;
 esac],[])
 
@@ -122,14 +122,6 @@ AC_ARG_ENABLE(tools,
   no)  tools=false ;;
   *) AC_MSG_ERROR(bad value ${enableval} for --enable-tools) ;;
 esac],[if test "x$tools" = "x"; then tools=false; fi])
-
-AC_ARG_ENABLE(nif,
-[AC_HELP_STRING([--enable-nif], [replace some functions with C equivalents. Requires Erlang R13B04 or higher (default: no)])],
-[case "${enableval}" in
-  yes) nif=true ;;
-  no)  nif=false ;;
-  *) AC_MSG_ERROR(bad value ${enableval} for --enable-nif) ;;
-esac],[if test "x$nif" = "x"; then nif=false; fi])
 
 AC_ARG_ENABLE(odbc,
 [AC_HELP_STRING([--enable-odbc], [enable pure ODBC support (default: no)])],
@@ -266,7 +258,6 @@ AC_SUBST(hipe)
 AC_SUBST(roster_gateway_workaround)
 AC_SUBST(transient_supervisors)
 AC_SUBST(full_xml)
-AC_SUBST(nif)
 AC_SUBST(db_type)
 AC_SUBST(odbc)
 AC_SUBST(mysql)

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -21,8 +21,6 @@ Macros = lists:flatmap(
                    [{d, 'ROSTER_GATEWAY_WORKAROUND'}];
               ({transient_supervisors, false}) ->
                    [{d, 'NO_TRANSIENT_SUPERVISORS'}];
-              ({nif, true}) ->
-                   [{d, 'NIF'}];
               ({db_type, mssql}) ->
                    [{d, 'mssql'}];
               ({lager, true}) ->
@@ -70,9 +68,7 @@ ConfigureCmd = fun(Pkg, Flags) ->
                end,
 
 XMLFlags = lists:foldl(
-             fun({nif, true}, Acc) ->
-                     Acc ++ " --enable-nif";
-                ({full_xml, true}, Acc) ->
+             fun({full_xml, true}, Acc) ->
                      Acc ++ " --enable-full-xml";
                 (_, Acc) ->
                      Acc

--- a/vars.config.in
+++ b/vars.config.in
@@ -10,7 +10,6 @@
 {roster_gateway_workaround, @roster_gateway_workaround@}.
 {transient_supervisors, @transient_supervisors@}.
 {full_xml, @full_xml@}.
-{nif, @nif@}.
 {db_type, @db_type@}.
 {debug, @debug@}.
 {hipe, @hipe@}.


### PR DESCRIPTION
Specifying `--enable-nif` or `--disable-nif` when running ejabberd's configure script has no effect anymore: NIF support is enabled by default and can only be disabled by building [the p1_xml dependency][1] with `--disable-nif`.  So, this commit removes the flag.

[1]: https://github.com/processone/xml