### PR TITLE
bug fix: ejabberd:start_app need to pass Type to application:start

### DIFF
--- a/src/ejabberd.erl
+++ b/src/ejabberd.erl
@@ -79,7 +79,7 @@ is_loaded() ->
 start_app(App, Type, StartFlag) when not is_list(App) ->
     start_app([App], Type, StartFlag);
 start_app([App|Apps], Type, StartFlag) ->
-    case application:start(App) of
+    case application:start(App,Type) of
         ok ->
             spawn(fun() -> check_app_modules(App, StartFlag) end),
             start_app(Apps, Type, StartFlag);


### PR DESCRIPTION
Hi, 
While I am reading the source code, I found the  second argument `ejabberd:start_app`, i.e. `Type` is not really used. 

I see `Type` could be `temporary` or `permanent`, so I guess it should be used by `application:start`.
Please reject it if I am wrong.

Br, wcy123.