### PR TITLE
get_room_options will not crash in case of query for a non-existent room

### DIFF
--- a/src/mod_muc_admin.erl
+++ b/src/mod_muc_admin.erl
@@ -816,8 +816,10 @@ change_option(Option, Value, Config) ->
 %%----------------------------
 
 get_room_options(Name, Service) ->
-    Pid = get_room_pid(Name, Service),
-    get_room_options(Pid).
+    case get_room_pid(Name, Service) of
+        room_not_found -> [];
+        Pid -> get_room_options(Pid)
+    end.
 
 get_room_options(Pid) ->
     Config = get_room_config(Pid),


### PR DESCRIPTION
Room options should return an empty list in case of a non-existent room. 
This lets other modules check muc options with proplists:get_bool(), which is nice.