### PR TITLE
Comment unused type, unused term

### DIFF
--- a/src/ejabberd_auth_external.erl
+++ b/src/ejabberd_auth_external.erl
@@ -281,7 +281,7 @@ is_fresh_enough(TimeStampLast, CacheTime) ->
 get_last_access(User, Server) ->
     case ejabberd_sm:get_user_resources(User, Server) of
       [] ->
-	  _US = {User, Server},
+%%	  _US = {User, Server},
 	  case get_last_info(User, Server) of
 	    mod_last_required -> mod_last_required;
 	    not_found -> never;

--- a/src/gen_iq_handler.erl
+++ b/src/gen_iq_handler.erl
@@ -44,9 +44,9 @@
 
 -record(state, {host, module, function}).
 
--type component() :: ejabberd_sm | ejabberd_local.
+%%-type component() :: ejabberd_sm | ejabberd_local.
 -type type() :: no_queue | one_queue | pos_integer() | parallel.
--type opts() :: no_queue | {one_queue, pid()} | {queues, [pid()]} | parallel.
+%%-type opts() :: no_queue | {one_queue, pid()} | {queues, [pid()]} | parallel.
 
 %%====================================================================
 %% API

--- a/src/mod_configure.erl
+++ b/src/mod_configure.erl
@@ -1912,7 +1912,7 @@ set_form(From, Host,
 						Server)
 		of
 	      [] ->
-		  _US = {User, Server},
+%%		  _US = {User, Server},
 		  case get_last_info(User, Server) of
 		    not_found -> ?T(Lang, <<"Never">>);
 		    {ok, Timestamp, _Status} ->


### PR DESCRIPTION
Fix compiling warnings: unused term(_US = {User, Server}), used type(component(),  opts()).
It seems work good after comment these four lines.