### PR TITLE
Allow root to run join_cluster and leave_cluster

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -444,11 +444,11 @@ check_start()
 # cluster setup
 join_cluster()
 {
-    $EJABBERD_BIN_PATH/joincluster $*
+    $EXEC_CMD "$EJABBERD_BIN_PATH/joincluster $*"
 }
 leave_cluster()
 {
-    $EJABBERD_BIN_PATH/leavecluster $*
+    $EXEC_CMD "$EJABBERD_BIN_PATH/leavecluster $*"
 }
 
 # allow sync calls

--- a/tools/joincluster
+++ b/tools/joincluster
@@ -145,7 +145,7 @@ start() ->
 EOF
 
 $ERLC -o $PA $CLUSTERSETUP_ERL
-sh -c "$ERL $NAME $ERLANG_NODE -pa $PA $KERNEL_OPTS -mnesia extra_db_nodes \"['$REMOTE']\" dir \"\\\"$SPOOL_DIR\\\"\" -s mnesia -s $CLUSTERSETUP start"
+$ERL $NAME $ERLANG_NODE -pa $PA $KERNEL_OPTS -mnesia extra_db_nodes "['$REMOTE']" dir "\"$SPOOL_DIR\"" -s mnesia -s $CLUSTERSETUP start
 cd -
 rm -Rf $PA
 

--- a/tools/leavecluster
+++ b/tools/leavecluster
@@ -101,7 +101,7 @@ start() ->
 EOF
 
 $ERLC -o $PA $CLUSTERSETUP_ERL
-sh -c "$ERL $NAME $ERLANG_NODE -pa $PA $KERNEL_OPTS -mnesia dir \"\\\"$SPOOL_DIR\\\"\" -s mnesia -s $CLUSTERSETUP start"
+$ERL $NAME $ERLANG_NODE -pa $PA $KERNEL_OPTS -mnesia dir "\"$SPOOL_DIR\"" -s mnesia -s $CLUSTERSETUP start
 cd -
 rm -Rf $PA
 


### PR DESCRIPTION
Prefix the call to joincluster and leavecluster in ejabberdctl by
$EXEC_CMD. Avoid using sh -c in these scripts.

Should fix #676.