### PR TITLE
Remove bashisms in {join,leave}cluster scripts

### DIFF
--- a/tools/joincluster
+++ b/tools/joincluster
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Add the current ejabberd node in a cluster
 
@@ -15,7 +15,7 @@
 # 30 : network issue
 # 31 : node names incompatibility
 
-function error
+error()
 {
     echo "Error: $1" >&2
     exit $2
@@ -67,7 +67,7 @@ CTL=$(which ejabberdctl)
 echo "Using commands:"
 [ -x "$CTL" ] && echo $CTL || error "can't find ejabberdctl" 10
 
-. $CTL stop 2>/dev/null >/dev/null
+$CTL stop 2>/dev/null >/dev/null
 ERLC=${ERL}c
 
 [ -x $ERL ] && echo $ERL || error "can't find erl"  11

--- a/tools/leavecluster
+++ b/tools/leavecluster
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Remove the current ejabberd node in a cluster
 
@@ -11,7 +11,7 @@
 # 12 : erlc not found
 # 22 : temporary dir can not be created
 
-function error
+error()
 {
     echo "Error: $1" >&2
     exit $2
@@ -45,7 +45,7 @@ CTL=$(which ejabberdctl)
 echo "Using commands:"
 [ -x "$CTL" ] && echo $CTL || error "can't find ejabberdctl" 10
 
-. $CTL stop 2>/dev/null >/dev/null
+$CTL stop 2>/dev/null >/dev/null
 ERLC=${ERL}c
 
 [ -x $ERL ] && echo $ERL || error "can't find erl"  11


### PR DESCRIPTION
So they can run in any POSIX shell, not bash only.

Bashisms have been detected with the checkbashisms program from the
devscripts package:
$ checkbashisms tools/*cluster
possible bashism in tools/joincluster line 18 ('function' is useless):
function error
possible bashism in tools/joincluster line 70 (sourced script with arguments):
. $CTL stop 2>/dev/null >/dev/null
possible bashism in tools/leavecluster line 14 ('function' is useless):
function error
possible bashism in tools/leavecluster line 48 (sourced script with arguments):
. $CTL stop 2>/dev/null >/dev/null
