### PR TITLE
Ignore mnesiadb and _build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ XmppAddr.hrl
 /logs/
 /priv/sql
 /rel/ejabberd
+/_build
+/mnesiadb


### PR DESCRIPTION
When building with `mix` these directories are created, but should not be checked into git.