### PR TITLE
Don't send full JID in 'from' of Roster Push (RFC 6121 section 2.1.6)

### DIFF
--- a/src/mod_shared_roster.erl
+++ b/src/mod_shared_roster.erl
@@ -1025,7 +1025,7 @@ push_item(User, Server, Item) ->
 					    children = [item_to_xml(Item)]}]}),
     lists:foreach(fun (Resource) ->
 			  JID = jlib:make_jid(User, Server, Resource),
-			  ejabberd_router:route(JID, JID, Stanza)
+			  ejabberd_router:route(jlib:jid_remove_resource(JID), JID, Stanza)
 		  end,
 		  ejabberd_sm:get_user_resources(User, Server)).
 


### PR DESCRIPTION
just providing @badlop patch from #367 as a pull request

I can vouch for this patch as I have been running with it for several months against various XMPP client implementations without issue. It solves the problem with the Smack library which is the pretext for #367