### PR TITLE
Update minimum required OpenSSL version

### DIFF
--- a/README
+++ b/README
@@ -107,7 +107,7 @@ To compile ejabberd you need:
  - Libexpat 1.95 or higher.
  - Libyaml 0.1.4 or higher.
  - Erlang/OTP 17.1 or higher.
- - OpenSSL 0.9.8 or higher, for STARTTLS, SASL and SSL encryption.
+ - OpenSSL 1.0.0 or higher, for STARTTLS, SASL and SSL encryption.
  - Zlib 1.2.3 or higher, for Stream Compression support (XEP-0138). Optional.
  - PAM library. Optional. For Pluggable Authentication Modules (PAM).
  - GNU Iconv 1.8 or higher, for the IRC Transport (mod_irc). Optional. Not


### PR DESCRIPTION
The documentation [here] specifies OpenSSL 1.0.0+

Also, when compiling on OS X with Apple's OpenSSL (0.9.8) the VM crashes.

[here]: http://docs.ejabberd.im/admin/guide/installation/