### PR TITLE
mod_offline: Support discarding chat state notifications

### DIFF
--- a/src/mod_client_state.erl
+++ b/src/mod_client_state.erl
@@ -91,22 +91,12 @@ filter_presence(_Action, #xmlel{name = <<"presence">>, attrs = Attrs}) ->
 filter_presence(Action, _Stanza) -> Action.
 
 filter_chat_states(_Action, #xmlel{name = <<"message">>} = Stanza) ->
-    %% All XEP-0085 chat states except for <gone/>:
-    ChatStates = [<<"active">>, <<"inactive">>, <<"composing">>, <<"paused">>],
-    Stripped =
-	lists:foldl(fun(ChatState, AccStanza) ->
-			    xml:remove_subtags(AccStanza, ChatState,
-					       {<<"xmlns">>, ?NS_CHATSTATES})
-		    end, Stanza, ChatStates),
-    case Stripped of
-      #xmlel{children = [#xmlel{name = <<"thread">>}]} ->
+    case jlib:is_standalone_chat_state(Stanza) of
+      true ->
 	  ?DEBUG("Got standalone chat state notification", []),
 	  {stop, drop};
-      #xmlel{children = []} ->
-	  ?DEBUG("Got standalone chat state notification", []),
-	  {stop, drop};
-      _ ->
-	  ?DEBUG("Got message with chat state notification", []),
+      false ->
+	  ?DEBUG("Got message stanza", []),
 	  {stop, send}
     end;
 filter_chat_states(Action, _Stanza) -> Action.

--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -286,10 +286,14 @@ need_to_store(LServer, Packet) ->
        and (Type /= <<"headline">>) ->
 	    case gen_mod:get_module_opt(
 		   LServer, ?MODULE, store_empty_body,
-		   fun(V) when is_boolean(V) -> V end,
-		   true) of
+		   fun(V) when is_boolean(V) -> V;
+		      (unless_chat_state) -> unless_chat_state
+		   end,
+		   unless_chat_state) of
 		false ->
 		    xml:get_subtag(Packet, <<"body">>) /= false;
+		unless_chat_state ->
+		    not jlib:is_standalone_chat_state(Packet);
 		true ->
 		    true
 	    end;
@@ -1129,6 +1133,8 @@ mod_opt_type(access_max_user_messages) ->
     fun (A) -> A end;
 mod_opt_type(db_type) -> fun gen_mod:v_db/1;
 mod_opt_type(store_empty_body) ->
-    fun (V) when is_boolean(V) -> V end;
+    fun (V) when is_boolean(V) -> V;
+        (unless_chat_state) -> unless_chat_state
+    end;
 mod_opt_type(_) ->
     [access_max_user_messages, db_type, store_empty_body].


### PR DESCRIPTION
XEP-0160 says that standalone chat state notifications should not be stored offline.  Let `mod_offline` support `store_empty_body: unless_chat_state`, which discards all chat states except for `<gone/>` notifications (as clients might [depend on those][1]).  Other messages with empty bodies (such as MUC invitations) are still stored offline unless `store_empty_body` is set to `false`.

Closes #842.

[1]: http://xmpp.org/extensions/xep-0085.html#bizrules-threads