### PR TITLE
mod_irc: Disable spurious vCard->WHOIS requests.

### DIFF
--- a/src/mod_irc_connection.erl
+++ b/src/mod_irc_connection.erl
@@ -451,8 +451,10 @@ handle_info({route_chan, Channel, Resource,
 					  ?ERR_FEATURE_NOT_IMPLEMENTED),
 	      ejabberd_router:route(To, From, Err);
 	  #iq{xmlns = ?NS_VCARD} ->
-	      Res = io_lib:format("WHOIS ~s \r\n", [Resource]),
-	      _ = (?SEND(Res)),
+	      % TODO: catch WHOIS replies and translate their details to something resembling vCards
+	      % For now this just errors out.
+	      %Res = io_lib:format("WHOIS ~s \r\n", [Resource]),
+	      %_ = (?SEND(Res)),
 	      Err = jlib:make_error_reply(El,
 					  ?ERR_FEATURE_NOT_IMPLEMENTED),
 	      ejabberd_router:route(To, From, Err);


### PR DESCRIPTION
It makes sense that vCard in XMPP roughly maps to WHOIS in IRC,
but there is no code that actually handles receiving WHOISes properly:
they just get passed through as plain messages coming from user!ircserver@irc.xmppserver.tld.
I suppose sometimes you want to manually be able to run a WHOIS and see the results,
so I don't want them banned entirely, but I don't want them on each run.

Sending spurious WHOISes pisses off Xabber, which overenthusiastically sends "get vCard"
IQ stanzas on every single presence change (even "unavailable"); this has the horrible
side effect of spawning a huge number of private chats with users I have never talked to,
and buzzing my phone uncontrollably for a good minute, whenever I join a channel with more
than 50 people in it, and the same every time someone's connection drops.

Disabling this scratches an itch for me and patches over what is arguably Xabber's problem,
but in fact, this code was already half-disabled: _even though it sends IRC commands_ it
returns ?ERR_FEATURE_NOT_IMPLEMENTED.  Was this an oversight?
