### PR TITLE
Don't return error for blocked headlines and MUC messages

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1636,6 +1636,8 @@ handle_info({route, From, To,
 					 deny ->
                                                case xml:get_attr_s(<<"type">>, Attrs) of
                                                    <<"error">> -> ok;
+                                                   <<"groupchat">> -> ok;
+                                                   <<"headline">> -> ok;
                                                    <<"result">> -> ok;
                                                    _ ->
                                                        Err =


### PR DESCRIPTION
If a message stanza is blocked as per XEP-0016 or XEP-0191, [return an error][1] only if the type of the blocked message is `normal` or `chat`. This makes sure users won't be kicked from MUC rooms when blocking other participants.

[1]: http://xmpp.org/extensions/xep-0016.html#protocol-error