### PR TITLE
add room_id_regexp option

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -613,7 +613,8 @@ do_route1(Host, ServerHost, Access, HistorySize, RoomShaper,
 		    case {Name, Type} of
 			{<<"presence">>, <<"">>} ->
 			    case check_user_can_create_room(ServerHost,
-				    AccessCreate, From, Room) of
+				    AccessCreate, From, Room) and
+				check_create_roomid(ServerHost, Room) of
 				true ->
 				    {ok, Pid} = start_new_room(Host, ServerHost, Access,
 					    Room, HistorySize,
@@ -644,16 +645,21 @@ do_route1(Host, ServerHost, Access, HistorySize, RoomShaper,
     end.
 
 check_user_can_create_room(ServerHost, AccessCreate,
-			   From, RoomID) ->
+			   From, _RoomID) ->
     case acl:match_rule(ServerHost, AccessCreate, From) of
-      allow ->
-	  byte_size(RoomID) =<
-	    gen_mod:get_module_opt(ServerHost, ?MODULE, max_room_id,
-                                   fun(infinity) -> infinity;
-                                      (I) when is_integer(I), I>0 -> I
-                                   end, infinity);
+      allow -> true;
       _ -> false
     end.
+
+check_create_roomid(ServerHost, RoomID) ->
+    Max = gen_mod:get_module_opt(ServerHost, ?MODULE, max_room_id,
+				 fun(infinity) -> infinity;
+				    (I) when is_integer(I), I>0 -> I
+				 end, infinity),
+    Regexp = gen_mod:get_module_opt(ServerHost, ?MODULE, room_id_regexp,
+				    fun iolist_to_binary/1, ""),
+    (byte_size(RoomID) =< Max) and
+    (re:run(RoomID, Regexp, [unicode, {capture, none}]) == match).
 
 get_rooms(ServerHost, Host) ->
     LServer = jlib:nameprep(ServerHost),
@@ -1334,6 +1340,8 @@ mod_opt_type(max_room_id) ->
     fun (infinity) -> infinity;
 	(I) when is_integer(I), I > 0 -> I
     end;
+mod_opt_type(room_id_regexp) ->
+    fun iolist_to_binary/1;
 mod_opt_type(max_room_name) ->
     fun (infinity) -> infinity;
 	(I) when is_integer(I), I > 0 -> I
@@ -1359,7 +1367,7 @@ mod_opt_type(user_presence_shaper) ->
 mod_opt_type(_) ->
     [access, access_admin, access_create, access_persistent,
      db_type, default_room_options, history_size, host,
-     max_room_desc, max_room_id, max_room_name,
+     max_room_desc, max_room_id, max_room_name, room_id_regexp,
      max_user_conferences, max_users,
      max_users_admin_threshold, max_users_presence,
      min_message_interval, min_presence_interval,


### PR DESCRIPTION
I want to restrict room id such as ascii only.
This patch allow room_id_regexp option for muc.
room_id_regexp: "^[a-z0-9]+$"