### PR TITLE
Remove empty and unused module

### DIFF
--- a/lib/ejabberd.ex
+++ b/lib/ejabberd.ex
@@ -1,2 +1,0 @@
-defmodule Ejabberd do
-end


### PR DESCRIPTION
Elixir modules with `.`s in the name are not nested, they're just module names with `.`s in them. As a result you don't need to define "parent" modules, unlike in languages such as Ruby.

Here I'm removing a module that is not needed.