### PR TITLE
change mod_ping Timers using maps instead of dict

### DIFF
--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -44,8 +44,6 @@
 
 -define(DEFAULT_PING_INTERVAL, 60).
 
--define(DICT, dict).
-
 %% API
 -export([start_link/2, start_ping/2, stop_ping/2]).
 
@@ -65,7 +63,7 @@
 	 ping_interval = ?DEFAULT_PING_INTERVAL :: non_neg_integer(),
 	 ping_ack_timeout = undefined :: non_neg_integer(),
 	 timeout_action = none :: none | kill,
-         timers = (?DICT):new() :: ?TDICT}).
+         timers = maps:new() :: map()}).
 
 %%====================================================================
 %% API
@@ -136,7 +134,7 @@ init([Host, Opts]) ->
 	    ping_interval = PingInterval,
 	    timeout_action = TimeoutAction,
 	    ping_ack_timeout = PingAckTimeout,
-	    timers = (?DICT):new()}}.
+	    timers = maps:new()}}.
 
 terminate(_Reason, #state{host = Host}) ->
     ejabberd_hooks:delete(sm_remove_connection_hook, Host,
@@ -228,20 +226,22 @@ user_send(Packet, _C2SState, JID, _From) ->
 %%====================================================================
 add_timer(JID, Interval, Timers) ->
     LJID = jid:tolower(JID),
-    NewTimers = case (?DICT):find(LJID, Timers) of
-		  {ok, OldTRef} ->
-		      cancel_timer(OldTRef), (?DICT):erase(LJID, Timers);
-		  _ -> Timers
+    NewTimers = case maps:find(LJID, Timers) of
+      {ok, OldTRef} ->
+		      cancel_timer(OldTRef),
+          maps:remove(LJID, Timers);
+      _ -> Timers
 		end,
     TRef = erlang:start_timer(Interval * 1000, self(),
 			      {ping, JID}),
-    (?DICT):store(LJID, TRef, NewTimers).
+    maps:put(LJID, TRef, NewTimers).
 
 del_timer(JID, Timers) ->
     LJID = jid:tolower(JID),
-    case (?DICT):find(LJID, Timers) of
+    case maps:find(LJID, Timers) of
       {ok, TRef} ->
-	  cancel_timer(TRef), (?DICT):erase(LJID, Timers);
+	  cancel_timer(TRef),
+    maps:remove(LJID, Timers);
       _ -> Timers
     end.
 


### PR DESCRIPTION
Since OTP 18 maps function more efficient than dict, change the mod_ping using dict instead.