### PR TITLE
EJAB-1480: fix issue with retreiving user roster

### DIFF
--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -145,7 +145,7 @@ get_user_roster(Items, {U, S} = US) ->
             %%case dict:find(US1, SRUsers1) of
                 {value, _, SRUsers2} -> {Item#roster{subscription = both, ask = none}, SRUsers2};
                 %%{ok, _GroupNames} -> {Item#roster{subscription = both, ask = none}, dict:erase(US1, SRUsers1)};
-                error -> {Item, SRUsers1}
+                false -> {Item, SRUsers1}
             end
         end,
         SRUsers, Items),


### PR DESCRIPTION
Hello. Please refer https://support.process-one.net/browse/EJAB-1480 for details. It fix issue with retrieving roster for every user.