### PR TITLE
Fixed type specifications for 'rebar doc'

### DIFF
--- a/src/ejabberd_auth_external.erl
+++ b/src/ejabberd_auth_external.erl
@@ -222,7 +222,7 @@ check_password_cache(User, Server, Password,
 get_password_internal(User, Server) ->
     ejabberd_auth_internal:get_password(User, Server).
 
-%% @spec (User, Server, CacheTime) -> false | Password::string()
+-spec get_password_cache(User::binary(), Server::binary(), CacheTime::integer()) -> Password::string() | false.
 get_password_cache(User, Server, CacheTime) ->
     case get_last_access(User, Server) of
       online -> get_password_internal(User, Server);
@@ -273,10 +273,10 @@ is_fresh_enough(TimeStampLast, CacheTime) ->
     Now = p1_time_compat:system_time(seconds),
     TimeStampLast + CacheTime > Now.
 
-%% @spec (User, Server) -> online | never | mod_last_required | TimeStamp::integer()
 %% Code copied from mod_configure.erl
 %% Code copied from web/ejabberd_web_admin.erl
 %% TODO: Update time format to XEP-0202: Entity Time
+-spec(get_last_access(User::binary(), Server::binary()) -> (online | never | mod_last_required | integer())).
 get_last_access(User, Server) ->
     case ejabberd_sm:get_user_resources(User, Server) of
       [] ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -112,7 +112,7 @@ get_env_config() ->
 %% @doc Read the ejabberd configuration file.
 %% It also includes additional configuration files and replaces macros.
 %% This function will crash if finds some error in the configuration file.
-%% @spec (File::string()) -> #state{}.
+%% @spec (File::string()) -> #state{}
 read_file(File) ->
     read_file(File, [{replace_macros, true},
                      {include_files, true},

--- a/src/ejabberd_logger.erl
+++ b/src/ejabberd_logger.erl
@@ -50,6 +50,7 @@
 %% "ejabberd.log" in current directory.
 %% Note: If the directory where to place the ejabberd log file to not exist,
 %% it is not created and no log file will be generated.
+%% @spec () -> string()
 get_log_path() ->
     case ejabberd_config:env_binary_to_list(ejabberd, log_path) of
 	{ok, Path} ->
@@ -99,6 +100,7 @@ get_string_env(Name, Default) ->
             Default
     end.
 
+%% @spec () -> ok
 start() ->
     application:load(sasl),
     application:set_env(sasl, sasl_error_logger, false),
@@ -126,10 +128,12 @@ start() ->
     ejabberd:start_app(lager),
     ok.
 
+%% @spec () -> ok
 reopen_log() ->
     %% Lager detects external log rotation automatically.
     ok.
 
+%% @spec () -> ok
 rotate_log() ->
     lager_crash_log ! rotate,
     lists:foreach(
@@ -139,6 +143,7 @@ rotate_log() ->
               ok
       end, gen_event:which_handlers(lager_event)).
 
+%% @spec () -> {loglevel(), atom(), string()}
 get() ->
     case lager:get_loglevel(lager_console_backend) of
         none -> {0, no_log, "No log"};
@@ -152,6 +157,7 @@ get() ->
         debug -> {5, debug, "Debug"}
     end.
 
+%% @spec (loglevel() | {loglevel(), list()}) -> {module, module()}
 set(LogLevel) when is_integer(LogLevel) ->
     LagerLogLevel = case LogLevel of
                         0 -> none;

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -1775,6 +1775,20 @@ update_auth(Host, Node, Type, Nidx, Subscriber, Allow, Subs) ->
 %%<li>nodetree create_node checks if nodeid already exists</li>
 %%<li>node plugin create_node just sets default affiliation/subscription</li>
 %%</ul>
+-spec(create_node/5 ::
+    (
+	Host          :: mod_pubsub:host(),
+	ServerHost    :: binary(),
+	Node        :: <<>> | mod_pubsub:nodeId(),
+	Owner         :: jid(),
+	Type          :: binary())
+    -> {result, [xmlel(),...]}
+    %%%
+    | {error, xmlel()}
+    ).
+create_node(Host, ServerHost, Node, Owner, Type) ->
+    create_node(Host, ServerHost, Node, Owner, Type, all, []).
+
 -spec(create_node/7 ::
     (
 	Host          :: mod_pubsub:host(),
@@ -1788,8 +1802,6 @@ update_auth(Host, Node, Type, Nidx, Subscriber, Allow, Subs) ->
     %%%
     | {error, xmlel()}
     ).
-create_node(Host, ServerHost, Node, Owner, Type) ->
-    create_node(Host, ServerHost, Node, Owner, Type, all, []).
 create_node(Host, ServerHost, <<>>, Owner, Type, Access, Configuration) ->
     case lists:member(<<"instant-nodes">>, plugin_features(Host, Type)) of
 	true ->


### PR DESCRIPTION
Hello, 
I wanted to generate the ejabberd EDoc documentation via `rebar doc`, but not the full documentation could be generated due to syntax errors in type specifications. 
I fixed this, the EDoc documentation should now build for all modules. Also, I removed a lot of old, deprecated documentation (which was confusingly all over the place) in `ejabberd_piefxis.erl`. It seemed that it survived the integration of the module into ejabberd core but didn't get updated since.

- Fixed type @specs and -specs to remove 'rebar doc' errors
- Removed a lot of wrong and deprecated documentation in ejabberd_piefxis.erl