### PR TITLE
Minimal auth_method ordering fix

### DIFF
--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -408,7 +408,7 @@ maps_to_lists(IMap) ->
               end, [], IMap).
 
 merge_configs(Terms, ResMap) ->
-    lists:foldl(fun({Name, Val}, Map) when is_list(Val) ->
+    lists:foldl(fun({Name, Val}, Map) when is_list(Val), Name =/= auth_method ->
                         Old = maps:get(Name, Map, #{}),
                         New = lists:foldl(fun(SVal, OMap) ->
                                                   NVal = if Name == host_config orelse Name == append_host_config ->


### PR DESCRIPTION
This is a minimal invasive patch to `ejabberd_config.erl` which fixes #886.
I tested parsing the authentication methods globally:
```
auth_method: [odbc, internal, anonymous]
```

As well as for one host:
```
host_config:
    "localhost":
        auth_method:
            - internal
            - anonymous
```
both ways now keep the order in which `auth_method` is supplied:
```
(ejabberd@localhost)1> ejabberd_config:get_option({auth_method,<<"localhost">>},fun(A) -> A end,[internal]).
[odbc,internal,anonymous]
```