### PR TITLE
Generalizing OAuth2 Implementation

### DIFF
--- a/src/cyrsasl_oauth.erl
+++ b/src/cyrsasl_oauth.erl
@@ -45,13 +45,21 @@ mech_new(Host, _GetPassword, _CheckPassword, _CheckPasswordDigest) ->
 mech_step(State, ClientIn) ->
     case prepare(ClientIn) of
         [AuthzId, User, Token] ->
-            case ejabberd_oauth:check_token(
-                   User, State#state.host, <<"sasl_auth">>, Token) of
-                true ->
-                    {ok,
-                     [{username, User}, {authzid, AuthzId},
-                      {auth_module, ejabberd_oauth}]};
-                false ->
+            case oauth2:verify_access_token(Token, {}) of
+                {ok, {_, GrantContext}} ->
+                    Scope = <<"sasl_auth">>,
+                    Host = State#state.host,
+                    ResourceOwner = proplists:get_value(<<"resource_owner">>, GrantContext, undefined),
+                    TokenScope = proplists:get_value(<<"scope">>, GrantContext, []),
+                    case {ResourceOwner, oauth2_priv_set:is_member(Scope, oauth2_priv_set:new(TokenScope))} of
+                        {{user, User, Host}, true} ->
+                            {ok, [{username, User},
+                                  {authzid, AuthzId},
+                                  {auth_module, ejabberd_oauth}]};
+                        _ ->
+                            {error, <<"not-authorized">>, User}
+                    end;
+                {error, _} ->
                     {error, <<"not-authorized">>, User}
             end;
         _ -> {error, <<"bad-protocol">>}

--- a/src/cyrsasl_oauth.erl
+++ b/src/cyrsasl_oauth.erl
@@ -47,7 +47,7 @@ mech_step(State, ClientIn) ->
         [AuthzId, User, Token] ->
             Host = State#state.host,
             Scope = <<"sasl_auth">>,
-            case ejabberd_auth:verify_access_token(Token, Scope, {user, User, Host}) of
+            case ejabberd_auth:check_access_token(Token, Scope, {user, User, Host}) of
                 {ok, User, Host} ->
                     {ok, [{username, User},
                           {authzid, AuthzId},

--- a/src/ejabberd_auth.erl
+++ b/src/ejabberd_auth.erl
@@ -34,7 +34,7 @@
 %% External exports
 -export([start/0, set_password/3, check_password/3,
 	 check_password/5, check_password_with_authmodule/3,
-	 check_password_with_authmodule/5, try_register/3,
+	 check_password_with_authmodule/5, check_access_token/3, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
 	 get_vh_registered_users/2, export/1, import/1,
 	 get_vh_registered_users_number/1, import/3,
@@ -66,6 +66,7 @@
 -callback check_password(binary(), binary(), binary()) -> boolean().
 -callback check_password(binary(), binary(), binary(), binary(),
                          fun((binary()) -> binary())) -> boolean().
+-callback check_access_token(binary(), binary(), {user, binary(), binary()} | undefined) -> {ok, {binary(), binary()}} | {error, atom()}.
 -callback try_register(binary(), binary(), binary()) -> {atomic, atom()} |
                                                         {error, atom()}.
 -callback dirty_get_registered_users() -> [{binary(), binary()}].
@@ -75,6 +76,8 @@
 -callback get_vh_registered_users_number(binary(), opts()) -> number().
 -callback get_password(binary(), binary()) -> false | binary() | {binary(), binary(), binary(), integer()}.
 -callback get_password_s(binary(), binary()) -> binary() | {binary(), binary(), binary(), integer()}.
+
+
 
 start() ->
     %% This is only executed by ejabberd_c2s for non-SASL auth client
@@ -410,6 +413,78 @@ entropy(B) ->
 			    end,
 			    [0, 0, 0, 0, 0], S),
 	  length(S) * math:log(lists:sum(Set)) / math:log(2)
+    end.
+
+%% @spec (Token, Scope, {user, User, Host} | undefined) -> {ok, User, Server} | {error, atom()}
+%% @doc Verifies the given oauth2 access token
+%% Returns the associated user and server if the access token is valid and the
+%% requested scope matches the scope in the grant context, if not, returns an error.
+%% If the user/host is also given, the verification failes, if the token has been
+%% associated to a different resource owner.
+-spec check_access_token(binary(), binary(), {user, binary(), binary()} | undefined) -> {ok, {binary(), binary()}} | {error, atom()}.
+
+check_access_token(Token, Scope, RequestedOwner) ->
+    %% First give the auth modules a chance to verify the access token
+    %% with their own implementation. If the token could not be verified,
+    %% use the internal behaviour.
+    Modules = case RequestedOwner of
+        {user, _, Host} ->
+            auth_modules(Host);
+        undefined ->
+            auth_modules()
+    end,
+    Response = lists:foldl(fun (_, {ok, _, _} = Res) -> Res;
+                               (M, Res) ->
+                                   case erlang:function_exported(M, verify_access_token, 3) of
+                                       true -> M:check_access_token(Token, Scope, RequestedOwner);
+                                       false -> Res
+                                   end
+                               end,
+                               {error, not_implemented}, Modules),
+    case Response of
+        {ok, User, Host2} ->
+            {ok, User, Host2};
+        {error, _} ->
+            internal_check_access_token(Token, Scope, RequestedOwner)
+    end.
+
+internal_check_access_token(Token, Scope, undefined) ->
+    case oauth2:verify_access_token(Token, undefined) of
+        {ok, {_, GrantContext}} ->
+            ResourceOwner = proplists:get_value(<<"resource_owner">>, GrantContext, undefined),
+            TokenScope = proplists:get_value(<<"scope">>, GrantContext, []),
+            case ResourceOwner of
+                {user, User, Host} ->
+                  case oauth2_priv_set:is_member(Scope, oauth2_priv_set:new(TokenScope)) of
+                    true ->
+                        {ok, User, Host};
+                    false ->
+                        {error, invalid_scope}
+                  end;
+                _ ->
+                  {error, resource_owner_mismatch}
+            end;
+        Error ->
+            Error
+    end;
+internal_check_access_token(Token, Scope, {user, User, Host}) ->
+    case oauth2:verify_access_token(Token, undefined) of
+        {ok, {_, GrantContext}} ->
+            ResourceOwner = proplists:get_value(<<"resource_owner">>, GrantContext, undefined),
+            TokenScope = proplists:get_value(<<"scope">>, GrantContext, []),
+            case ResourceOwner of
+                {user, User, Host} ->
+                  case oauth2_priv_set:is_member(Scope, oauth2_priv_set:new(TokenScope)) of
+                    true ->
+                        {ok, User, Host};
+                    false ->
+                        {error, invalid_scope}
+                  end;
+                _ ->
+                  {error, resource_owner_mismatch}
+            end;
+        Error ->
+            Error
     end.
 
 %%%----------------------------------------------------------------------

--- a/src/ejabberd_auth.erl
+++ b/src/ejabberd_auth.erl
@@ -435,7 +435,7 @@ check_access_token(Token, Scope, RequestedOwner) ->
     end,
     Response = lists:foldl(fun (_, {ok, _, _} = Res) -> Res;
                                (M, Res) ->
-                                   case erlang:function_exported(M, verify_access_token, 3) of
+                                   case erlang:function_exported(M, check_access_token, 3) of
                                        true -> M:check_access_token(Token, Scope, RequestedOwner);
                                        false -> Res
                                    end

--- a/src/ejabberd_auth_anonymous.erl
+++ b/src/ejabberd_auth_anonymous.erl
@@ -39,7 +39,7 @@
 	]).
 
 -export([login/2, set_password/3, check_password/3,
-	 check_password/5, try_register/3,
+	 check_password/5, check_access_token/3, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
 	 get_vh_registered_users/2,
 	 get_vh_registered_users_number/1,
@@ -191,6 +191,9 @@ check_password(User, Server, _Password, _Digest,
       maybe -> false;
       false -> login(User, Server)
     end.
+
+check_access_token(_Token, _Scope, _RequestedOwner) ->
+    {error, not_implemented}.
 
 login(User, Server) ->
     case is_login_anonymous_enabled(Server) of

--- a/src/ejabberd_auth_external.erl
+++ b/src/ejabberd_auth_external.erl
@@ -32,7 +32,7 @@
 -behaviour(ejabberd_auth).
 
 -export([start/1, set_password/3, check_password/3,
-	 check_password/5, try_register/3,
+	 check_password/5, check_access_token/3, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
 	 get_vh_registered_users/2,
 	 get_vh_registered_users_number/1,
@@ -86,6 +86,8 @@ check_password(User, Server, Password) ->
 check_password(User, Server, Password, _Digest,
 	       _DigestGen) ->
     check_password(User, Server, Password).
+
+check_access_token(_Token, _Scope, _RequestedOwner) -> {error, not_implemented}.
 
 set_password(User, Server, Password) ->
     case extauth:set_password(User, Server, Password) of

--- a/src/ejabberd_auth_internal.erl
+++ b/src/ejabberd_auth_internal.erl
@@ -32,7 +32,7 @@
 -behaviour(ejabberd_auth).
 
 -export([start/1, set_password/3, check_password/3,
-	 check_password/5, try_register/3,
+	 check_password/5, check_access_token/3, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
 	 get_vh_registered_users/2,
 	 get_vh_registered_users_number/1,
@@ -126,6 +126,8 @@ check_password(User, Server, Password, Digest,
 	  end;
       _ -> false
     end.
+
+check_access_token(_Token, _Scope, _RequestedOwner) -> {error, not_implemented}.
 
 %% @spec (User::string(), Server::string(), Password::string()) ->
 %%       ok | {error, invalid_jid}

--- a/src/ejabberd_auth_ldap.erl
+++ b/src/ejabberd_auth_ldap.erl
@@ -37,8 +37,8 @@
 	 handle_cast/2, terminate/2, code_change/3]).
 
 -export([start/1, stop/1, start_link/1, set_password/3,
-	 check_password/3, check_password/5, try_register/3,
-	 dirty_get_registered_users/0, get_vh_registered_users/1,
+	 check_password/3, check_password/5, check_access_token/3,
+     try_register/3, dirty_get_registered_users/0, get_vh_registered_users/1,
 	 get_vh_registered_users/2,
 	 get_vh_registered_users_number/1,
 	 get_vh_registered_users_number/2, get_password/2,
@@ -129,6 +129,8 @@ check_password(User, Server, Password) ->
 check_password(User, Server, Password, _Digest,
 	       _DigestGen) ->
     check_password(User, Server, Password).
+
+check_access_token(_Token, _Scope, _RequestedOwner) -> {error, not_implemented}.
 
 set_password(User, Server, Password) ->
     {ok, State} = eldap_utils:get_state(Server, ?MODULE),

--- a/src/ejabberd_auth_odbc.erl
+++ b/src/ejabberd_auth_odbc.erl
@@ -32,7 +32,7 @@
 -behaviour(ejabberd_auth).
 
 -export([start/1, set_password/3, check_password/3,
-	 check_password/5, try_register/3,
+	 check_password/5, check_access_token/3, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
 	 get_vh_registered_users/2,
 	 get_vh_registered_users_number/1,
@@ -142,6 +142,8 @@ check_password(User, Server, Password, Digest,
                     false
             end
     end.
+    
+check_access_token(_Token, _Scope, _RequestedOwner) -> {error, not_implemented}.
 
 %% @spec (User::string(), Server::string(), Password::string()) ->
 %%       ok | {error, invalid_jid}

--- a/src/ejabberd_auth_pam.erl
+++ b/src/ejabberd_auth_pam.erl
@@ -31,7 +31,7 @@
 -behaviour(ejabberd_auth).
 
 -export([start/1, set_password/3, check_password/3,
-	 check_password/5, try_register/3,
+	 check_password/5, check_access_token/3, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
 	 get_vh_registered_users/2,
 	 get_vh_registered_users_number/1,
@@ -62,6 +62,8 @@ check_password(User, Host, Password) ->
       true -> true;
       _ -> false
     end.
+
+check_access_token(_Token, _Scope, _RequestedOwner) -> {error, not_implemented}.
 
 try_register(_User, _Server, _Password) ->
     {error, not_allowed}.

--- a/src/ejabberd_auth_riak.erl
+++ b/src/ejabberd_auth_riak.erl
@@ -31,7 +31,7 @@
 
 %% External exports
 -export([start/1, set_password/3, check_password/3,
-	 check_password/5, try_register/3,
+	 check_password/5, check_access_token/3, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
 	 get_vh_registered_users/2,
 	 get_vh_registered_users_number/1,
@@ -103,6 +103,8 @@ check_password(User, Server, Password, Digest,
 	  end;
       _ -> false
     end.
+    
+check_access_token(_Token, _Scope, _RequestedOwner) -> {error, not_implemented}.
 
 set_password(User, Server, Password) ->
     LUser = jid:nodeprep(User),

--- a/src/ejabberd_commands.erl
+++ b/src/ejabberd_commands.erl
@@ -509,7 +509,7 @@ check_auth(_Command, noauth) ->
     no_auth_provided;
 check_auth(Command, {User, Server, {oauth, Token}, _}) ->
     Scope = erlang:atom_to_binary(Command#ejabberd_commands.name, utf8),
-    case ejabberd_auth:verify_access_token(Token, Scope, {user, User, Server}) of
+    case ejabberd_auth:check_access_token(Token, Scope, {user, User, Server}) of
         {error, _} ->
             throw({error, invalid_account_data});
         ResourceOwner ->

--- a/src/ejabberd_oauth.erl
+++ b/src/ejabberd_oauth.erl
@@ -220,7 +220,9 @@ authenticate_user({{user, User, Server}, {password, Password}}, Ctx) ->
             end;
         error ->
             {error, badpass}
-    end.
+    end;
+authenticate_user(_, _) ->
+    {error, notfound}.
 
 authenticate_client(Client, Ctx) ->
     {ok, {Ctx, {client, Client}}}.

--- a/src/ejabberd_oauth.erl
+++ b/src/ejabberd_oauth.erl
@@ -30,20 +30,31 @@
 
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2,
-	 handle_info/2, terminate/2, code_change/3]).
+     handle_info/2, terminate/2, code_change/3]).
 
 -export([start/0,
          start_link/0,
-         get_client_identity/2,
-         verify_redirection_uri/3,
-         authenticate_user/2,
+         process/2,
+         opt_type/1]).
+
+%%% OAuth2 backend functionality
+-export([authenticate_user/2,
          authenticate_client/2,
-         verify_resowner_scope/3,
          associate_access_code/3,
          associate_access_token/3,
          associate_refresh_token/3,
-         process/2,
-         opt_type/1]).
+         resolve_access_code/2,
+         resolve_access_token/2,
+         resolve_refresh_token/2,
+         revoke_access_code/2,
+         revoke_access_token/2,
+         revoke_refresh_token/2,
+         get_client_identity/2,
+         verify_redirection_uri/3,
+         verify_client_scope/3,
+         verify_resowner_scope/3,
+         verify_scope/3
+        ]).
 
 -include("jlib.hrl").
 
@@ -53,12 +64,23 @@
 -include("ejabberd_http.hrl").
 -include("ejabberd_web_admin.hrl").
 
--record(oauth_token, {
-          token = {<<"">>, <<"">>} :: {binary(), binary()},
-          us = {<<"">>, <<"">>}    :: {binary(), binary()},
-          scope = []               :: [binary()],
-          expire                   :: integer()
+-record(oauth_access_code, {
+          code,
+          grant_context,
+          expiry_time
+        }).
+
+-record(oauth_access_token, {
+          token,
+          grant_context,
+          expiry_time
          }).
+
+-record(oauth_refresh_token, {
+          token,
+          grant_context,
+          expiry_time
+        }).
 
 -define(EXPIRE, 3600).
 
@@ -69,7 +91,7 @@ start() ->
     application:set_env(oauth2, expiry_time, Expire),
     application:start(oauth2),
     ChildSpec = {?MODULE, {?MODULE, start_link, []},
-		 temporary, 1000, worker, [?MODULE]},
+         temporary, 1000, worker, [?MODULE]},
     supervisor:start_child(ejabberd_sup, ChildSpec),
     ok.
 
@@ -87,18 +109,11 @@ handle_call(_Request, _From, State) ->
 handle_cast(_Msg, State) -> {noreply, State}.
 
 handle_info(clean, State) ->
-    {MegaSecs, Secs, MiniSecs} = os:timestamp(),
-    TS = 1000000 * MegaSecs + Secs,
-    F = fun() ->
-		Ts = mnesia:select(
-		       oauth_token,
-		       [{#oauth_token{expire = '$1', _ = '_'},
-			 [{'<', '$1', TS}],
-			 ['$_']}]),
-		lists:foreach(fun mnesia:delete_object/1, Ts)
-        end,
-    mnesia:async_dirty(F),
-    erlang:send_after(trunc(expire() * 1000 * (1 + MiniSecs / 1000000)),
+    error_logger:debug_msg("Cleaning up expired oauth tokens and codes"),
+    clean(oauth_access_code),
+    clean(oauth_access_token),
+    clean(oauth_refresh_token),
+    erlang:send_after(trunc(expire() * 1000 * (1 / 1000000)),
                       self(), clean),
     {noreply, State};
 handle_info(_Info, State) -> {noreply, State}.
@@ -107,22 +122,84 @@ terminate(_Reason, _State) -> ok.
 
 code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
+expire() ->
+    ejabberd_config:get_option(
+        oauth_expire,
+        fun(I) when is_integer(I) -> I end,
+        ?EXPIRE).
+
+clean(oauth_access_code) ->
+    {MegaSecs, Secs, _} = os:timestamp(),
+    TS = 1000000 * MegaSecs + Secs,
+    F = fun() ->
+        Ts = mnesia:select(
+               oauth_access_code,
+               [{#oauth_access_code{expiry_time = '$1', _ = '_'},
+             [{'<', '$1', TS}],
+             ['$_']}]),
+        lists:foreach(fun mnesia:delete_object/1, Ts)
+        end,
+    mnesia:async_dirty(F);
+clean(oauth_access_token) ->
+    {MegaSecs, Secs, _} = os:timestamp(),
+    TS = 1000000 * MegaSecs + Secs,
+    F = fun() ->
+        Ts = mnesia:select(
+               oauth_access_code,
+               [{#oauth_access_code{expiry_time = '$1', _ = '_'},
+             [{'<', '$1', TS}],
+             ['$_']}]),
+        lists:foreach(fun mnesia:delete_object/1, Ts)
+        end,
+    mnesia:async_dirty(F);
+clean(oauth_refresh_token) ->
+    {MegaSecs, Secs, _} = os:timestamp(),
+    TS = 1000000 * MegaSecs + Secs,
+    F = fun() ->
+        Ts = mnesia:select(
+               oauth_refresh_token,
+               [{#oauth_refresh_token{expiry_time = '$1', _ = '_'},
+             [{'<', '$1', TS}],
+             ['$_']}]),
+        lists:foreach(fun mnesia:delete_object/1, Ts)
+        end,
+    mnesia:async_dirty(F).
 
 init_db(mnesia, _Host) ->
-    mnesia:create_table(oauth_token,
+    
+    %% Delete any leftover table using the previous record name (oauth_token).
+    %% It is not necessary to migrate the content, because the users can
+    %% easily create a new token.
+    mnesia:delete_table(oauth_token),
+    
+    %% Setting up the tables for the access code, access token and refresh token.
+    %% The table have a simple very simple structure consisting of the token
+    %% (or code) as the key, the grant context and the expiry time (for cleanup).
+    mnesia:create_table(oauth_access_code,
                         [{disc_copies, [node()]},
-                         {attributes,
-                          record_info(fields, oauth_token)}]),
-    mnesia:add_table_copy(oauth_token, node(), disc_copies);
+                         {attributes, record_info(fields, oauth_access_code)},
+                         {index, [expire]}]),
+    mnesia:add_table_copy(oauth_access_code, node(), disc_copies),
+    
+    mnesia:create_table(oauth_access_token,
+                        [{disc_copies, [node()]},
+                         {attributes, record_info(fields, oauth_access_token)},
+                         {index, [expire]}]),
+    mnesia:add_table_copy(oauth_access_token, node(), disc_copies),
+    
+    mnesia:create_table(oauth_refresh_token,
+                        [{disc_copies, [node()]},
+                         {attributes, record_info(fields, oauth_refresh_token)},
+                         {index, [expire]}]),
+    mnesia:add_table_copy(oauth_refresh_token, node(), disc_copies);
 init_db(_, _) ->
     ok.
 
+%% --------------------------------------------------------
+%% oauth2 backend API
+%% --------------------------------------------------------
 
-get_client_identity(Client, Ctx) -> {ok, {Ctx, {client, Client}}}.
-
-verify_redirection_uri(_, _, Ctx) -> {ok, Ctx}.
-
-authenticate_user({User, Server}, {password, Password} = Ctx) ->
+authenticate_user({{user, User, Server}, {password, Password}}, Ctx) ->
     case jid:make(User, Server, <<"">>) of
         #jid{} = JID ->
             Access =
@@ -145,7 +222,83 @@ authenticate_user({User, Server}, {password, Password} = Ctx) ->
             {error, badpass}
     end.
 
-authenticate_client(Client, Ctx) -> {ok, {Ctx, {client, Client}}}.
+authenticate_client(Client, Ctx) ->
+    {ok, {Ctx, {client, Client}}}.
+
+associate_access_code(AccessCode, Context, AppContext) ->
+    Expire = proplists:get_value(<<"expiry_time">>, Context, 0),
+    R = #oauth_access_code{
+        code = AccessCode,
+        grant_context = Context,
+        expiry_time = Expire
+    },
+    mnesia:dirty_write(R),
+    {ok, AppContext}.
+
+associate_access_token(AccessToken, Context, AppContext) ->
+    Expire = proplists:get_value(<<"expiry_time">>, Context, 0),
+    R = #oauth_access_token{
+      token = AccessToken,
+      grant_context = Context,
+      expiry_time = Expire
+     },
+    mnesia:dirty_write(R),
+    {ok, AppContext}.
+
+associate_refresh_token(RefreshToken, Context, AppContext) ->
+    Expire = proplists:get_value(<<"expiry_time">>, Context, 0),
+    R = #oauth_refresh_token{
+        token = RefreshToken,
+        grant_context = Context,
+        expiry_time = Expire
+    },
+    mnesia:dirty_write(R),
+    {ok, AppContext}.
+
+resolve_access_code(Code, AppContext) ->
+    case mnesia:dirty_read({oauth_access_code, Code}) of
+        [] ->
+            {error, notfound};
+        [#oauth_access_code{grant_context = Context}|_] ->
+            {ok, {AppContext, Context}}
+    end.
+
+resolve_access_token(Token, AppContext) ->
+    case mnesia:dirty_read({oauth_access_token, Token}) of
+        [] ->
+            {error, notfound};
+        [#oauth_access_token{grant_context = Context}|_] ->
+            {ok, {AppContext, Context}}
+    end.
+
+resolve_refresh_token(Token, AppContext) ->
+    case mnesia:dirty_read({oauth_refresh_token, Token}) of
+        [] ->
+            {error, notfound};
+        [#oauth_refresh_token{grant_context = Context}|_] ->
+            {ok, {AppContext, Context}}
+    end.
+
+revoke_access_code(Code, AppContext) ->
+    mnesia:dirty_delete(oauth_access_code, Code),
+    {ok, AppContext}.
+
+revoke_access_token(Token, AppContext) ->
+    mnesia:dirty_delete(oauth_access_token, Token),
+    {ok, AppContext}.
+
+revoke_refresh_token(Token, AppContext) ->
+    mnesia:dirty_delete(oauth_refresh_token, Token),
+    {ok, AppContext}.
+
+get_client_identity(Client, Ctx) ->
+    {ok, {Ctx, {client, Client}}}.
+
+verify_redirection_uri(_, _, Ctx) ->
+    {ok, Ctx}.
+
+verify_client_scope(_Client, Scope, AppContext) ->
+    {ok, {AppContext, Scope}}.
 
 verify_resowner_scope({user, _User, _Server}, Scope, Ctx) ->
     Cmds = ejabberd_commands:get_commands(),
@@ -161,49 +314,31 @@ verify_resowner_scope({user, _User, _Server}, Scope, Ctx) ->
 verify_resowner_scope(_, _, _) ->
     {error, badscope}.
 
+verify_scope(RegisteredScope, Scope, AppContext) ->
+    case oauth2_priv_set:is_subset(oauth2_priv_set:new(Scope), 
+                                   oauth2_priv_set:new(RegisteredScope)) of
+        true ->
+            {ok, {AppContext, Scope}};
+        false ->
+            {error, badscope}
+    end.
 
-associate_access_code(_AccessCode, _Context, AppContext) ->
-    %put(?ACCESS_CODE_TABLE, AccessCode, Context),
-    {ok, AppContext}.
-
-associate_access_token(AccessToken, Context, AppContext) ->
-    {user, User, Server} =
-        proplists:get_value(<<"resource_owner">>, Context, <<"">>),
-    Scope = proplists:get_value(<<"scope">>, Context, []),
-    Expire = proplists:get_value(<<"expiry_time">>, Context, 0),
-    LUser = jid:nodeprep(User),
-    LServer = jid:nameprep(Server),
-    R = #oauth_token{
-      token = AccessToken,
-      us = {LUser, LServer},
-      scope = Scope,
-      expire = Expire
-     },
-    mnesia:dirty_write(R),
-    {ok, AppContext}.
-
-associate_refresh_token(_RefreshToken, _Context, AppContext) ->
-    %put(?REFRESH_TOKEN_TABLE, RefreshToken, Context),
-    {ok, AppContext}.
-
-expire() ->
-    ejabberd_config:get_option(
-      oauth_expire,
-      fun(I) when is_integer(I) -> I end,
-      ?EXPIRE).
+%% --------------------------------------------------------
+%% Web API
+%% --------------------------------------------------------
 
 -define(DIV(Class, Els),
-	?XAE(<<"div">>, [{<<"class">>, Class}], Els)).
+    ?XAE(<<"div">>, [{<<"class">>, Class}], Els)).
 -define(INPUTID(Type, Name, Value),
-	?XA(<<"input">>,
-	    [{<<"type">>, Type}, {<<"name">>, Name},
-	     {<<"value">>, Value}, {<<"id">>, Name}])).
+    ?XA(<<"input">>,
+        [{<<"type">>, Type}, {<<"name">>, Name},
+         {<<"value">>, Value}, {<<"id">>, Name}])).
 -define(LABEL(ID, Els),
-	?XAE(<<"label">>, [{<<"for">>, ID}], Els)).
+    ?XAE(<<"label">>, [{<<"for">>, ID}], Els)).
 
 process(_Handlers,
-	#request{method = 'GET', q = Q, lang = Lang,
-		 path = [_, <<"authorization_token">>]}) ->
+    #request{method = 'GET', q = Q, lang = Lang,
+         path = [_, <<"authorization_token">>]}) ->
     ResponseType = proplists:get_value(<<"response_type">>, Q, <<"">>),
     ClientId = proplists:get_value(<<"client_id">>, Q, <<"">>),
     RedirectURI = proplists:get_value(<<"redirect_uri">>, Q, <<"">>),
@@ -264,8 +399,8 @@ process(_Handlers,
     Body = ?DIV(<<"container">>, [Top, Middle, Bottom]),
     ejabberd_web:make_xhtml(web_head(), [Body]);
 process(_Handlers,
-	#request{method = 'POST', q = Q, lang = _Lang,
-		 path = [_, <<"authorization_token">>]}) ->
+    #request{method = 'POST', q = Q, lang = _Lang,
+         path = [_, <<"authorization_token">>]}) ->
     _ResponseType = proplists:get_value(<<"response_type">>, Q, <<"">>),
     ClientId = proplists:get_value(<<"client_id">>, Q, <<"">>),
     RedirectURI = proplists:get_value(<<"redirect_uri">>, Q, <<"">>),
@@ -275,11 +410,11 @@ process(_Handlers,
     Password = proplists:get_value(<<"password">>, Q, <<"">>),
     State = proplists:get_value(<<"state">>, Q, <<"">>),
     Scope = str:tokens(SScope, <<" ">>),
-    case oauth2:authorize_password({Username, Server},
+    case oauth2:authorize_password({{user, Username, Server}, {password, Password}},
                                    ClientId,
                                    RedirectURI,
                                    Scope,
-                                   {password, Password}) of
+                                   context) of
         {ok, {_AppContext, Authorization}} ->
             {ok, {_AppContext2, Response}} =
                 oauth2:issue_token(Authorization, none),

--- a/src/mod_http_api.erl
+++ b/src/mod_http_api.erl
@@ -124,19 +124,10 @@ check_permissions(#request{auth = HTTPAuth, headers = Headers}, Command)
                                 false
                         end;
                     {oauth, Token, _} ->
-                        case oauth2:verify_access_token(Token, {}) of
-                            {ok, {_, GrantContext}} ->
-                                Scope = Command,
-                                ResourceOwner = proplists:get_value(<<"resource_owner">>, GrantContext, undefined),
-                                TokenScope = proplists:get_value(<<"scope">>, GrantContext, []),
-                                case {ResourceOwner, oauth2_priv_set:is_member(Scope, oauth2_priv_set:new(TokenScope))} of
-                                    {{user, User, Server}, true} ->
-                                        {ok, {User, Server, {oauth, Token}, Admin}};
-                                    _ ->
-                                        false
-                                end;
-                            {error, _} ->
-                                false
+                        case ejabberd_auth:verify_access_token(Token, Command, undefined) of
+                            {ok, User, Server} ->
+                                {ok, {User, Server, {oauth, Token}, Admin}};
+                            _ -> false
                         end;
                     _ ->
                         false

--- a/src/mod_http_api.erl
+++ b/src/mod_http_api.erl
@@ -124,7 +124,7 @@ check_permissions(#request{auth = HTTPAuth, headers = Headers}, Command)
                                 false
                         end;
                     {oauth, Token, _} ->
-                        case ejabberd_auth:verify_access_token(Token, Command, undefined) of
+                        case ejabberd_auth:check_access_token(Token, Command, undefined) of
                             {ok, User, Server} ->
                                 {ok, {User, Server, {oauth, Token}, Admin}};
                             _ -> false


### PR DESCRIPTION
This generalizes the ejabberd backend for oauth2 (ejabberd_oauth) and removes the dependency to the underlying implementation of the backend from other modules.
- The current implementation of the oauth2 backend does not provide the full feature set. This update adds the missing methods (in ejabberd_oauth).
  - Access codes and refresh tokens are also stored in mnesia.
  - Codes and Tokens can be revoked.
  - Codes and tokens can be looked up.
- Add a function to ejabberd_auth to verify an access token instead of accessing the used oauth2 backend directly (currently `ejabberd_oauth:check_token`).
  
  ```
  check_access_token(binary(), binary(), {user, binary(), binary()} | undefined)
  -> {ok, {binary(), binary()}} | {error, atom()}. 
  ```
  
  This function will resolve the access token and verifies the scope and the resources owner. If the scope matches the scope in the grant context of the token and the given resource owner is either _undefined_ or the resource owner of the access token, the function will return the user and host.
- Custom auth modules can implement `check_access_token/3` and use their own implementation. If those modules couldn't verify the token, a default is used.

Unfortunately I was not able to setup the test environment and write a test for this change. Therefore I tested it _by hand_ by starting ejabberd, adding a user and using the web api to request a token.

If these changes are accepted, I would also separate in the backend part from web api part in ejabberd_oauth to allow using another backend.
