### PR TITLE
Use uuid for ejabberdctl

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -387,7 +387,7 @@ ctl()
         # concurrent invocations using a bound
         # number of atoms
         for N in `seq 1 $MAXCONNID`; do
-            CTL_CONN="ejabberdctl-$N"
+            CTL_CONN="ejabberdctl-$N-${ERLANG_NODE}"
             CTL_LOCKFILE="$CONNLOCKDIR/$CTL_CONN"
             (
                 exec 8>"$CTL_LOCKFILE"

--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -366,7 +366,12 @@ ctl()
     MAXCONNID=100
     CONNLOCKDIR={{localstatedir}}/lock/ejabberdctl
     FLOCK=/usr/bin/flock
-    if [ ! -x "$FLOCK" ] || [ ! -d "$CONNLOCKDIR" ] ; then
+    if [ -f /proc/sys/kernel/random/uuid ]; then
+        UUID=`cat /proc/sys/kernel/random/uuid`
+        CTL_CONN="${UUID}-${ERLANG_NODE}"
+        ctlexec $CTL_CONN "$@"
+        result=$?
+    elif [ ! -x "$FLOCK" ] || [ ! -d "$CONNLOCKDIR" ] ; then
         JOT=/usr/bin/jot
         if [ ! -x "$JOT" ] ; then
             # no flock or jot, simply invoke ctlexec()


### PR DESCRIPTION
This code work only linux but, 
There are several advantages: no concurrecy number limitation, no need flock, no need jot.
Also Free BSD has /compat/linux/proc/sys/kernel/random/uuid
