### PR TITLE
fix broken check_password

### DIFF
--- a/src/ejabberd_auth.erl
+++ b/src/ejabberd_auth.erl
@@ -32,7 +32,7 @@
 -author('alexey@process-one.net').
 
 %% External exports
--export([start/0, set_password/3, check_password/4,
+-export([start/0, set_password/3, check_password/3, check_password/4,
 	 check_password/6, check_password_with_authmodule/4,
 	 check_password_with_authmodule/6, try_register/3,
 	 dirty_get_registered_users/0, get_vh_registered_users/1,
@@ -101,6 +101,12 @@ store_type(Server) ->
 		    (M, plain) -> M:store_type()
 		end,
 		plain, auth_modules(Server)).
+
+
+-spec check_password(binary(), binary(), binary()) -> boolean().
+
+check_password(User, Server, Password) ->
+    check_password(User, <<>>, Server, Password).
 
 -spec check_password(binary(), binary(), binary(), binary()) -> boolean().
 

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -31,7 +31,7 @@
 -include("logger.hrl").
 
 -export([start/2, stop/1, compile/1, get_cookie/0,
-	 remove_node/1, set_password/3, check_password/3,
+	 remove_node/1, set_password/3,
 	 check_password_hash/4, delete_old_users/1,
 	 delete_old_users_vhost/2, ban_account/3,
 	 num_active_users/2, num_resources/2, resource_num/3,
@@ -162,7 +162,7 @@ get_commands_spec() ->
 			result_desc = "Status code: 0 on success, 1 otherwise"},
      #ejabberd_commands{name = check_password, tags = [accounts],
 			desc = "Check if a password is correct",
-			module = ?MODULE, function = check_password,
+			module = ejabberd_auth, function = check_password,
 			args = [{user, binary}, {host, binary}, {password, binary}],
 			args_example = [<<"peter">>, <<"myserver.com">>, <<"secret">>],
 			args_desc = ["User name to check", "Server to check", "Password to check"],
@@ -592,9 +592,6 @@ remove_node(Node) ->
 set_password(User, Host, Password) ->
     Fun = fun () -> ejabberd_auth:set_password(User, Host, Password) end,
     user_action(User, Host, Fun, ok).
-
-check_password(User, Host, Password) ->
-    ejabberd_auth:check_password(User, <<>>, Host, Password).
 
 %% Copied some code from ejabberd_commands.erl
 check_password_hash(User, Host, PasswordHash, HashMethod) ->


### PR DESCRIPTION
check_password when used from ejabberdctl/xmlrpc/rest etc is broken since 917d48f30bca65f984c4e1305eefe7266097ff65 was merged. This fixes it by adding ejabberd_auth:check_password/3 for backwards compatibility 