### PR TITLE
specify su shell

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -27,7 +27,7 @@ if [ "$INSTALLUSER" != "" ] ; then
                 mkdir -p "$INSTALLUSER_HOME"
                 chown "$INSTALLUSER" "$INSTALLUSER_HOME"
             fi
-            EXEC_CMD="su $INSTALLUSER -c"
+            EXEC_CMD="su $INSTALLUSER --shell=/bin/bash -c"
         fi
     done
     if [ `id -g` -eq `id -g $INSTALLUSER` ] ; then


### PR DESCRIPTION
This script written in bash.
So it will fail depends login shell of INSTALLUSER.
Also we'll  get following error when setting /usr/sbin/nologin for login shell:
~~~
# ejabberdctl
This account is currently not available.
~~~