### PR TITLE
Return error when blocking message to offline user

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -601,15 +601,12 @@ route_message(From, To, Packet, Type) ->
 	  case Type of
 	    headline -> ok;
 	    _ ->
-		case ejabberd_auth:is_user_exists(LUser, LServer) of
+		case ejabberd_auth:is_user_exists(LUser, LServer) andalso
+		    is_privacy_allow(From, To, Packet) of
 		  true ->
-		      case is_privacy_allow(From, To, Packet) of
-			true ->
-			    ejabberd_hooks:run(offline_message_hook, LServer,
-					       [From, To, Packet]);
-			false -> ok
-		      end;
-		  _ ->
+		      ejabberd_hooks:run(offline_message_hook, LServer,
+					 [From, To, Packet]);
+		  false ->
 		      Err = jlib:make_error_reply(Packet,
 						  ?ERR_SERVICE_UNAVAILABLE),
 		      ejabberd_router:route(To, From, Err)


### PR DESCRIPTION
As per XEP-0016 and XEP-0191, return a service-unavailable error when an incoming message sent to an offline user was blocked by a privacy list.  The same is done for a message sent to an online user, so this avoids a presence leak.