### PR TITLE
Return error when blocking last activity request

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -1563,6 +1563,12 @@ handle_info({route, From, To,
 							 {true, Attrs,
 							  StateData};
 						     deny ->
+							 Err =
+							     jlib:make_error_reply(Packet,
+										   ?ERR_SERVICE_UNAVAILABLE),
+							 ejabberd_router:route(To,
+									       From,
+									       Err),
 							 {false, Attrs,
 							  StateData}
 						   end;


### PR DESCRIPTION
Return a generic service-unavailable error whenever an IQ-get or IQ-set is rejected (as per [RFC 6121][1], [XEP-0016][2], and [XEP-0191][3]).

[1]: https://tools.ietf.org/html/rfc6121#section-8.5.3.2.3
[2]: http://xmpp.org/extensions/xep-0016.html#protocol-error
[3]: http://xmpp.org/extensions/xep-0191.html#block