### PR TITLE
Handle messages of unknown type like messages of type "normal"

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -518,16 +518,16 @@ do_route(From, To, #xmlel{} = Packet) ->
 		  <<"message">> ->
 		      case fxml:get_attr_s(<<"type">>, Attrs) of
 			<<"chat">> -> route_message(From, To, Packet, chat);
-			<<"normal">> -> route_message(From, To, Packet, normal);
-			<<"">> -> route_message(From, To, Packet, normal);
 			<<"headline">> -> ok;
 			<<"error">> -> ok;
-			_ ->
+			<<"groupchat">> ->
 			    ErrTxt = <<"User session not found">>,
 			    Err = jlib:make_error_reply(
 				    Packet,
 				    ?ERRT_SERVICE_UNAVAILABLE(Lang, ErrTxt)),
-			    ejabberd_router:route(To, From, Err)
+			    ejabberd_router:route(To, From, Err);
+			_ ->
+			    route_message(From, To, Packet, normal)
 		      end;
 		  <<"iq">> ->
 		      case fxml:get_attr_s(<<"type">>, Attrs) of


### PR DESCRIPTION
If an incoming message sent to an unavailable resource has an unknown type, handle it like messages of type `normal` (as mandated by [RFC 6121, section 5.2.2][1]).  The same [is already done][2] for messages of unknown type sent to the bare JID of an offline user.

[1]: https://tools.ietf.org/html/rfc6121#section-5.2.2
[2]: https://github.com/processone/ejabberd/blob/65ad70d7dc577b107d889923c2d19d5aac82ffb6/src/ejabberd_sm.erl#L497