### PR TITLE
Notify on MUC affiliation changes of non-occupants

### DIFF
--- a/test/ejabberd_SUITE.erl
+++ b/test/ejabberd_SUITE.erl
@@ -1435,6 +1435,11 @@ muc_master(Config) ->
 			    items = [#muc_item{affiliation = member,
 					       jid = PeerJID,
 					       role = participant}]}]}),
+    ?recv1(#message{from = Room,
+	      sub_els = [#muc_user{
+			    items = [#muc_item{affiliation = member,
+					       jid = Localhost,
+					       role = none}]}]}),
     %% BUG: We should not receive any sub_els!
     ?recv1(#iq{type = result, id = I1, sub_els = [_|_]}),
     %% Receive groupchat message from the peer


### PR DESCRIPTION
Notify the current room occupants if the affiliation of a non-occupant is changed.  In anonymous rooms, only moderators are notified, though.

This follows [example 195][1] of XEP-0045.  The example only mentions the case where the `admin` status is revoked, but such notifications might be just as useful for changes to the `owner` or `member` list (e.g., when implementing presence-less group chat).

[1]: http://xmpp.org/extensions/xep-0045.html#revokeadmin
