### PR TITLE
Add support for PubSub publishing options

### DIFF
--- a/include/pubsub.hrl
+++ b/include/pubsub.hrl
@@ -93,7 +93,12 @@
 
 -type(subOptions() :: [mod_pubsub:subOption(),...]).
 
+-type(pubOption() ::
+    {Option::binary(),
+     Values::[binary()]
+}).
 
+-type(pubOptions() :: [mod_pubsub:pubOption()]).
 
 -type(affiliation() :: 'none'
                      | 'owner'

--- a/src/gen_pubsub_node.erl
+++ b/src/gen_pubsub_node.erl
@@ -35,6 +35,7 @@
 -type(pubsubState() :: mod_pubsub:pubsubState()).
 -type(pubsubItem() :: mod_pubsub:pubsubItem()).
 -type(subOptions() :: mod_pubsub:subOptions()).
+-type(pubOptions() :: mod_pubsub:pubOptions()).
 -type(affiliation() :: mod_pubsub:affiliation()).
 -type(subscription() :: mod_pubsub:subscription()).
 -type(subId() :: mod_pubsub:subId()).
@@ -109,7 +110,8 @@
 	PublishModel :: publishModel(),
 	Max_Items :: non_neg_integer(),
 	ItemId :: <<>> | itemId(),
-	Payload :: payload()) ->
+	Payload :: payload(),
+	Options :: pubOptions()) ->
     {result, {default, broadcast, [itemId()]}} |
     {error, xmlel()}.
 

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -107,6 +107,8 @@
 	nodeOptions/0,
 	subOption/0,
 	subOptions/0,
+	pubOption/0,
+	pubOptions/0,
 	%%
 	affiliation/0,
 	subscription/0,
@@ -1289,7 +1291,16 @@ iq_pubsub(Host, ServerHost, From, IQType, SubEl, Lang, Access, Plugins) ->
 			[#xmlel{name = <<"item">>, attrs = ItemAttrs,
 					children = Payload}] ->
 			    ItemId = fxml:get_attr_s(<<"id">>, ItemAttrs),
-			    publish_item(Host, ServerHost, Node, From, ItemId, Payload, Access);
+			    PubOpts = case [C || #xmlel{name = <<"publish-options">>,
+							children = [C]} <- Rest] of
+				[XEl] ->
+				    case jlib:parse_xdata_submit(XEl) of
+				      invalid -> [];
+				      Form -> Form
+				    end;
+				_ -> []
+			    end,
+			    publish_item(Host, ServerHost, Node, From, ItemId, Payload, PubOpts, Access);
 			[] ->
 			    {error,
 				extended_error(?ERR_BAD_REQUEST, <<"item-required">>)};
@@ -2185,10 +2196,10 @@ unsubscribe_node(Host, Node, From, Subscriber, SubId) ->
     | {error, xmlel()}
     ).
 publish_item(Host, ServerHost, Node, Publisher, ItemId, Payload) ->
-    publish_item(Host, ServerHost, Node, Publisher, ItemId, Payload, all).
-publish_item(Host, ServerHost, Node, Publisher, <<>>, Payload, Access) ->
-    publish_item(Host, ServerHost, Node, Publisher, uniqid(), Payload, Access);
-publish_item(Host, ServerHost, Node, Publisher, ItemId, Payload, Access) ->
+    publish_item(Host, ServerHost, Node, Publisher, ItemId, Payload, [], all).
+publish_item(Host, ServerHost, Node, Publisher, <<>>, Payload, PubOpts, Access) ->
+    publish_item(Host, ServerHost, Node, Publisher, uniqid(), Payload, PubOpts, Access);
+publish_item(Host, ServerHost, Node, Publisher, ItemId, Payload, PubOpts, Access) ->
     Action = fun (#pubsub_node{options = Options, type = Type, id = Nidx}) ->
 	    Features = plugin_features(Host, Type),
 	    PublishFeature = lists:member(<<"publish">>, Features),
@@ -2220,7 +2231,7 @@ publish_item(Host, ServerHost, Node, Publisher, ItemId, Payload, Access) ->
 			extended_error(?ERR_BAD_REQUEST, <<"item-required">>)};
 		true ->
 		    node_call(Host, Type, publish_item,
-			[Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload])
+			[Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload, PubOpts])
 	    end
     end,
     Reply = [#xmlel{name = <<"pubsub">>,
@@ -2281,7 +2292,8 @@ publish_item(Host, ServerHost, Node, Publisher, ItemId, Payload, Access) ->
 					 attrs = [{<<"xmlns">>, ?NS_PUBSUB}],
 					 children = [#xmlel{name = <<"create">>,
 							    attrs = [{<<"node">>, NewNode}]}]}]} ->
-				    publish_item(Host, ServerHost, NewNode, Publisher, ItemId, Payload);
+			    publish_item(Host, ServerHost, NewNode, Publisher, ItemId,
+				Payload, PubOpts, Access);
 				_ ->
 				    {error, ?ERR_ITEM_NOT_FOUND}
 			    end;

--- a/src/node_buddy.erl
+++ b/src/node_buddy.erl
@@ -33,7 +33,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -102,8 +102,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+			       Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_club.erl
+++ b/src/node_club.erl
@@ -33,7 +33,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -101,8 +101,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_dag.erl
+++ b/src/node_dag.erl
@@ -33,7 +33,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -72,7 +72,7 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_hometree:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
     case nodetree_dag:get_node(Nidx) of
 	#pubsub_node{options = Options} ->
 	    case find_opt(node_type, Options) of
@@ -82,7 +82,7 @@ publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
 		     ?ERR_EXTENDED(?ERRT_NOT_ALLOWED(?MYLANG, Txt), <<"publish">>)};
 		_ ->
 		    node_hometree:publish_item(Nidx, Publisher, Model,
-			MaxItems, ItemId, Payload)
+			MaxItems, ItemId, Payload, PubOpts)
 	    end;
 	Err -> Err
     end.

--- a/src/node_dispatch.erl
+++ b/src/node_dispatch.erl
@@ -39,7 +39,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -99,13 +99,14 @@ subscribe_node(_Nidx, _Sender, _Subscriber, _AccessModel, _SendLast, _PresenceSu
 unsubscribe_node(_Nidx, _Sender, _Subscriber, _SubId) ->
     {error, ?ERR_FORBIDDEN}.
 
-publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload) ->
+publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload,
+	     PubOpts) ->
     case nodetree_tree:get_node(Nidx) of
 	#pubsub_node{nodeid = {Host, Node}} ->
 	    lists:foreach(fun (SubNode) ->
 			node_hometree:publish_item(SubNode#pubsub_node.id,
 			    Publisher, PublishModel, MaxItems,
-			    ItemId, Payload)
+			    ItemId, Payload, PubOpts)
 		end,
 		nodetree_tree:get_subnodes(Host, Node, Publisher)),
 	    {result, {default, broadcast, []}};

--- a/src/node_flat.erl
+++ b/src/node_flat.erl
@@ -39,7 +39,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -345,7 +345,8 @@ delete_subscriptions(SubKey, Nidx, Subscriptions, SubState) ->
 %%   to completly disable persistance.</li></ul>
 %% </p>
 %% <p>In the default plugin module, the record is unchanged.</p>
-publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload) ->
+publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload,
+	     _PubOpts) ->
     SubKey = jid:tolower(Publisher),
     GenKey = jid:remove_resource(SubKey),
     GenState = get_state(Nidx, GenKey),

--- a/src/node_flat_sql.erl
+++ b/src/node_flat_sql.erl
@@ -39,7 +39,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -217,7 +217,8 @@ delete_subscription(SubKey, Nidx, {Subscription, SubId}, Affiliation, Subscripti
 	_ -> update_subscription(Nidx, SubKey, NewSubs)
     end.
 
-publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload) ->
+publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload,
+	     _PubOpts) ->
     SubKey = jid:tolower(Publisher),
     GenKey = jid:remove_resource(SubKey),
     {Affiliation, Subscriptions} = select_affiliation_subscriptions(Nidx, GenKey, SubKey),

--- a/src/node_hometree.erl
+++ b/src/node_hometree.erl
@@ -33,7 +33,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -99,8 +99,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_hometree_sql.erl
+++ b/src/node_hometree_sql.erl
@@ -33,7 +33,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -77,8 +77,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat_sql:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat_sql:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat_sql:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat_sql:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_mb.erl
+++ b/src/node_mb.erl
@@ -46,7 +46,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -116,8 +116,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_pep:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_pep:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_pep:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_pep:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_mix.erl
+++ b/src/node_mix.erl
@@ -14,7 +14,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -89,8 +89,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload,
+	PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_mix_sql.erl
+++ b/src/node_mix_sql.erl
@@ -14,7 +14,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -89,8 +89,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat_sql:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat_sql:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat_sql:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat_sql:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_online.erl
+++ b/src/node_online.erl
@@ -33,7 +33,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -99,8 +99,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_pep.erl
+++ b/src/node_pep.erl
@@ -37,7 +37,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -130,8 +130,9 @@ unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
 	{result, _} -> {result, []}
     end.
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_pep_sql.erl
+++ b/src/node_pep_sql.erl
@@ -37,7 +37,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -86,8 +86,9 @@ unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
 	{result, _} -> {result, []}
     end.
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat_sql:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat_sql:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat_sql:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_private.erl
+++ b/src/node_private.erl
@@ -33,7 +33,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -101,8 +101,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_public.erl
+++ b/src/node_public.erl
@@ -33,7 +33,7 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/6, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -101,8 +101,9 @@ subscribe_node(Nidx, Sender, Subscriber, AccessModel,
 unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
     node_flat:unsubscribe_node(Nidx, Sender, Subscriber, SubId).
 
-publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload) ->
-    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload).
+publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
+    node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
+	Payload, PubOpts).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).


### PR DESCRIPTION
Add code necessary to support publishing options as [described in XEP-0060][1].  A node plugin that expects publishing options must add `<<"publish-options">>` to the `features/0` list and then handle the publishing options handed over to the `publish_item/7` call.

This is one of the additions required to use the app server part of [`mod_push`][2].

[1]: http://xmpp.org/extensions/xep-0060.html#publisher-publish-options
[2]: https://github.com/royneary/mod_push