### PR TITLE
mod_blocking_sql: Handle default list corner case

### DIFF
--- a/src/mod_blocking_sql.erl
+++ b/src/mod_blocking_sql.erl
@@ -25,7 +25,12 @@ process_blocklist_block(LUser, LServer, Filter) ->
 		Default = case mod_privacy_sql:sql_get_default_privacy_list_t(LUser) of
 			      {selected, []} ->
 				  Name = <<"Blocked contacts">>,
-				  mod_privacy_sql:sql_add_privacy_list(LUser, Name),
+				  case mod_privacy_sql:sql_get_privacy_list_id_t(LUser, Name) of
+				      {selected, []} ->
+					  mod_privacy_sql:sql_add_privacy_list(LUser, Name);
+				      {selected, [{_ID}]} ->
+					  ok
+				  end,
 				  mod_privacy_sql:sql_set_default_privacy_list(LUser, Name),
 				  Name;
 			      {selected, [{Name}]} -> Name


### PR DESCRIPTION
If a [XEP-0016][1] client created a list called *Blocked contacts* and no default list exists, using [XEP-0191][2] will fail with SQL errors such as:

    ** Last abort reason: "#23000Duplicate entry 'juliet-Blocked contacts' for key 'i_privacy_list_username_name'"
    ** Stacktrace: [{ejabberd_sql,sql_query_t,1,[{file,"src/ejabberd_sql.erl"},{line,185}]},{mod_blocking_sql,'-process_blocklist_block/3-fun-0-',2,[{file,"src/mod_blocking_sql.erl"},{line,28}]},{ejabberd_sql,outer_transaction,3,[{file,"src/ejabberd_sql.erl"},{line,474}]},{ejabberd_sql,run_sql_cmd,4,[{file,"src/ejabberd_sql.erl"},{line,411}]},{p1_fsm,handle_msg,10,[{file,"src/p1_fsm.erl"},{line,582}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]
    ** When State == {state,<0.510.0>,mysql,undefined,30000,<<"montague.net">>,1000,{0,{[],[]}}}
    2016-06-21 23:46:57.570 [error] <0.30387.46>@mod_blocking:process_blocklist_block:164 Error processing {<<"juliet">>,<<"montague.net">>,[{<<"romeo">>,<<"montague.net">>,<<>>}]}: {aborted,"#23000Duplicate entry 'juliet-Blocked contacts' for key 'i_privacy_list_username_name'"}

It's stumbling over line 28 in `mod_blocking_sql.erl` because the *Blocked contacts* already exists:

    mod_privacy_sql:sql_add_privacy_list(LUser, Name)

This PR fixes the issue.

[1]: https://xmpp.org/extensions/xep-0016.html
[2]: https://xmpp.org/extensions/xep-0191.html