### PR TITLE
Harden the systemd unit

### DIFF
--- a/ejabberd.service.template
+++ b/ejabberd.service.template
@@ -12,6 +12,13 @@ ExecStop=@ctlscriptpath@/ejabberdctl stop
 ExecReload=@ctlscriptpath@/ejabberdctl reload_config
 Type=oneshot
 RemainAfterExit=yes
+# The CAP_DAC_OVERRIDE capability is required for pam authentication to work
+CapabilityBoundingSet=CAP_DAC_OVERRIDE
+PrivateTmp=true
+PrivateDevices=true
+ProtectHome=true
+ProtectSystem=full
+NoNewPrivileges=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Restrict capabilities, have a private tmp directory, private /dev, and don't accessing file system locations that really shouldn't be accessed.

This hardening improvement reduces the damage that can be done if ejabberd is compromised. There aren't any tests or anything like that that I can think of... to test it, just use the unit and make sure ejabberd continues to work :)
