### PR TITLE
Fix issue #625: Writing Elixir modules

### DIFF
--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -45,6 +45,7 @@ start(normal, _Args) ->
     write_pid_file(),
     jid:start(),
     start_apps(),
+    start_elixir_application(),
     ejabberd:check_app(ejabberd),
     randoms:start(),
     db_init(),
@@ -237,3 +238,9 @@ opt_type(modules) ->
 		      Mods)
     end;
 opt_type(_) -> [cluster_nodes, loglevel, modules, net_ticktime].
+
+start_elixir_application() ->
+  case application:ensure_started(elixir) of
+    ok -> ok;
+    {error, Msg} -> ?ERROR_MSG("Elixir application not started.", [])
+  end.


### PR DESCRIPTION
PR for supporting elixir modules in the installer. Resolves issue #625.

It compiles all the `*.ex` files found inside `/lib` and `/deps` folder.

I've tried to leverage the `Kernel. ParallelCompiler ` module from elixir instead of executing a cmd command (using elixirc), but to maintain consistency with the error checking I'm passing one file at a time  instead of passing them all at once, not exploiting the parallel compilation of elixir. This has been necessary because the `files_to_path/3` function doesn't return anything when a compilation error occurs, instead it throws an exception.