### PR TITLE
Do not crash on check when we do not have JID

### DIFF
--- a/src/ejabberd_commands.erl
+++ b/src/ejabberd_commands.erl
@@ -555,6 +555,8 @@ execute_check_policy(
 
 execute_check_access(_FromJID, #ejabberd_commands{access = []} = Command, Arguments) ->
     do_execute_command(Command, Arguments);
+execute_check_access(undefined, _Command, _Arguments) ->
+    throw({error, access_rules_unauthorized});
 execute_check_access(FromJID, #ejabberd_commands{access = AccessRefs} = Command, Arguments) ->
     %% TODO Review: Do we have smarter / better way to check rule on other Host than global ?
     Host = global,


### PR DESCRIPTION
Fix Crash when passing empty bearer in http request