### PR TITLE
Set MemoryDenyWriteExecute in the systemd unit

### DIFF
--- a/ejabberd.service.template
+++ b/ejabberd.service.template
@@ -19,6 +19,7 @@ PrivateDevices=true
 ProtectHome=true
 ProtectSystem=full
 NoNewPrivileges=true
+MemoryDenyWriteExecute=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I've tested this changed and it seems to work great. Note that because systemd ignored unknown options, this change will not cause problems for users of systemd < 231.

The benefit is that, for users of systemd 231, a whole class of attacks are mitigated.
