### PR TITLE
Fixed #1260 Stream Management feature for the websocket connections

### DIFF
--- a/src/ejabberd_http_ws.erl
+++ b/src/ejabberd_http_ws.erl
@@ -112,7 +112,7 @@ socket_handoff(LocalPath, Request, Socket, SockMod, Buf, Opts) ->
 %%% Internal
 
 init([{#ws{ip = IP, http_opts = HOpts}, _} = WS]) ->
-    SOpts = lists:filtermap(fun({stream_managment, _}) -> true;
+    SOpts = lists:filtermap(fun({stream_management, _}) -> true;
                                ({max_ack_queue, _}) -> true;
                                ({resume_timeout, _}) -> true;
                                ({max_resume_timeout, _}) -> true;


### PR DESCRIPTION
Settings to disable Stream Management feature for the websockets connections:

```
port: 5280
    ip: "::"
    module: ejabberd_http
    request_handlers:
      "/ws-chat": ejabberd_http_ws
    stream_management: false
```