### PR TITLE
fix is_online/1 function to filter sessions without living process

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -432,8 +432,14 @@ online(Sessions) ->
 
 -spec is_online(#session{}) -> boolean().
 
-is_online(#session{info = Info}) ->
-    not proplists:get_bool(offline, Info).
+is_online(#session{info = Info, sid = Sid}) ->
+    not proplists:get_bool(offline, Info) andalso is_session_alive(Sid).
+
+-spec is_session_alive(sid()) -> boolean().
+
+is_session_alive(Sid) ->
+	Pid = element(2, Sid),
+	rpc:call(node(Pid), erlang, is_process_alive, [Pid]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
in situation which I described in #1271 I can see this output in debug console:

```
(ejabberd@localhost)1> ejabberd_sm_redis:get_sessions(<<"user_1136">>, <<"some.host">>, <<"ru.app.debug_1.56.0-D_build_2_Android_5.0_62df618a-cc30-4d24-b3bf-216fcf810126.1470982580701">>).
[{session,{{1473,54402,3278},<0.8407.4>},
          {<<"user_1136">>,<<"some.host">>,
           <<"ru.app.debug_1.56.0-D_build_2_Android_5.0_62df618a-cc30-4d24-b3bf-216fcf810126."...>>},
          {<<"user_1136">>,<<"some.host">>},
          0,
          [{ip,{{85,140,6,7},31920}},
           {conn,c2s},
           {auth_module,ejabberd_auth_external}]}]
```

meanwhile:

```
(ejabberd@localhost)2> is_process_alive(list_to_pid("<0.8407.4>")).
false
```

To fix this issue, I think we can add additional check to is_online/1 function, to be sure that session process is still alive.
