### PR TITLE
New stream management option: ack_timeout

### DIFF
--- a/src/ejabberd_http_bind.erl
+++ b/src/ejabberd_http_bind.erl
@@ -340,6 +340,7 @@ init([Sid, Key, IP, HOpts]) ->
     Opts1 = ejabberd_c2s_config:get_c2s_limits(),
     SOpts = lists:filtermap(fun({stream_management, _}) -> true;
                                ({max_ack_queue, _}) -> true;
+                               ({ack_timeout, _}) -> true;
                                ({resume_timeout, _}) -> true;
                                ({max_resume_timeout, _}) -> true;
                                ({resend_on_timeout, _}) -> true;

--- a/src/ejabberd_http_ws.erl
+++ b/src/ejabberd_http_ws.erl
@@ -114,6 +114,7 @@ socket_handoff(LocalPath, Request, Socket, SockMod, Buf, Opts) ->
 init([{#ws{ip = IP, http_opts = HOpts}, _} = WS]) ->
     SOpts = lists:filtermap(fun({stream_management, _}) -> true;
                                ({max_ack_queue, _}) -> true;
+                               ({ack_timeout, _}) -> true;
                                ({resume_timeout, _}) -> true;
                                ({max_resume_timeout, _}) -> true;
                                ({resend_on_timeout, _}) -> true;


### PR DESCRIPTION
Close the connection if a stream management client fails to respond to an acknowledgement request within 60 seconds.  This number of seconds can be changed with the new `ack_timeout` option, and the mechanism can be disabled by specifying `infinity`.

As a side effect of this change, a new acknowledgement is no longer requested before the response to the previous request is received.