### PR TITLE
Don't let systemd hide /home and /tmp

### DIFF
--- a/ejabberd.service.template
+++ b/ejabberd.service.template
@@ -14,9 +14,7 @@ Type=oneshot
 RemainAfterExit=yes
 # The CAP_DAC_OVERRIDE capability is required for pam authentication to work
 CapabilityBoundingSet=CAP_DAC_OVERRIDE
-PrivateTmp=true
 PrivateDevices=true
-ProtectHome=true
 ProtectSystem=full
 NoNewPrivileges=true
 


### PR DESCRIPTION
Admins might expect ejabberd to be able to access data below `/home` or `/tmp`.  For example, they might use those locations to dump/restore Mnesia backups, or as a document root for `mod_http_fileserver` or `mod_http_upload`.

Fixes #1297.  See also #1178.