### PR TITLE
Enable elixir when used as a mix dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Ejabberd.Mixfile do
   defp erlc_options do
     # Use our own includes + includes from all dependencies
     includes = ["include"] ++ Path.wildcard(Path.join("..", "/*/include"))
-    [:debug_info] ++ Enum.map(includes, fn(path) -> {:i, path} end)
+    [:debug_info, {:d, :ELIXIR_ENABLED}] ++ Enum.map(includes, fn(path) -> {:i, path} end)
   end
 
   defp deps do


### PR DESCRIPTION
When using ejabberd as a mix dependency, pass the appropriate compiler flag to make

``` erlang
-ifdef(ELIXIR_ENABLED).
```

preprocessor macros true.

This allows users to write config files in elixir when ejabberd is embedded in a mix project. @gabrielgatu I see you've done most of the work on elixir config. Does this look right?
