### PR TITLE
Introduce muc_invite hook

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -5056,6 +5056,8 @@ process_invitations(From, InviteEls, Lang, StateData) ->
 			  throw({error, ?ERRT_JID_MALFORMED(Lang, Txt)});
 		    JID1 -> JID1
 		  end,
+	  ejabberd_hooks:run(muc_invite, StateData#state.server_host,
+ 			     [StateData#state.jid, StateData#state.config, From, JID, Reason]),
 	  ejabberd_router:route(StateData#state.jid, JID, Msg),
 	  JID
 	end,


### PR DESCRIPTION
We want to send an email notification when a user invites other users to an MUC room. We've tried to implement this using a `filter_packet` hook. However, we then need to get access to the room config (to retrieve the room title). In addition, by filtering all packets, we add a potential performance bottleneck.

We think that it is quite a common use case to have an additional notification (besides XMPP) of such an invitation. Therefore, this pull request adds a new hook that is triggered for each invite to an MUC room:

    muc_invite(RoomJID, RoomConfig, From, To, Reason) -> ok

where

- RoomJID = From = To = #jid (see jlib.h)
- RoomConfig = #config (see mod_muc_room.hrl)
- Reason = binary()

~~I can also submit an additional pull request for processone/docs.ejabberd.im to address the documentation.~~ I've submitted an additional to address the documentation in processone/docs.ejabberd.im#19.