### PR TITLE
Fix: Replace erlang function with fail-safe jlib function.

### DIFF
--- a/src/ejabberd_sql.erl
+++ b/src/ejabberd_sql.erl
@@ -629,7 +629,7 @@ generic_sql_query_format(SQLQuery) ->
 
 generic_escape() ->
     #sql_escape{string = fun(X) -> <<"'", (escape(X))/binary, "'">> end,
-                integer = fun(X) -> integer_to_binary(X) end,
+                integer = fun(X) -> jlib:i2l(X) end,
                 boolean = fun(true) -> <<"1">>;
                              (false) -> <<"0">>
                           end
@@ -646,7 +646,7 @@ sqlite_sql_query_format(SQLQuery) ->
 
 sqlite_escape() ->
     #sql_escape{string = fun(X) -> <<"'", (standard_escape(X))/binary, "'">> end,
-                integer = fun(X) -> integer_to_binary(X) end,
+                integer = fun(X) -> jlib:i2l(X) end,
                 boolean = fun(true) -> <<"1">>;
                              (false) -> <<"0">>
                           end
@@ -664,13 +664,13 @@ mssql_sql_query(SQLQuery) ->
 pgsql_prepare(SQLQuery, State) ->
     Escape = #sql_escape{_ = fun(X) -> X end},
     N = length((SQLQuery#sql_query.args)(Escape)),
-    Args = [<<$$, (integer_to_binary(I))/binary>> || I <- lists:seq(1, N)],
+    Args = [<<$$, (jlib:i2l(I))/binary>> || I <- lists:seq(1, N)],
     Query = (SQLQuery#sql_query.format_query)(Args),
     pgsql:prepare(State#state.db_ref, SQLQuery#sql_query.hash, Query).
 
 pgsql_execute_escape() ->
     #sql_escape{string = fun(X) -> X end,
-                integer = fun(X) -> [integer_to_binary(X)] end,
+                integer = fun(X) -> [jlib:i2l(X)] end,
                 boolean = fun(true) -> "1";
                              (false) -> "0"
                           end

--- a/src/ejabberd_sql.erl
+++ b/src/ejabberd_sql.erl
@@ -664,7 +664,7 @@ mssql_sql_query(SQLQuery) ->
 pgsql_prepare(SQLQuery, State) ->
     Escape = #sql_escape{_ = fun(X) -> X end},
     N = length((SQLQuery#sql_query.args)(Escape)),
-    Args = [<<$$, (jlib:i2l(I))/binary>> || I <- lists:seq(1, N)],
+    Args = [<<$$, (integer_to_binary(I))/binary>> || I <- lists:seq(1, N)],
     Query = (SQLQuery#sql_query.format_query)(Args),
     pgsql:prepare(State#state.db_ref, SQLQuery#sql_query.hash, Query).
 


### PR DESCRIPTION
As reported in:
 https://www.ejabberd.im/forum/28580/erlang-function-integertobinary1-throwing-badargs-exception

This change is in continuation of earlier [commit](https://github.com/processone/ejabberd/commit/2ab72bcd009536a6bef2be04c71470f17e19d0b2) to handle data type conversion with fail-safe mechanism. Please refer above forum link for details.

This has been verified locally.

