### PR TITLE
Allow to add extra modules using application env

### DIFF
--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -912,8 +912,9 @@ default_db(Host, Module) ->
 
 get_modules_with_options() ->
     {ok, Mods} = application:get_key(ejabberd, modules),
+    AddMods = application:get_env(ejabberd, modules, []),
     ExtMods = [Name || {Name, _Details} <- ext_mod:installed()],
-    AllMods = [?MODULE|ExtMods++Mods],
+    AllMods = [?MODULE|ExtMods++Mods++AddMods],
     init_module_db_table(AllMods),
     lists:foldl(
       fun(Mod, D) ->


### PR DESCRIPTION
Hi, guys!

Today I've encountered an issue. I have setup with ejabberd embedded into node with my custom applications. I wrote my own authorization plugin. I was surprised when ejabberd was unable to locate this module, even if it was loaded into the node. I've found that current modules discovery schema requires this module to be placed in [certain place](https://github.com/processone/ejabberd/blob/master/src/ext_mod.erl#L356). It would be cool if I'll be able to add extra modules one more way. 