### PR TITLE
Mark messages as copies by attaching metadata

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -613,8 +613,7 @@ route_message(From, To, Packet, Type) ->
 maybe_mark_as_copy(Packet, R, R, P, P) ->
     Packet;
 maybe_mark_as_copy(Packet, _, _, P, P) ->
-    Meta = Packet#message.meta,
-    Packet#message{meta = Meta#{sm_copy => true}};
+    xmpp:put_meta(Packet, sm_copy, true);
 maybe_mark_as_copy(Packet, _, _, _, _) ->
     Packet.
 

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -52,9 +52,10 @@
 -callback list(binary(), binary()) -> [{binary(), binary()}].
 
 -spec is_carbon_copy(stanza()) -> boolean().
-is_carbon_copy(Packet) ->
-    xmpp:has_subtag(Packet, #carbons_sent{}) orelse
-	xmpp:has_subtag(Packet, #carbons_received{}).
+is_carbon_copy(#message{meta = #{carbon_copy := true}}) ->
+    true;
+is_carbon_copy(_) ->
+    false.
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts,fun gen_iq_handler:check_type/1, one_queue),
@@ -203,7 +204,8 @@ build_forward_packet(JID, #message{type = T} = Msg, Sender, Dest, Direction) ->
 		 sent -> #carbons_sent{forwarded = Forwarded};
 		 received -> #carbons_received{forwarded = Forwarded}
 	     end,
-    #message{from = Sender, to = Dest, type = T, sub_els = [Carbon]}.
+    #message{from = Sender, to = Dest, type = T, sub_els = [Carbon],
+	     meta = #{carbon_copy => true}}.
 
 -spec enable(binary(), binary(), binary(), binary()) -> ok | {error, any()}.
 enable(Host, U, R, CC)->


### PR DESCRIPTION
Let `mod_carboncopy` and `ejabberd_sm` mark message copies using the [new][1] `meta` field of `message{}` records.  This makes it easier for other modules (e.g., `mod_mam`) to ignore duplicates, and it fixes #1356.

[1]: https://github.com/processone/xmpp/commit/196ec7a9a968fe5b99f034b330a89b43580c9a60