### PR TITLE
Add muc_register_nick command to mod_muc_admin.

### DIFF
--- a/src/mod_muc_admin.erl
+++ b/src/mod_muc_admin.erl
@@ -12,8 +12,8 @@
 -behaviour(gen_mod).
 
 -export([start/2, stop/1, depends/2, muc_online_rooms/1,
-	 muc_unregister_nick/1, create_room/3, destroy_room/2,
-	 create_room_with_opts/4,
+	 muc_register_nick/3, muc_unregister_nick/1,
+	 create_room/3, destroy_room/2, create_room_with_opts/4,
 	 create_rooms_file/1, destroy_rooms_file/1,
 	 rooms_unused_list/2, rooms_unused_destroy/2,
 	 get_user_rooms/2, get_room_occupants/2,
@@ -66,6 +66,11 @@ get_commands_spec() ->
 		       module = ?MODULE, function = muc_online_rooms,
 		       args = [{host, binary}],
 		       result = {rooms, {list, {room, string}}}},
+     #ejabberd_commands{name = muc_register_nick, tags = [muc],
+		       desc = "Register a nick in the MUC service at the given domain to the given JID",
+		       module = ?MODULE, function = muc_register_nick,
+		       args = [{nick, binary}, {jid, binary}, {domain, binary}],
+		       result = {res, rescode}},
      #ejabberd_commands{name = muc_unregister_nick, tags = [muc],
 		       desc = "Unregister the nick in the MUC service",
 		       module = ?MODULE, function = muc_unregister_nick,
@@ -201,7 +206,6 @@ get_commands_spec() ->
 						}}}
     ].
 
-
 %%%
 %%% ejabberd commands
 %%%
@@ -223,6 +227,17 @@ muc_online_rooms(ServerHost) ->
       end,
       [],
       Rooms).
+
+muc_register_nick(Nick, JID, Domain) ->
+    {jid, UID, Host, _,_,_,_} = jlib:string_to_jid(JID),
+    F = fun (MHost, MNick) ->
+                mnesia:write(#muc_registered{us_host=MHost,
+                                             nick=MNick})
+        end,
+    case mnesia:transaction(F, [{{UID, Host}, Domain}, Nick]) of
+        {atomic, ok} -> ok;
+        {aborted, _Error} -> error
+    end.
 
 muc_unregister_nick(Nick) ->
     F2 = fun(N) ->


### PR DESCRIPTION
Just what it says on the tin; a command to register MUC nicks similar to the existing one to unregister.

I've used this to automatically register nicknames, like so:

    ejabberdctl muc_register_nick Nickname user@example.com conference.example.com