### PR TITLE
Use include_lib() to import external libraries.

### DIFF
--- a/include/jlib.hrl
+++ b/include/jlib.hrl
@@ -18,8 +18,8 @@
 %%%
 %%%----------------------------------------------------------------------
 
--include("ns.hrl").
--include("fxml.hrl").
+-include_lib("xmpp/include/ns.hrl").
+-include_lib("fast_xml/include/fxml.hrl").
 
 -define(STANZA_ERROR(Code, Type, Condition),
 	#xmlel{name = <<"error">>,

--- a/src/acl.erl
+++ b/src/acl.erl
@@ -41,7 +41,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 
 -record(acl, {aclname, aclspec}).
 -record(access, {name       :: aclname(),

--- a/src/ejabberd_auth_anonymous.erl
+++ b/src/ejabberd_auth_anonymous.erl
@@ -50,7 +50,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 
 %% Create the anonymous table if at least one virtual host has anonymous features enabled
 %% Register to login / logout events

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -74,7 +74,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 %%-include("legacy.hrl").
 
 -include("mod_privacy.hrl").

--- a/src/ejabberd_captcha.erl
+++ b/src/ejabberd_captcha.erl
@@ -43,7 +43,7 @@
 	 is_feature_available/0, create_captcha_x/5,
 	 opt_type/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd.hrl").
 -include("logger.hrl").
 -include("ejabberd_http.hrl").

--- a/src/ejabberd_http.erl
+++ b/src/ejabberd_http.erl
@@ -39,7 +39,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/ejabberd_http_ws.erl
+++ b/src/ejabberd_http_ws.erl
@@ -39,7 +39,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -46,7 +46,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state, {}).
 

--- a/src/ejabberd_oauth.erl
+++ b/src/ejabberd_oauth.erl
@@ -51,7 +51,7 @@
 
 -export([oauth_issue_token/3, oauth_list_tokens/0, oauth_revoke_token/1, oauth_list_scopes/0]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd.hrl").
 -include("logger.hrl").

--- a/src/ejabberd_oauth_rest.erl
+++ b/src/ejabberd_oauth_rest.erl
@@ -35,7 +35,7 @@
 -include("ejabberd.hrl").
 -include("ejabberd_oauth.hrl").
 -include("logger.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 
 init() ->
     rest:start(?MYNAME),

--- a/src/ejabberd_oauth_sql.erl
+++ b/src/ejabberd_oauth_sql.erl
@@ -36,7 +36,7 @@
 -include("ejabberd_oauth.hrl").
 -include("ejabberd.hrl").
 -include("ejabberd_sql_pt.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 
 init() ->
     ok.

--- a/src/ejabberd_piefxis.erl
+++ b/src/ejabberd_piefxis.erl
@@ -48,7 +48,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 -include("mod_roster.hrl").
 

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -54,7 +54,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -type local_hint() :: undefined | integer() | {apply, atom(), atom()}.
 

--- a/src/ejabberd_router_multicast.erl
+++ b/src/ejabberd_router_multicast.erl
@@ -43,7 +43,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(route_multicast, {domain = <<"">> :: binary() | '_',
 			  pid = self() :: pid()}).

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -56,7 +56,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_commands.hrl").
 

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -42,7 +42,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(DICT, dict).
 

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -50,7 +50,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state,
 	{socket                           :: ejabberd_socket:socket_state(),

--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -46,7 +46,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state,
 	{socket                    :: ejabberd_socket:socket_state(),

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -78,7 +78,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_commands.hrl").
 -include("mod_privacy.hrl").

--- a/src/ejabberd_system_monitor.erl
+++ b/src/ejabberd_system_monitor.erl
@@ -41,7 +41,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state, {}).
 

--- a/src/ejabberd_web.erl
+++ b/src/ejabberd_web.erl
@@ -34,7 +34,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/ejabberd_web_admin.erl
+++ b/src/ejabberd_web_admin.erl
@@ -38,7 +38,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/ejabberd_websocket.erl
+++ b/src/ejabberd_websocket.erl
@@ -47,7 +47,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/ejabberd_xmlrpc.erl
+++ b/src/ejabberd_xmlrpc.erl
@@ -42,7 +42,7 @@
 -include("ejabberd_http.hrl").
 -include("mod_roster.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state,
 	{access_commands = [] :: list(),

--- a/src/gen_iq_handler.erl
+++ b/src/gen_iq_handler.erl
@@ -40,7 +40,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state, {host, module, function}).
 

--- a/src/gen_pubsub_node.erl
+++ b/src/gen_pubsub_node.erl
@@ -25,7 +25,7 @@
 
 -module(gen_pubsub_node).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -type(host() :: mod_pubsub:host()).
 -type(nodeId() :: mod_pubsub:nodeId()).

--- a/src/jd2ejd.erl
+++ b/src/jd2ejd.erl
@@ -32,7 +32,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 %%%----------------------------------------------------------------------
 %%% API

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -39,7 +39,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, fun gen_iq_handler:check_type/1,

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -84,7 +84,7 @@
 -include("mod_roster.hrl").
 -include("mod_privacy.hrl").
 -include("ejabberd_sm.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 %%%
 %%% gen_mod

--- a/src/mod_announce.erl
+++ b/src/mod_announce.erl
@@ -39,7 +39,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_announce.hrl").
 
 -callback init(binary(), gen_mod:opts()) -> any().

--- a/src/mod_announce_mnesia.erl
+++ b/src/mod_announce_mnesia.erl
@@ -30,7 +30,7 @@
 -export([init/2, set_motd_users/2, set_motd/2, delete_motd/1,
 	 get_motd/1, is_motd_user/2, set_motd_user/2, import/3]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_announce.hrl").
 -include("logger.hrl").
 

--- a/src/mod_announce_riak.erl
+++ b/src/mod_announce_riak.erl
@@ -30,7 +30,7 @@
 -export([init/2, set_motd_users/2, set_motd/2, delete_motd/1,
 	 get_motd/1, is_motd_user/2, set_motd_user/2, import/3]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_announce.hrl").
 
 %%%===================================================================

--- a/src/mod_announce_sql.erl
+++ b/src/mod_announce_sql.erl
@@ -33,7 +33,7 @@
 	 get_motd/1, is_motd_user/2, set_motd_user/2, import/3,
 	 export/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_announce.hrl").
 -include("ejabberd_sql_pt.hrl").
 

--- a/src/mod_blocking.erl
+++ b/src/mod_blocking.erl
@@ -35,7 +35,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("mod_privacy.hrl").
 

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -54,7 +54,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_caps.hrl").
 
 -define(PROCNAME, ejabberd_mod_caps).

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -41,7 +41,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -define(PROCNAME, ?MODULE).
 
 -type direction() :: sent | received.

--- a/src/mod_client_state.erl
+++ b/src/mod_client_state.erl
@@ -39,7 +39,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(CSI_QUEUE_MAX, 100).
 

--- a/src/mod_configure.erl
+++ b/src/mod_configure.erl
@@ -40,7 +40,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_sm.hrl").
 
 -define(T(Lang, Text), translate:translate(Lang, Text)).

--- a/src/mod_delegation.erl
+++ b/src/mod_delegation.erl
@@ -43,7 +43,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -type disco_acc() :: {error, stanza_error()} | {result, [binary()]} | empty.
 -record(state, {server_host = <<"">> :: binary(),

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -44,7 +44,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 -include("mod_roster.hrl").
 

--- a/src/mod_echo.erl
+++ b/src/mod_echo.erl
@@ -42,7 +42,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state, {host = <<"">> :: binary()}).
 

--- a/src/mod_http_api.erl
+++ b/src/mod_http_api.erl
@@ -77,7 +77,7 @@
 -export([start/2, stop/1, process/2, mod_opt_type/1, depends/2]).
 
 -include("ejabberd.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("ejabberd_http.hrl").
 

--- a/src/mod_http_upload.erl
+++ b/src/mod_http_upload.erl
@@ -92,7 +92,7 @@
 
 -include("ejabberd.hrl").
 -include("ejabberd_http.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 
 -record(state,

--- a/src/mod_http_upload_quota.erl
+++ b/src/mod_http_upload_quota.erl
@@ -53,7 +53,7 @@
 %% ejabberd_hooks callback.
 -export([handle_slot_request/5]).
 
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("logger.hrl").
 -include_lib("kernel/include/file.hrl").
 

--- a/src/mod_irc.erl
+++ b/src/mod_irc.erl
@@ -43,7 +43,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_irc.hrl").
 
 -define(DEFAULT_IRC_ENCODING, <<"iso8859-15">>).

--- a/src/mod_irc_connection.erl
+++ b/src/mod_irc_connection.erl
@@ -41,7 +41,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(SETS, gb_sets).
 

--- a/src/mod_irc_mnesia.erl
+++ b/src/mod_irc_mnesia.erl
@@ -29,7 +29,7 @@
 %% API
 -export([init/2, get_data/3, set_data/4, import/2]).
 
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("mod_irc.hrl").
 -include("logger.hrl").
 

--- a/src/mod_irc_riak.erl
+++ b/src/mod_irc_riak.erl
@@ -29,7 +29,7 @@
 %% API
 -export([init/2, get_data/3, set_data/4, import/2]).
 
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("mod_irc.hrl").
 
 %%%===================================================================

--- a/src/mod_irc_sql.erl
+++ b/src/mod_irc_sql.erl
@@ -31,7 +31,7 @@
 %% API
 -export([init/2, get_data/3, set_data/4, import/1, import/2, export/1]).
 
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("mod_irc.hrl").
 -include("ejabberd_sql_pt.hrl").
 

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -42,7 +42,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("mod_privacy.hrl").
 -include("mod_last.hrl").

--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -39,7 +39,7 @@
 	 muc_filter_message/5, message_is_archived/5, delete_old_messages/2,
 	 get_commands_spec/0, msg_to_el/4, get_room_config/4, set_room_option/3]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("mod_muc_room.hrl").
 -include("ejabberd_commands.hrl").

--- a/src/mod_mam_mnesia.erl
+++ b/src/mod_mam_mnesia.erl
@@ -31,7 +31,7 @@
 	 extended_fields/0, store/7, write_prefs/4, get_prefs/2, select/6]).
 
 -include_lib("stdlib/include/ms_transform.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("mod_mam.hrl").
 

--- a/src/mod_mam_sql.erl
+++ b/src/mod_mam_sql.erl
@@ -33,7 +33,7 @@
 	 extended_fields/0, store/7, write_prefs/4, get_prefs/2, select/6]).
 
 -include_lib("stdlib/include/ms_transform.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_mam.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_metrics.erl
+++ b/src/mod_metrics.erl
@@ -31,7 +31,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -export([start/2, stop/1, send_metrics/4, opt_type/1, mod_opt_type/1,
 	 depends/2]).

--- a/src/mod_mix.erl
+++ b/src/mod_mix.erl
@@ -37,7 +37,7 @@
 	 terminate/2, code_change/3]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(PROCNAME, ejabberd_mod_mix).
 -define(NODES, [?NS_MIX_NODES_MESSAGES,

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -64,7 +64,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_muc.hrl").
 
 -record(state,

--- a/src/mod_muc_admin.erl
+++ b/src/mod_muc_admin.erl
@@ -43,7 +43,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_muc_room.hrl").
 -include("mod_muc.hrl").
 -include("ejabberd_http.hrl").

--- a/src/mod_muc_log.erl
+++ b/src/mod_muc_log.erl
@@ -46,7 +46,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_muc.hrl").
 -include("mod_muc_room.hrl").
 

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -51,7 +51,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("mod_muc_room.hrl").
 

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -36,7 +36,7 @@
 -export([set_affiliation/6, set_affiliations/4, get_affiliation/5,
 	 get_affiliations/3, search_affiliation/4]).
 
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("mod_muc.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_multicast.erl
+++ b/src/mod_multicast.erl
@@ -45,7 +45,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state,
 	{lserver, lservice, access, service_limits}).

--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -74,7 +74,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/mod_offline_mnesia.erl
+++ b/src/mod_offline_mnesia.erl
@@ -31,7 +31,7 @@
 	 read_message/3, remove_message/3, read_all_messages/2,
 	 remove_all_messages/2, count_messages/2, import/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_offline.hrl").
 -include("logger.hrl").
 

--- a/src/mod_offline_riak.erl
+++ b/src/mod_offline_riak.erl
@@ -31,7 +31,7 @@
 	 read_message/3, remove_message/3, read_all_messages/2,
 	 remove_all_messages/2, count_messages/2, import/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_offline.hrl").
 
 %%%===================================================================

--- a/src/mod_offline_sql.erl
+++ b/src/mod_offline_sql.erl
@@ -33,7 +33,7 @@
 	 read_message/3, remove_message/3, read_all_messages/2,
 	 remove_all_messages/2, count_messages/2, import/1, export/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_offline.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -36,7 +36,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(SUPERVISOR, ejabberd_sup).
 

--- a/src/mod_pres_counter.erl
+++ b/src/mod_pres_counter.erl
@@ -33,7 +33,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(pres_counter,
 	{dir, start, count, logged = false}).

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -42,7 +42,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("mod_privacy.hrl").
 

--- a/src/mod_privacy_mnesia.erl
+++ b/src/mod_privacy_mnesia.erl
@@ -33,7 +33,7 @@
 	 set_privacy_list/4, get_user_list/2, get_user_lists/2,
 	 remove_user/2, import/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 -include("logger.hrl").
 

--- a/src/mod_privacy_riak.erl
+++ b/src/mod_privacy_riak.erl
@@ -35,7 +35,7 @@
 
 -export([privacy_schema/0]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 
 %%%===================================================================

--- a/src/mod_privacy_sql.erl
+++ b/src/mod_privacy_sql.erl
@@ -44,7 +44,7 @@
 	 sql_get_privacy_list_id_t/2,
 	 sql_set_default_privacy_list/2, sql_set_privacy_list/2]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -38,7 +38,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_private.hrl").
 
 -callback init(binary(), gen_mod:opts()) -> any().

--- a/src/mod_private_mnesia.erl
+++ b/src/mod_private_mnesia.erl
@@ -30,7 +30,7 @@
 -export([init/2, set_data/3, get_data/3, get_all_data/2, remove_user/2,
 	 import/3]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_private.hrl").
 -include("logger.hrl").
 

--- a/src/mod_private_riak.erl
+++ b/src/mod_private_riak.erl
@@ -30,7 +30,7 @@
 -export([init/2, set_data/3, get_data/3, get_all_data/2, remove_user/2,
 	 import/3]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_private.hrl").
 
 %%%===================================================================

--- a/src/mod_private_sql.erl
+++ b/src/mod_private_sql.erl
@@ -30,7 +30,7 @@
 -export([init/2, set_data/3, get_data/3, get_all_data/2, remove_user/2,
 	 import/3, export/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_private.hrl").
 
 %%%===================================================================

--- a/src/mod_privilege.erl
+++ b/src/mod_privilege.erl
@@ -42,7 +42,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state, {server_host = <<"">> :: binary(),
 		permissions = dict:new() :: ?TDICT}).

--- a/src/mod_proxy65_service.erl
+++ b/src/mod_proxy65_service.erl
@@ -39,7 +39,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(PROCNAME, ejabberd_mod_proxy65_service).
 

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -41,7 +41,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("pubsub.hrl").
 
 -define(STDTREE, <<"tree">>).

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -41,7 +41,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, fun gen_iq_handler:check_type/1,

--- a/src/mod_register_web.erl
+++ b/src/mod_register_web.erl
@@ -60,7 +60,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -55,7 +55,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("mod_roster.hrl").
 

--- a/src/mod_service_log.erl
+++ b/src/mod_service_log.erl
@@ -35,7 +35,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 start(Host, _Opts) ->
     ejabberd_hooks:add(user_send_packet, Host, ?MODULE,

--- a/src/mod_shared_roster.erl
+++ b/src/mod_shared_roster.erl
@@ -44,7 +44,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("mod_roster.hrl").
 

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -45,7 +45,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_roster.hrl").
 -include("eldap.hrl").
 

--- a/src/mod_shared_roster_mnesia.erl
+++ b/src/mod_shared_roster_mnesia.erl
@@ -36,7 +36,7 @@
 -include("mod_roster.hrl").
 -include("mod_shared_roster.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 %%%===================================================================
 %%% API

--- a/src/mod_shared_roster_riak.erl
+++ b/src/mod_shared_roster_riak.erl
@@ -35,7 +35,7 @@
 
 -include("mod_roster.hrl").
 -include("mod_shared_roster.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 %%%===================================================================
 %%% API

--- a/src/mod_shared_roster_sql.erl
+++ b/src/mod_shared_roster_sql.erl
@@ -36,7 +36,7 @@
 	 add_user_to_group/3, remove_user_from_group/3, import/3,
 	 export/1]).
 
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("mod_roster.hrl").
 -include("mod_shared_roster.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_sic.erl
+++ b/src/mod_sic.erl
@@ -36,7 +36,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, fun gen_iq_handler:check_type/1,

--- a/src/mod_stats.erl
+++ b/src/mod_stats.erl
@@ -35,7 +35,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, fun gen_iq_handler:check_type/1,

--- a/src/mod_time.erl
+++ b/src/mod_time.erl
@@ -38,7 +38,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, fun gen_iq_handler:check_type/1,

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -41,7 +41,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_vcard.hrl").
 
 -define(JUD_MATCHES, 30).

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -43,7 +43,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 -include("eldap.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(PROCNAME, ejabberd_mod_vcard_ldap).
 

--- a/src/mod_vcard_mnesia.erl
+++ b/src/mod_vcard_mnesia.erl
@@ -32,7 +32,7 @@
 -export([is_search_supported/1]).
 
 -include("ejabberd.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_vcard.hrl").
 -include("logger.hrl").
 

--- a/src/mod_vcard_riak.erl
+++ b/src/mod_vcard_riak.erl
@@ -31,7 +31,7 @@
 	 search_fields/1, search_reported/1, import/3, stop/1]).
 -export([is_search_supported/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_vcard.hrl").
 
 %%%===================================================================

--- a/src/mod_vcard_sql.erl
+++ b/src/mod_vcard_sql.erl
@@ -33,7 +33,7 @@
 	 search_fields/1, search_reported/1, import/3, export/1]).
 -export([is_search_supported/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_vcard.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_vcard_xupdate.erl
+++ b/src/mod_vcard_xupdate.erl
@@ -36,7 +36,7 @@
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -callback init(binary(), gen_mod:opts()) -> any().
 -callback import(binary(), binary(), [binary()]) -> ok.

--- a/src/mod_version.erl
+++ b/src/mod_version.erl
@@ -37,7 +37,7 @@
 -include("ejabberd.hrl").
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 start(Host, Opts) ->
     IQDisc = gen_mod:get_opt(iqdisc, Opts, fun gen_iq_handler:check_type/1,

--- a/src/node_dag.erl
+++ b/src/node_dag.erl
@@ -28,7 +28,7 @@
 -author('bjc@kublai.com').
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,

--- a/src/node_dispatch.erl
+++ b/src/node_dispatch.erl
@@ -34,7 +34,7 @@
 -author('christophe.romain@process-one.net').
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,

--- a/src/node_flat.erl
+++ b/src/node_flat.erl
@@ -34,7 +34,7 @@
 -author('christophe.romain@process-one.net').
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,

--- a/src/node_flat_sql.erl
+++ b/src/node_flat_sql.erl
@@ -36,7 +36,7 @@
 -compile([{parse_transform, ejabberd_sql_pt}]).
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_sql_pt.hrl").
 
 -export([init/3, terminate/2, options/0, features/0,

--- a/src/node_online.erl
+++ b/src/node_online.erl
@@ -28,7 +28,7 @@
 -author('christophe.romain@process-one.net').
 
 -include("pubsub.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,

--- a/src/nodetree_dag.erl
+++ b/src/nodetree_dag.erl
@@ -30,7 +30,7 @@
 -include_lib("stdlib/include/qlc.hrl").
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -export([init/3, terminate/2, options/0, set_node/1,
     get_node/3, get_node/2, get_node/1, get_nodes/2,

--- a/src/nodetree_tree.erl
+++ b/src/nodetree_tree.erl
@@ -40,7 +40,7 @@
 -include_lib("stdlib/include/qlc.hrl").
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -export([init/3, terminate/2, options/0, set_node/1,
     get_node/3, get_node/2, get_node/1, get_nodes/2,

--- a/src/nodetree_tree_sql.erl
+++ b/src/nodetree_tree_sql.erl
@@ -40,7 +40,7 @@
 -compile([{parse_transform, ejabberd_sql_pt}]).
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_sql_pt.hrl").
 
 -export([init/3, terminate/2, options/0, set_node/1,

--- a/src/prosody2ejabberd.erl
+++ b/src/prosody2ejabberd.erl
@@ -28,7 +28,7 @@
 -export([from_dir/1]).
 
 -include("ejabberd.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("mod_roster.hrl").
 -include("mod_offline.hrl").

--- a/src/pubsub_subscription.erl
+++ b/src/pubsub_subscription.erl
@@ -39,7 +39,7 @@
 
 -include("pubsub.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(PUBSUB_DELIVER, <<"pubsub#deliver">>).
 -define(PUBSUB_DIGEST, <<"pubsub#digest">>).

--- a/src/pubsub_subscription_sql.erl
+++ b/src/pubsub_subscription_sql.erl
@@ -35,7 +35,7 @@
 
 -include("pubsub.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(PUBSUB_DELIVER, <<"pubsub#deliver">>).
 -define(PUBSUB_DIGEST, <<"pubsub#digest">>).

--- a/test/muc_tests.erl
+++ b/test/muc_tests.erl
@@ -16,7 +16,7 @@
 		disconnect/1, put_event/2, get_event/1, peer_muc_jid/1,
 		my_muc_jid/1, get_features/2, set_opt/3]).
 -include("suite.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 
 %%%===================================================================
 %%% API

--- a/test/suite.hrl
+++ b/test/suite.hrl
@@ -1,9 +1,9 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("fast_xml/include/fxml.hrl").
--include("ns.hrl").
+-include_lib("xmpp/include/ns.hrl").
 -include("ejabberd.hrl").
 -include("mod_proxy65.hrl").
--include("xmpp_codec.hrl").
+-include_lib("xmpp/include/xmpp_codec.hrl").
 
 -define(STREAM_TRAILER, <<"</stream:stream>">>).
 


### PR DESCRIPTION
This commit adjusts several ```include()``` statements across the project to use ```include_lib()``` instead so that the libraries can be found from a system install. This commit enables ejabberd-16.12 to be built in Fedora Rawhide with ```xmpp``` and ```fast_xml``` being installed in ```/usr/lib64/erlang/lib/```.

If there's a better way to do this, I'd love to know about it (I'm new to Erlang)!