### PR TITLE
mod_pubsub: Fix last item cache for multiple hosts

### DIFF
--- a/include/pubsub.hrl
+++ b/include/pubsub.hrl
@@ -166,7 +166,7 @@
 
 -record(pubsub_last_item,
 {
-    nodeid   ,% :: mod_pubsub:nodeIdx(),
+    nodeid   ,% :: {binary(), mod_pubsub:nodeIdx()},
     itemid   ,% :: mod_pubsub:itemId(),
     creation ,% :: {erlang:timestamp(), jlib:ljid()},
     payload  % :: mod_pubsub:payload()

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -177,7 +177,7 @@
 
 -type(pubsubLastItem() ::
     #pubsub_last_item{
-	nodeid   :: mod_pubsub:nodeIdx(),
+	nodeid   :: {binary(), mod_pubsub:nodeIdx()},
 	itemid   :: mod_pubsub:itemId(),
 	creation :: {erlang:timestamp(), ljid()},
 	payload  :: mod_pubsub:payload()
@@ -3426,7 +3426,7 @@ set_cached_item({_, ServerHost, _}, Nidx, ItemId, Publisher, Payload) ->
     set_cached_item(ServerHost, Nidx, ItemId, Publisher, Payload);
 set_cached_item(Host, Nidx, ItemId, Publisher, Payload) ->
     case is_last_item_cache_enabled(Host) of
-	true -> mnesia:dirty_write({pubsub_last_item, Nidx, ItemId,
+	true -> mnesia:dirty_write({pubsub_last_item, {Host, Nidx}, ItemId,
 		    {p1_time_compat:timestamp(), jid:tolower(jid:remove_resource(Publisher))},
 		    Payload});
 	_ -> ok
@@ -3437,7 +3437,7 @@ unset_cached_item({_, ServerHost, _}, Nidx) ->
     unset_cached_item(ServerHost, Nidx);
 unset_cached_item(Host, Nidx) ->
     case is_last_item_cache_enabled(Host) of
-	true -> mnesia:dirty_delete({pubsub_last_item, Nidx});
+	true -> mnesia:dirty_delete({pubsub_last_item, {Host, Nidx}});
 	_ -> ok
     end.
 
@@ -3447,8 +3447,8 @@ get_cached_item({_, ServerHost, _}, Nidx) ->
 get_cached_item(Host, Nidx) ->
     case is_last_item_cache_enabled(Host) of
 	true ->
-	    case mnesia:dirty_read({pubsub_last_item, Nidx}) of
-		[#pubsub_last_item{itemid = ItemId, creation = Creation, payload = Payload}] ->
+	    case mnesia:dirty_read({pubsub_last_item, {Host, Nidx}}) of
+		[#pubsub_last_item{itemid = {Host, ItemId}, creation = Creation, payload = Payload}] ->
 		    %            [{pubsub_last_item, Nidx, ItemId, Creation,
 		    %              Payload}] ->
 		    #pubsub_item{itemid = {ItemId, Nidx},


### PR DESCRIPTION
Don't let the `last_item_cache` intermix PubSub nodes of different virtual domains.