### PR TITLE
No need to explicitly return ok here

### DIFF
--- a/src/cyrsasl_anonymous.erl
+++ b/src/cyrsasl_anonymous.erl
@@ -35,8 +35,7 @@
 -record(state, {server = <<"">> :: binary()}).
 
 start(_Opts) ->
-    cyrsasl:register_mechanism(<<"ANONYMOUS">>, ?MODULE, plain),
-    ok.
+    cyrsasl:register_mechanism(<<"ANONYMOUS">>, ?MODULE, plain).
 
 stop() -> ok.
 

--- a/src/cyrsasl_oauth.erl
+++ b/src/cyrsasl_oauth.erl
@@ -36,8 +36,7 @@
 -export_type([error_reason/0]).
 
 start(_Opts) ->
-    cyrsasl:register_mechanism(<<"X-OAUTH2">>, ?MODULE, plain),
-    ok.
+    cyrsasl:register_mechanism(<<"X-OAUTH2">>, ?MODULE, plain).
 
 stop() -> ok.
 

--- a/src/cyrsasl_plain.erl
+++ b/src/cyrsasl_plain.erl
@@ -36,8 +36,7 @@
 -export_type([error_reason/0]).
 
 start(_Opts) ->
-    cyrsasl:register_mechanism(<<"PLAIN">>, ?MODULE, plain),
-    ok.
+    cyrsasl:register_mechanism(<<"PLAIN">>, ?MODULE, plain).
 
 stop() -> ok.
 


### PR DESCRIPTION
No need to explicitly return ok here. Return value will be ignored
anyway.

Signed-off-by: Peter Lemenkov <lemenkov@redhat.com>