### PR TITLE
RFE: Use crypto:hash/2 function

### DIFF
--- a/src/ejabberd_websocket.erl
+++ b/src/ejabberd_websocket.erl
@@ -153,7 +153,7 @@ handshake(#ws{headers = Headers} = State) ->
                                 [<<"Sec-Websocket-Protocol:">>, V, <<"\r\n">>]
                         end,
     Hash = jlib:encode_base64(
-             p1_sha:sha1(<<Key/binary, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11">>)),
+             crypto:hash(sha, <<Key/binary, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11">>)),
     {State, [<<"HTTP/1.1 101 Switching Protocols\r\n">>,
              <<"Upgrade: websocket\r\n">>,
              <<"Connection: Upgrade\r\n">>,

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -734,7 +734,7 @@ get_md5(AccountPass) ->
                       || X <- binary_to_list(erlang:md5(AccountPass))]).
 get_sha(AccountPass) ->
     iolist_to_binary([io_lib:format("~2.16.0B", [X])
- 		      || X <- binary_to_list(p1_sha:sha1(AccountPass))]).
+		      || X <- binary_to_list(crypto:hash(sha, AccountPass))]).
 
 num_active_users(Host, Days) ->
     DB_Type = gen_mod:db_type(Host, mod_last),

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -409,11 +409,11 @@ make_disco_hash(DiscoInfo, Algo) ->
                              concat_features(DiscoInfo), concat_info(DiscoInfo)]),
     jlib:encode_base64(case Algo of
                            md5 -> erlang:md5(Concat);
-                           sha -> p1_sha:sha1(Concat);
-                           sha224 -> p1_sha:sha224(Concat);
-                           sha256 -> p1_sha:sha256(Concat);
-                           sha384 -> p1_sha:sha384(Concat);
-                           sha512 -> p1_sha:sha512(Concat)
+                           sha -> crypto:hash(sha, Concat);
+                           sha224 -> crypto:hash(sha224, Concat);
+                           sha256 -> crypto:hash(sha256, Concat);
+                           sha384 -> crypto:hash(sha384, Concat);
+                           sha512 -> crypto:hash(sha512, Concat)
                        end).
 
 -spec check_hash(caps(), disco_info()) -> boolean().

--- a/src/scram.erl
+++ b/src/scram.erl
@@ -45,7 +45,7 @@ client_key(SaltedPassword) ->
 
 -spec stored_key(binary()) -> binary().
 
-stored_key(ClientKey) -> p1_sha:sha1(ClientKey).
+stored_key(ClientKey) -> crypto:hash(sha, ClientKey).
 
 -spec server_key(binary()) -> binary().
 


### PR DESCRIPTION
Use crypto:hash/2 function instead of ones from p1_sha.

This function exists since commit
erlang/otp@208f9ad3828313f6c659a501d53f5534ec1bdf2e and also implemented
as NIF, so I believe it's safe to use it.

The rest of fast_tls functions still doesn't have (AFAIK) a direct and fast counterpart within Erlang/OTP source tree.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>