### PR TITLE
Use ejabberd_config:get_option/2 instead of ejabberd_config:get_local_option/2

### DIFF
--- a/src/ejabberd_auth_external.erl
+++ b/src/ejabberd_auth_external.erl
@@ -315,7 +315,7 @@ get_mod_last_configured(Server) ->
     end.
 
 is_configured(Host, Module) ->
-    Os = ejabberd_config:get_local_option({modules, Host},
+    Os = ejabberd_config:get_option({modules, Host},
 					  fun(M) when is_list(M) -> M end),
     lists:keymember(Module, 1, Os).
 

--- a/src/ejabberd_auth_riak.erl
+++ b/src/ejabberd_auth_riak.erl
@@ -270,7 +270,7 @@ remove_user(User, Server, Password) ->
 
 is_scrammed() ->
     scram ==
-      ejabberd_config:get_local_option({auth_password_format, ?MYNAME},
+      ejabberd_config:get_option({auth_password_format, ?MYNAME},
                                        fun(V) -> V end).
 
 password_to_scram(Password) ->

--- a/src/ejabberd_commands.erl
+++ b/src/ejabberd_commands.erl
@@ -332,7 +332,7 @@ expose_commands(Commands) ->
                       end,
                       Commands),
 
-    case ejabberd_config:add_local_option(commands, [{add_commands, Names}]) of
+    case ejabberd_config:add_option(commands, [{add_commands, Names}]) of
         {aborted, Reason} ->
             {error, Reason};
         {atomic, Result} ->


### PR DESCRIPTION
All functions from ejabberd_config:get_{global|local}_option/X family just calls ejabberd_config:get_option of the same arity. So I believe it's better to use get_option everywhere (in two remaining places).

Should we remove exported get_local_option/get_global_option or at least mark them as deprecated?

Also add_local_option and add_global_option functions also just calls add_option. So they should be treated in the same way.