### PR TITLE
Support SASL GSSAPI authentication

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,7 +101,7 @@ AC_ARG_ENABLE(mssql,
 esac],[db_type=generic])
 
 AC_ARG_ENABLE(all,
-[AC_HELP_STRING([--enable-all], [same as --enable-odbc --enable-mysql --enable-pgsql --enable-sqlite --enable-pam --enable-zlib --enable-riak --enable-redis --enable-elixir --enable-iconv --enable-debug --enable-tools (useful for Dialyzer checks, default: no)])],
+[AC_HELP_STRING([--enable-all], [same as --enable-odbc --enable-mysql --enable-pgsql --enable-sqlite --enable-pam --enable-zlib --enable-riak --enable-redis --enable-elixir --enable-esasl --enable-iconv --enable-debug --enable-tools (useful for Dialyzer checks, default: no)])],
 [case "${enableval}" in
   yes) odbc=true mysql=true pgsql=true sqlite=true pam=true zlib=true riak=true redis=true elixir=true iconv=true debug=true tools=true ;;
   no) odbc=false mysql=false pgsql=false sqlite=false pam=false zlib=false riak=false redis=false elixir=false iconv=false debug=false tools=false ;;
@@ -196,6 +196,14 @@ AC_ARG_ENABLE(iconv,
   *) AC_MSG_ERROR(bad value ${enableval} for --enable-iconv) ;;
 esac],[if test "x$iconv" = "x"; then iconv=true; fi])
 
+AC_ARG_ENABLE(esasl,
+[AC_HELP_STRING([--enable-esasl], [enable esasl support (default: yes)])],
+[case "${enableval}" in
+  yes) esasl=true ;;
+  no)  esasl=false ;;
+  *) AC_MSG_ERROR(bad value ${enableval} for --enable-esasl) ;;
+esac],[if test "x$esasl" = "x"; then esasl=true; fi])
+
 AC_ARG_ENABLE(debug,
 [AC_HELP_STRING([--enable-debug], [enable debug information (default: yes)])],
 [case "${enableval}" in
@@ -253,6 +261,7 @@ AC_SUBST(riak)
 AC_SUBST(redis)
 AC_SUBST(elixir)
 AC_SUBST(iconv)
+AC_SUBST(esasl)
 AC_SUBST(debug)
 AC_SUBST(tools)
 AC_SUBST(latest_deps)

--- a/rebar.config
+++ b/rebar.config
@@ -125,6 +125,7 @@
                    {if_var_false, riak, "(\"riak.*\":_/_)"},
                    {if_var_true, riak, "(\"riak_object\":_/_)"},
                    {if_var_false, zlib, "(\"ezlib\":_/_)"},
+                   {if_var_false, esasl, "(\"esasl\":_/_)"},
                    {if_var_false, http, "(\"lhttpc\":_/_)"},
                    {if_var_false, iconv, "(\"iconv\":_/_)"},
                    {if_var_false, odbc, "(\"odbc\":_/_)"},

--- a/src/cyrsasl.erl
+++ b/src/cyrsasl.erl
@@ -97,6 +97,7 @@ init([]) ->
     cyrsasl_scram:start([]),
     cyrsasl_anonymous:start([]),
     cyrsasl_oauth:start([]),
+    try_start_gssapi(),
     {ok, #state{}}.
 
 handle_call(_Request, _From, State) ->
@@ -145,6 +146,14 @@ register_mechanism(Mechanism, Module, PasswordType) ->
 	  ets:insert(sasl_mechanism,
 		     #sasl_mechanism{mechanism = Mechanism, module = Module,
 			       password_type = PasswordType}).
+
+try_start_gssapi() ->
+    case code:load_file(esasl) of
+	{module, _Module} ->
+	    cyrsasl_gssapi:start([]);
+	{error, What} ->
+	    ?ERROR_MSG("Support for GSSAPI not started because esasl.beam was not found: ~p", [What])
+    end.
 
 check_credentials(_State, Props) ->
     User = proplists:get_value(authzid, Props, <<>>),

--- a/src/cyrsasl_gssapi.erl
+++ b/src/cyrsasl_gssapi.erl
@@ -1,0 +1,152 @@
+%%%----------------------------------------------------------------------
+%%% File    : cyrsasl_gssapi.erl
+%%% Author  : Mikael Magnusson <mikma@users.sourceforge.net>
+%%% Purpose : GSSAPI SASL mechanism
+%%% Created : 1 June 2007 by Mikael Magnusson <mikma@users.sourceforge.net>
+%%%
+%%%
+%%% Copyright (C) 2007  Mikael Magnusson <mikma@users.sourceforge.net>
+%%%
+%%% Permission is hereby granted, free of charge, to any person
+%%% obtaining a copy of this software and associated documentation
+%%% files (the "Software"), to deal in the Software without
+%%% restriction, including without limitation the rights to use, copy,
+%%% modify, merge, publish, distribute, sublicense, and/or sell copies
+%%% of the Software, and to permit persons to whom the Software is
+%%% furnished to do so, subject to the following conditions:
+%%%
+%%% The above copyright notice and this permission notice shall be
+%%% included in all copies or substantial portions of the Software.
+%%%
+%%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+%%% EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+%%% MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+%%% NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+%%% BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+%%% ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+%%% CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+%%% SOFTWARE.
+%%%
+
+%%%
+%%% configuration options:
+%%% sasl_realm: "<Kerberos realm>"
+%%% sasl_keytab: "<Path to Kerberos keytab>"
+%%%
+
+-module(cyrsasl_gssapi).
+-author('mikma@users.sourceforge.net').
+
+-include("ejabberd.hrl").
+-include("logger.hrl").
+
+-export([start/1,
+	 stop/0,
+	 mech_new/4,
+	 mech_step/2,
+         opt_type/1]).
+
+-behaviour(cyrsasl).
+
+-define(SERVER, cyrsasl_gssapi).
+
+-record(state, {sasl,
+		needsmore=true,
+		step=0,
+		host,
+		authid,
+		authzid,
+		authrealm}).
+
+start(_Opts) ->
+    KeyTab = ejabberd_config:get_option(sasl_keytab, fun(F) -> F end),
+    Ccname = "", % default ccname
+    ChildSpec =
+	{?SERVER,
+	 {esasl, start_link, [{local, ?SERVER}, KeyTab, Ccname]},
+	 transient,
+	 1000,
+	 worker,
+	 [esasl]},
+
+    {ok, _Pid} = supervisor:start_child(ejabberd_sup, ChildSpec),
+
+    cyrsasl:register_mechanism(<<"GSSAPI">>, ?MODULE, plain).
+
+stop() ->
+    esasl:stop(?SERVER),
+    supervisor:terminate_child(ejabberd_sup, ?SERVER),
+    supervisor:delete_child(ejabberd_sup, ?SERVER).
+
+mech_new(Host, _GetPassword, _CheckPassword, _CheckPasswordDigest) ->
+    ?DEBUG("Host [~p]~n", [Host]),
+    % FIXME Should we use sasl_realm value from config instead of Host?
+    {ok, Sasl} = esasl:server_start(?SERVER, "GSSAPI", "xmpp", Host),
+    {ok, #state{sasl=Sasl,host=Host}}.
+
+mech_step(State, ClientIn) when is_binary(ClientIn) ->
+    ?DEBUG("ClientIn [~p]~n", [ClientIn]),
+    catch do_step(State, ClientIn).
+
+do_step(#state{needsmore=false}=State, _) ->
+    check_user(State);
+do_step(#state{needsmore=true,sasl=Sasl,step=Step}=State, ClientIn) ->
+    ?DEBUG("ClientIn [~p]~n", [ClientIn]),
+    case esasl:step(Sasl, ClientIn) of
+	{ok, RspAuth} ->
+	    ?DEBUG("ok: ~p~n", [RspAuth]),
+	    {ok, Display_name} = esasl:property_get(Sasl, gssapi_display_name),
+	    {ok, Authzid} = esasl:property_get(Sasl, authzid),
+	    {Authid1, [$@ | Auth_realm1]} =
+		lists:splitwith(fun(E)->E =/= $@ end, Display_name),
+            Authid = list_to_binary(Authid1),
+            Auth_realm = list_to_binary(Auth_realm1),
+            ?DEBUG("Auth info: ~p ~p ~p ~p~n", [Authzid, Authid, Auth_realm, Display_name]),
+            %% TODO: gsasl 1.8.0 / esasl 0.1 always return empty Authzid, so use Authid as Authzid
+	    State1 = State#state{authid=Authid,
+                                 authzid=Authid,
+				 authrealm=Auth_realm},
+	    handle_step_ok(State1, RspAuth);
+	{needsmore, RspAuth} ->
+	    ?DEBUG("needsmore~n", []),
+	    if (Step > 0) and (ClientIn =:= <<>>) and (RspAuth =:= <<>>) ->
+		    {error, <<"not-authorized">>};
+		true ->
+		    {continue, RspAuth,
+		     State#state{step=Step+1}}
+	    end;
+	{error, _} ->
+	    {error, <<"not-authorized">>}
+    end.
+
+handle_step_ok(State, <<>>) ->
+    ?DEBUG("call check_user~n", []),
+    check_user(State);
+handle_step_ok(#state{step=Step}=State, RspAuth) ->
+    ?DEBUG("continue~n", []),
+    {continue, RspAuth, State#state{needsmore=false,step=Step+1}}.
+
+check_user(#state{authid=Authid,authzid=Authzid,
+		  authrealm=Auth_realm,host=Host}) ->
+    Realm = ejabberd_config:get_option({sasl_realm, Host}, fun(F) -> F end),
+
+    if Realm =/= Auth_realm ->
+	    ?DEBUG("bad realm ~p (expected ~p)~n",[Auth_realm, Realm]),
+	    throw({error, <<"not-authorized">>});
+       true ->
+	    ok
+    end,
+    ?DEBUG("checkuser: ~p ~p~n", [Authid, Host]),
+    case ejabberd_auth:is_user_exists(Authid, Host) of
+	false ->
+	    ?DEBUG("bad user ~p~n",[Authid]),
+	    throw({error, <<"not-authorized">>});
+	true ->
+	    ok
+    end,
+
+    ?DEBUG("GSSAPI authenticated ~p ~p~n", [Authid, Authzid]),
+    {ok, [{username, Authid}, {authzid, Authzid}]}.
+
+opt_type(sasl_realm) -> fun iolist_to_binary/1;
+opt_type(_) -> [sasl_realm].

--- a/vars.config.in
+++ b/vars.config.in
@@ -39,6 +39,7 @@
 {riak, @riak@}.
 {redis, @redis@}.
 {elixir, @elixir@}.
+{esasl, @esasl@}.
 {iconv, @iconv@}.
 
 %% Version


### PR DESCRIPTION
This PR is based on patchset floating around in internet since 2009.

Patchset since then was improved by @badlop, Fyodor Kupchik (https://launchpad.net/~ferimy), Konstantin L. Metlov (https://launchpad.net/~metlov), and many others.

This particular version was tested against working Kerberos installation at Fedora Project. Thanks for @bowlofeggs and @puiterwijk for that!

For the record - this is a patchset's breakdown:

* https://github.com/lemenkov/ejabberd/compare/3114f5c...75c1389
* https://github.com/lemenkov/ejabberd/tree/fedora-16.12-gssapi-test

This PR closes bug #1586.
