### PR TITLE
Note how to apply s2s Access Rights in the example

### DIFF
--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -517,6 +517,7 @@ access_rules:
   trusted_network: 
     - allow: loopback
   ## Do not establish S2S connections with bad servers
+  ## If you enable this you also have to uncomment "s2s_access: s2s"
   ## s2s: 
   ##   - deny:
   ##     - ip: "XXX.XXX.XXX.XXX/32"


### PR DESCRIPTION
This bit me in production. Took a long while to debug why my spam policies weren't working, so I thought I'd share the knowledge. A big problem here is that while a lot of the commented-out options are defaults, the referenced line is not.

I'm not sure this is the best way to do this - I'm happy to change the PR if folks want. Other ways to do this that I considered:

1. Uncomment the relevant line by default
2. Make `s2s_access: s2s` the default

Both of those feel magical, though.