### PR TITLE
Fixed wrong parameter values in mod_muc_admin

### DIFF
--- a/src/mod_muc_admin.erl
+++ b/src/mod_muc_admin.erl
@@ -484,7 +484,7 @@ create_room_with_opts(Name1, Host1, ServerHost, CustomRoomOpts) ->
 			  HistorySize,
 			  RoomShaper,
 			  RoomOpts),
-	    mod_muc:register_online_room(Host, Name, Pid),
+	    mod_muc:register_online_room(Name, Host, Pid),
 	    ok;
 	{ok, _} ->
 	    error


### PR DESCRIPTION
I got an unregistered_route error when trying to create a new room with `mod_muc_admin`
I found that the room was created in DB but unable to register it in online room list.
It is because `mod_muc_admin` is passing wrong parameter values to `register_online_room(Room, Host, Pid)` of `mod_muc`