### PR TITLE
Fix for network.target dependency

### DIFF
--- a/ejabberd.service.template
+++ b/ejabberd.service.template
@@ -1,5 +1,6 @@
 [Unit]
 Description=XMPP Server
+Requires=network.target
 After=network.target
 
 [Service]


### PR DESCRIPTION
Since the network.target is actually a requirement, it should be stated in "Requires=" as well. If missed, the system (tested on CentOS7) will attempt to stop the service after networking stops which doesn't work and causes unnecessary delay with a default (typically 90sec) timeout. Please note that the "After=" statement has to be there as well.