### PR TITLE
Fix order of starting supervisors.

### DIFF
--- a/src/ejabberd_sup.erl
+++ b/src/ejabberd_sup.erl
@@ -173,7 +173,7 @@ init([]) ->
 	   RouterMulticast,
 	   Local,
 	   SM,
-	   GenModSupervisor,
 	   ExtMod,
+	   GenModSupervisor,
 	   Auth,
 	   OAuth]}}.


### PR DESCRIPTION
ExtMod should be loaded before GenModSupervisor because ext_mod adds proper paths to ebin from modules (ejabberd-contrib).
Without this change you have to add -pa parameter with path to module's ebin.
