### PR TITLE
Fix routing of groupchat and headline messages

### DIFF
--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -553,7 +553,7 @@ do_route(#presence{to = #jid{lresource = <<"">>} = To} = Packet) ->
       end, get_user_present_resources(LUser, LServer));
 do_route(#message{to = #jid{lresource = <<"">>}, type = T} = Packet) ->
     ?DEBUG("processing message to bare JID:~n~s", [xmpp:pp(Packet)]),
-    if T == chat; T == headline; T == normal; T == groupchat ->
+    if T == chat; T == headline; T == normal ->
 	    route_message(Packet);
        true ->
 	    Lang = xmpp:get_lang(Packet),
@@ -573,7 +573,7 @@ do_route(Packet) ->
 	[] ->
 	    case Packet of
 		#message{type = T} when T == chat; T == normal;
-					T == headline; T == groupchat ->
+					T == headline ->
 		    route_message(Packet);
 		#presence{} ->
 		    ?DEBUG("dropping presence to unavailable resource:~n~s",

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -576,7 +576,7 @@ do_route(Packet) ->
 					T == headline; T == groupchat ->
 		    route_message(Packet);
 		#presence{} ->
-		    ?DEBUG("dropping presence to unavalable resource:~n~s",
+		    ?DEBUG("dropping presence to unavailable resource:~n~s",
 			   [xmpp:pp(Packet)]);
 		_ ->
 		    Lang = xmpp:get_lang(Packet),

--- a/test/offline_tests.erl
+++ b/test/offline_tests.erl
@@ -197,7 +197,9 @@ send_all_master(Config) ->
     		  Acc + 1
     	  end, 0, Deliver),
     lists:foreach(
-      fun(Msg) ->
+      fun(#message{type = headline} = Msg) ->
+	      send(Config, Msg#message{to = BarePeer});
+         (Msg) ->
 	      #message{type = error} = Err =
 		  send_recv(Config, Msg#message{to = BarePeer}),
 	      #stanza_error{reason = 'service-unavailable'} = xmpp:get_error(Err)

--- a/test/offline_tests.erl
+++ b/test/offline_tests.erl
@@ -410,6 +410,7 @@ message_iterator(Config) ->
 	      Els <- AllEls],
     lists:partition(
       fun(#message{type = error}) -> true;
+	 (#message{type = groupchat}) -> false;
 	 (#message{sub_els = [#offline{}|_]}) -> false;
 	 (#message{sub_els = [_, #xevent{id = I}]}) when I /= undefined -> false;
 	 (#message{sub_els = [#xevent{id = I}]}) when I /= undefined -> false;


### PR DESCRIPTION
As per [the spec][1],

* silently drop headline messages sent to the bare JID of an offline user or to the full JID of an unavailable resource, and
*  don't (re)route groupchat messages sent to the bare JID or to unavailable resources, but generate an error instead.  This avoids duplicated MUC messages.

[1]: https://tools.ietf.org/html/rfc6121#section-8