### PR TITLE
lager_crash_log in some cases not run, catch it

### DIFF
--- a/src/ejabberd_logger.erl
+++ b/src/ejabberd_logger.erl
@@ -160,7 +160,7 @@ reopen_log() ->
 
 %% @spec () -> ok
 rotate_log() ->
-    lager_crash_log ! rotate,
+    catch lager_crash_log ! rotate,
     lists:foreach(
       fun({lager_file_backend, File}) ->
               whereis(lager_event) ! {rotate, File};


### PR DESCRIPTION
In function `do_start_for_logger`, the `crash_log` is set to `false`.  In this situation, `lager_crash_log` not runs, catch it.