### PR TITLE
Allow c2s_terminated to know reason as shutdown

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -47,9 +47,9 @@
 	 process_terminated/2, process_info/2]).
 %% API
 -export([get_presence/1, get_subscription/2, get_subscribed/1,
-	 open_session/1, call/3, send/2, close/1, close/2, stop/1,
-	 reply/2, copy_state/2, set_timeout/2, route/2,
-	 host_up/1, host_down/1]).
+	 open_session/1, call/3, send/2, close/1, close/2, 
+	 stop/1, shutdown/1, reply/2, copy_state/2, set_timeout/2, 
+	 route/2, host_up/1, host_down/1]).
 
 -include("ejabberd.hrl").
 -include("xmpp.hrl").
@@ -125,6 +125,11 @@ close(Ref, Reason) ->
 	  (state()) -> no_return().
 stop(Ref) ->
     xmpp_stream_in:stop(Ref).
+
+-spec shutdown(pid()) -> ok.
+shutdown(Ref) ->
+    xmpp_stream_in:(Ref).
+
 
 -spec send(pid(), xmpp_element()) -> ok;
 	  (state(), xmpp_element()) -> state().

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -474,7 +474,7 @@ host_down(Host) ->
     lists:foreach(
       fun(#session{sid = {_, Pid}}) when node(Pid) == node() ->
 	      ejabberd_c2s:send(Pid, xmpp:serr_system_shutdown()),
-	      ejabberd_c2s:stop(Pid);
+	      ejabberd_c2s:shutdown(Pid);
 	 (_) ->
 	      ok
       end, get_sessions(Mod, Host)),

--- a/src/xmpp_stream_in.erl
+++ b/src/xmpp_stream_in.erl
@@ -27,7 +27,7 @@
 -protocol({xep, 114, '1.6'}).
 
 %% API
--export([start/3, start_link/3, call/3, cast/2, reply/2, stop/1,
+-export([start/3, start_link/3, call/3, cast/2, reply/2, stop/1, shutdown/1,
 	 send/2, close/1, close/2, send_error/3, establish/1,
 	 get_transport/1, change_shaper/2, set_timeout/2, format_error/1]).
 
@@ -129,6 +129,10 @@ cast(Ref, Msg) ->
 
 reply(Ref, Reply) ->
     ?GEN_SERVER:reply(Ref, Reply).
+
+-spec shutdown(pid()) -> ok.
+shutdown(Pid) when is_pid(Pid) ->
+    cast(Pid, shutdown).
 
 -spec stop(pid()) -> ok;
 	  (state()) -> no_return().
@@ -268,6 +272,8 @@ handle_cast({send, Pkt}, State) ->
     noreply(send_pkt(State, Pkt));
 handle_cast(stop, State) ->
     {stop, normal, State};
+handle_cast(shutdown, State) ->
+    {stop, shutdown, State};
 handle_cast({close, Reason}, State) ->
     State1 = close_socket(State),
     noreply(


### PR DESCRIPTION
We are open to contributions for ejabberd, as GitHub pull requests (PR).
Here are a few points to consider before submitting your PR. (You can
remove the whole text after reading.)

1. Does this PR address an issue? Please reference it in the PR
   description.

2. Have you properly described the proposed change?

3. Please make sure the change is atomic and does only touch the needed
   modules. If you have other changes/fixes to provide, please submit
   them as separate PRs.

4. If your change or new feature involves storage backends, did you make
   sure your change works with all backends?

5. Do you provide tests? How can we check the behavior of the code?

6. Did you consider documentation changes in the
   processone/docs.ejabberd.im repository?
