### PR TITLE
Fix version to be SemVer compatible

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Ejabberd.Mixfile do
 
   def project do
     [app: :ejabberd,
-     version: "17.03.0",
+     version: "17.3.0",
      description: description,
      elixir: "~> 1.3",
      elixirc_paths: ["lib"],


### PR DESCRIPTION
`mix.compile` is currently failing because of following error:

```
could not compile dependency :ejabberd, "mix compile" failed. You can recompile this dependency with "mix deps.compile ejabberd", update it with "mix deps.update ejabberd" or clean it with "mix deps.clean ejabberd"
==> fetchat
** (Mix) Expected :version to be a SemVer version, got: "17.03.0"
```

Here's the Version.parse implementation which is used to check version: https://github.com/elixir-lang/elixir/blob/c655ac091a1b760ea99abe4f0036accb012877de/lib/elixir/lib/version.ex#L256-L267

Doing manual check in interactive console:

```
iex(4)> Version.parse("17.03.0")
:error
iex(5)> Version.parse("17.3.0")
{:ok, #Version<17.3.0>}
```

After changing version from `17.03.0` to `17.3.0` compilation is successful.
