### PR TITLE
fixing exec_iex bug with proper --name arguement

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -115,7 +115,7 @@ exec_erl()
 exec_iex()
 {
     NODE=$1; shift
-    exec_cmd $IEX ${S:--}name $NODE --erl "$ERLANG_OPTS" "$@"
+    exec_cmd $IEX ${S:---}name $NODE --erl "$ERLANG_OPTS" "$@"
 }
 
 # usage


### PR DESCRIPTION
https://github.com/processone/ejabberd/issues/1765 Fix

Fixing `./ejabberctl iexlive` not working because of an incorrectly formed `-name` argument which should have been `--name`

Build from source and then `./ejabberctl iexlive` works