### PR TITLE
Fix mod_muc_admin:set_room_affiliation

### DIFF
--- a/src/mod_muc_admin.erl
+++ b/src/mod_muc_admin.erl
@@ -1012,7 +1012,7 @@ set_room_affiliation(Name, Service, JID, AffiliationString) ->
     case mod_muc:find_online_room(Name, Service) of
 	{ok, Pid} ->
 	    %% Get the PID for the online room so we can get the state of the room
-	    {ok, StateData} = gen_fsm:sync_send_all_state_event(Pid, {process_item_change, {jid:decode(JID), affiliation, Affiliation, <<"">>}, <<"">>}),
+	    {ok, StateData} = gen_fsm:sync_send_all_state_event(Pid, {process_item_change, {jid:decode(JID), affiliation, Affiliation, <<"">>}, undefined}),
 	    mod_muc:store_room(StateData#state.server_host, StateData#state.host, StateData#state.room, make_opts(StateData)),
 	    ok;
 	error ->

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2608,7 +2608,7 @@ process_item_change(UJID) ->
 -type admin_action() :: {jid(), affiliation | role,
 			 affiliation() | role(), binary()}.
 
--spec process_item_change(admin_action(), state(), jid()) -> state() | {error, stanza_error()}.
+-spec process_item_change(admin_action(), state(), undefined | jid()) -> state() | {error, stanza_error()}.
 process_item_change(Item, SD, UJID) ->
     try case Item of
 	    {JID, affiliation, owner, _} when JID#jid.luser == <<"">> ->
@@ -2658,8 +2658,15 @@ process_item_change(Item, SD, UJID) ->
 		SD1
 	end
     catch E:R ->
-	    ?ERROR_MSG("failed to set item ~p from ~s: ~p",
-		       [Item, jid:encode(UJID),
+		FromSuffix = case UJID of
+			#jid{} ->
+				JidString = jid:encode(UJID),
+				<<" from ", JidString/binary>>;
+			undefined ->
+				<<"">>
+		end,
+		?ERROR_MSG("failed to set item ~p~s: ~p",
+		       [Item, FromSuffix,
 			{E, {R, erlang:get_stacktrace()}}]),
 	    {error, xmpp:err_internal_server_error()}
     end.


### PR DESCRIPTION
The following command fails in 17.04:

```
ejabberdctl set_room_affiliation my-room conference.my-domain user-id@my-domain none
```

The root cause is that `send_kickban_presence1/6` in `mod_muc_room` expects `undefined | jid()` as it’s first parameter (`UJID`). However, `mod_muc_admin` passes an empty binary string (last element in tuple):

```
gen_fsm:sync_send_all_state_event(Pid,
    {process_item_change, {jid:decode(JID), affiliation, Affiliation, <<"">>}, <<"">>})
```

Thus, `jid:tolower(UJID)` in `mod_muc_room:send_kickban_presence1/6` fails.

In addition, the root cause is hidden by a bug in the catch block of `process_item_change/3` where `jid:encode(UJID)` is called with the empty binary string.

This pull request changes `process_item_change/3` to also work with `undefined` as `UJID` and passes `undefined` from `mod_muc_admin`.

Unfortunately, I couldn’t find a unit test for `process_item_change`. I’d be happy to contribute one, but didn’t know where to start or where to put it.