### PR TITLE
Adding allow_local_users config option to mod_block_strangers

### DIFF
--- a/src/mod_block_strangers.erl
+++ b/src/mod_block_strangers.erl
@@ -58,9 +58,11 @@ filter_packet({#message{} = Msg, State} = Acc) ->
     LFrom = jid:tolower(From),
     LBFrom = jid:remove_resource(LFrom),
     #{pres_a := PresA, jid := JID, lserver := LServer} = State,
+    AllowLocalUsers = gen_mod:get_module_opt(LServer, ?MODULE, allow_local_users, true),
+
     case (Msg#message.body == [] andalso
           Msg#message.subject == [])
-        orelse ejabberd_router:is_my_route(From#jid.lserver)
+        orelse (AllowLocalUsers andalso ejabberd_router:is_my_route(From#jid.lserver))
         orelse (?SETS):is_element(LFrom, PresA)
         orelse (?SETS):is_element(LBFrom, PresA)
         orelse sets_bare_member(LBFrom, PresA) of


### PR DESCRIPTION
This is addressing https://github.com/processone/ejabberd/issues/1804
I wasn't sure what to call the option, so feel free to pick something new.
I default it to true to maintain the old behavior by default.
I could also update the documentation on the module, if someone shows me how to do that.
