### PR TITLE
fixing mix compile when using ejabberd as an elixir dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Ejabberd.Mixfile do
      compile_path: ".",
      compilers: [:asn1] ++ Mix.compilers,
      erlc_options: erlc_options(),
+     erlc_include_path: ["include", "deps/p1_utils/include", "deps/xmpp/include", "deps/fast_xml/include"],
      erlc_paths: ["asn1", "src"],
      # Elixir tests are starting the part of ejabberd they need
      aliases: [test: "test --no-start"],
@@ -33,9 +34,7 @@ defmodule Ejabberd.Mixfile do
   end
 
   defp erlc_options do
-    # Use our own includes + includes from all dependencies
-    includes = ["include"] ++ deps_include(["fast_xml", "xmpp", "p1_utils"])
-    [:debug_info, {:d, :ELIXIR_ENABLED}] ++ Enum.map(includes, fn(path) -> {:i, path} end)
+    [:debug_info, :return_errors, {:d, :ELIXIR_ENABLED}]
   end
 
   defp deps do

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Ejabberd.Mixfile do
      elixirc_paths: ["lib"],
      compile_path: ".",
      compilers: [:asn1] ++ Mix.compilers,
-     erlc_options: erlc_options(),
+     erlc_options: [:debug_info, :return_errors, {:d, :ELIXIR_ENABLED}],
      erlc_include_path: ["include", "deps/p1_utils/include", "deps/xmpp/include", "deps/fast_xml/include"],
      erlc_paths: ["asn1", "src"],
      # Elixir tests are starting the part of ejabberd they need
@@ -31,10 +31,6 @@ defmodule Ejabberd.Mixfile do
                              :fast_tls, :stringprep, :fast_xml, :xmpp,
                              :stun, :fast_yaml, :esip, :jiffy, :p1_oauth2]
                          ++ cond_apps()]
-  end
-
-  defp erlc_options do
-    [:debug_info, :return_errors, {:d, :ELIXIR_ENABLED}]
   end
 
   defp deps do

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cache_tab": {:hex, :cache_tab, "1.0.8", "eac8923f0f20c35e630317790c4d4c2629c5bc792753fa48eb5391bd39c80245", [:rebar3], [{:p1_utils, "1.0.9", [hex: :p1_utils, optional: false]}]},
+%{"cache_tab": {:hex, :cache_tab, "1.0.9", "07c82d363eb3660c9d4e178045b285d6fa747ebe177b40e00a6fc2b8e738e084", [:rebar3], [{:p1_utils, "1.0.9", [hex: :p1_utils, optional: false]}]},
   "distillery": {:hex, :distillery, "1.4.0", "d633cd322c8efa0428082b00b7f902daf8caa166d45f9022bbc19a896d2e1e56", [:mix], []},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
   "esip": {:hex, :esip, "1.0.12", "e0505afe74bb362b0ea486e2a64b3c1934b1eb541a7b3e990b23045e4bdc07d4", [:rebar3], [{:fast_tls, "1.0.12", [hex: :fast_tls, optional: false]}, {:p1_utils, "1.0.9", [hex: :p1_utils, optional: false]}, {:stun, "1.0.11", [hex: :stun, optional: false]}]},


### PR DESCRIPTION
`mix deps.compile ejabberd` was failing prior to this change. I tested it with the following mix file and doing `mix do deps.get, compile` from within the mix project:

```elixir
defmodule Ejapp.Mixfile do
  use Mix.Project

  def project do
    [app: :ejapp,
     version: "0.1.0",
     elixir: "~> 1.4",
     build_embedded: Mix.env == :prod,
     start_permanent: Mix.env == :prod,
     deps: deps()]
  end

  def application do
    [extra_applications: [:logger, :ejabberd]]
  end

  defp deps do
    [{:ejabberd, git: "https://github.com/IRog/ejabberd.git", branch: "mixCompile"}]
  end
end

```

Without this change using ejabberd as an Elixir mix dependency seems to be broken.