### PR TITLE
Add integration test for set_room_affiliation

### DIFF
--- a/test/ejabberd_SUITE_data/ejabberd.yml
+++ b/test/ejabberd_SUITE_data/ejabberd.yml
@@ -450,6 +450,8 @@ listen:
     port: @@web_port@@
     module: ejabberd_http
     captcha: true
+    request_handlers:
+      "/api": mod_http_api
   - 
     port: @@component_port@@
     module: ejabberd_service
@@ -466,6 +468,7 @@ modules:
   mod_proxy65: []
   mod_legacy: []
   mod_muc: []
+  mod_muc_admin: []
   mod_register: 
     welcome_message: 
       subject: "Welcome!"
@@ -488,3 +491,8 @@ outgoing_s2s_port: @@s2s_port@@
 shaper: 
   fast: 50000
   normal: 10000
+
+api_permissions:
+  "public commands":
+    who: all
+    what: "*"


### PR DESCRIPTION
Add integration test for `mod_muc_admin:set_room_affiliation` as discussed in #1793.

The test creates a room, calls `set_room_affiliation` via the HTTP API, and checks that it receives a message announcing the new member.