### PR TITLE
fix some of the errors in the new ejabberdctl version

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -21,7 +21,7 @@ if [ -n "$INSTALLUSER" ] ; then
     if [ $(id -g) -eq $(id -g $INSTALLUSER || echo -1) ] ; then
         EXEC_CMD="as_current_user"
     else
-        id -Gn | grep -q wheel && EXEC_CMD="as_install_user"
+        id -un | grep -q root && EXEC_CMD="as_install_user"
     fi
 else
     EXEC_CMD="as_current_user"
@@ -103,7 +103,9 @@ export ERL_LIBS
 exec_cmd()
 {
     case $EXEC_CMD in
-        as_install_user) su -c '"$0" $@"' "$INSTALLUSER" -- "$@" ;;
+        as_install_user) 
+            cd ${SPOOL_DIR}
+            su -c '"$0" "$@"' "$INSTALLUSER" -- "$@" ;;
         as_current_user) "$@" ;;
     esac
 }


### PR DESCRIPTION
ejabberdctl was broken in ejabberd 17.06 or 17.07 if executed as root user.

The change in line 24 fixes the check for the user root (the if-branch of that statement (line 21/22) tests for the user $INSTALLUSER). 

The second change (line 106ff) cd's to SPOOL_DIR (otherwise ejabberdctl prints error log statements) and fixes a quotation issue (the original has a missing quote before `$@"`.