### PR TITLE
Fix ERLANG_OPTS when setting INET_DIST_INTERFACE

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -69,7 +69,7 @@ fi
 if [ "$INET_DIST_INTERFACE" != "" ] ; then
     INET_DIST_INTERFACE2=$("$ERL" -noshell -eval 'case inet:parse_address("'$INET_DIST_INTERFACE'") of {ok,IP} -> io:format("~p",[IP]); _ -> ok end.' -s erlang halt)
     if [ "$INET_DIST_INTERFACE2" != "" ] ; then
-        ERLANG_OPTS="$ERLANG_OPTS -kernel inet_dist_use_interface \"$INET_DIST_INTERFACE2\""
+        ERLANG_OPTS="$ERLANG_OPTS -kernel inet_dist_use_interface $INET_DIST_INTERFACE2"
     fi
 fi
 ERL_LIBS={{libdir}}


### PR DESCRIPTION
When specifying an IP address in INET_DIST_INTERFACE, `ejabberdctl` breaks due to excessive use of quote characters, as quote characters are being passed as command-line arguments by shell:

    λ sudo -u ejabberd -H sh -x ejabberdctl --node ejabberd@chateau.d.if status
    + POLL=true
    + SMP=auto
    + ERL_MAX_PORTS=32000
    + ERL_PROCESSES=250000
    + ERL_MAX_ETS_TABLES=1400
    + FIREWALL_WINDOW=''
    + ERLANG_NODE=ejabberd@localhost
    + ERL=/usr/local/bin/erl
    + IEX=/usr/local/bin/iex
    + EPMD=/usr/local/bin/epmd
    + INSTALLUSER=''
    + EXEC_CMD=false
    + [ -n '' ]
    + EXEC_CMD=as_current_user
    + [ as_current_user '=' false ]
    + ERLANG_NODE_ARG=ejabberd@chateau.d.if
    + shift
    + shift
    + break
    + : /usr/local/etc/ejabberd
    + : /var/log/ejabberd
    + : /var/spool/ejabberd
    + : /usr/local/etc/ejabberd/ejabberd.yml
    + : /usr/local/etc/ejabberd/ejabberdctl.cfg
    + [ -f /usr/local/etc/ejabberd/ejabberdctl.cfg ]
    + . /usr/local/etc/ejabberd/ejabberdctl.cfg
    + FIREWALL_WINDOW=4200-4210
    + INET_DIST_INTERFACE=172.16.0.2
    + [ ejabberd@chateau.d.if '!=' '' ]
    + ERLANG_NODE=ejabberd@chateau.d.if
    + [ ejabberd@chateau.d.if '=' ejabberd@chateau.d ]
    + : /usr/local/share/doc/ejabberd
    + : /var/log/ejabberd/ejabberd.log
    + ERLANG_OPTS='+K true -smp auto +P 250000 '
    + [ 4200-4210 '!=' '' ]
    + ERLANG_OPTS='+K true -smp auto +P 250000  -kernel         inet_dist_listen_min 4200         inet_dist_listen_max 4210'
    + [ 172.16.0.2 '!=' '' ]
    + /usr/local/bin/erl -noshell -eval 'case inet:parse_address("172.16.0.2") of {ok,IP} -> io:format("~p",[IP]); _ -> ok end.' -s erlang halt
    + INET_DIST_INTERFACE2={172,16,0,2}
    + [ {172,16,0,2} '!=' '' ]
    + ERLANG_OPTS='+K true -smp auto +P 250000  -kernel         inet_dist_listen_min 4200         inet_dist_listen_max 4210 -kernel inet_dist_use_interface "{172,16,0,2}"'
    + ERL_LIBS=/usr/local/lib/erlang/lib/ejabberd-17.07
    + ERL_LIBS=/usr/local/lib/erlang/lib/ejabberd-17.07:/usr/local/lib/erlang/lib/ejabberd-17.07/lib
    + date +%Y%m%d-%H%M%S
    + ERL_CRASH_DUMP=/var/log/ejabberd/erl_crash_20170715-164125.dump
    + ERL_INETRC=/usr/local/etc/ejabberd/inetrc
    + sed '/^log_rate_limit/!d;s/:[ \t]*\([0-9]*\).*/ \1/;s/^/ /' /usr/local/etc/ejabberd/ejabberd.yml
    + sed '/^log_rotate_size/!d;s/:[ \t]*\([0-9]*\).*/ \1/;s/^/ /' /usr/local/etc/ejabberd/ejabberd.yml
    + sed '/^log_rotate_count/!d;s/:[ \t]*\([0-9]*\).*/ \1/;s/^/ /' /usr/local/etc/ejabberd/ejabberd.yml
    + sed '/^log_rotate_date/!d;s/:[ \t]*\(.[^ ]*\).*/ \1/;s/^/ /' /usr/local/etc/ejabberd/ejabberd.yml
    + EJABBERD_OPTS=' log_rate_limit 100 log_rotate_size 10485760 log_rotate_count 1 log_rotate_date ""'
    + [ -n ' log_rate_limit 100 log_rotate_size 10485760 log_rotate_count 1 log_rotate_date ""' ]
    + EJABBERD_OPTS='-ejabberd  log_rate_limit 100 log_rotate_size 10485760 log_rotate_count 1 log_rotate_date ""'
    + EJABBERD_OPTS='-mnesia dir "/var/spool/ejabberd"  -ejabberd  log_rate_limit 100 log_rotate_size 10485760 log_rotate_count 1 log_rotate_date "" -s ejabberd'
    + export EJABBERD_CONFIG_PATH
    + export EJABBERD_LOG_PATH
    + export EJABBERD_DOC_PATH
    + export EJABBERD_PID_PATH
    + export ERL_CRASH_DUMP
    + export ERL_EPMD_ADDRESS
    + export ERL_INETRC
    + export ERL_MAX_PORTS
    + export ERL_MAX_ETS_TABLES
    + export CONTRIB_MODULES_PATH
    + export CONTRIB_MODULES_CONF_DIR
    + export ERL_LIBS
    + uid ctl
    + uuidgen
    + uuid=5764ad31-694e-11e7-84a1-408d5c4a96e3
    + [ -z 5764ad31-694e-11e7-84a1-408d5c4a96e3 -a -f /proc/sys/kernel/random/uuid ]
    + [ -z 5764ad31-694e-11e7-84a1-408d5c4a96e3 ]
    + uuid=5764ad31
    + [ 1 -eq 0 ]
    + [ 1 -eq 1 ]
    + echo 5764ad31-ctl-ejabberd@chateau.d.if
    + [ 1 -eq 2 ]
    + exec_erl 5764ad31-ctl-ejabberd@chateau.d.if -hidden -noinput -s ejabberd_ctl -extra ejabberd@chateau.d.if status
    + NODE=5764ad31-ctl-ejabberd@chateau.d.if
    + shift
    + exec_cmd /usr/local/bin/erl -name 5764ad31-ctl-ejabberd@chateau.d.if +K true -smp auto +P 250000 -kernel inet_dist_listen_min 4200 inet_dist_listen_max 4210 -kernel inet_dist_use_interface '"{172,16,0,2}"' -hidden -noinput -s ejabberd_ctl -extra ejabberd@chateau.d.if status
    + /usr/local/bin/erl -name 5764ad31-ctl-ejabberd@chateau.d.if +K true -smp auto +P 250000 -kernel inet_dist_listen_min 4200 inet_dist_listen_max 4210 -kernel inet_dist_use_interface '"{172,16,0,2}"' -hidden -noinput -s ejabberd_ctl -extra ejabberd@chateau.d.if status
    Protocol 'inet_tcp': register/listen error: badarg
    + result=1
    + :
    + exit 1

The mentioned diff fixes the issue. OS in the question is `FreeBSD 11.0-RELEASE` (amd64), but I think it's reproducible on GNU/Linux as well.

HTH