### PR TITLE
Fix old route record in mnesia's route table haven't been remove when restarting in some cases (#1184)

### DIFF
--- a/src/ejabberd_router_mnesia.erl
+++ b/src/ejabberd_router_mnesia.erl
@@ -149,7 +149,7 @@ init([]) ->
     lists:foreach(
       fun (Pid) -> erlang:monitor(process, Pid) end,
       mnesia:dirty_select(route,
-			  [{{route, '_', '$1', '_'}, [], ['$1']}])),
+			  [{#route{pid = '$1', _ = '_'}, [], ['$1']}])),
     {ok, #state{}}.
 
 handle_call(_Request, _From, State) ->


### PR DESCRIPTION
This PR fixes issue #1184. Process monitoring setup at router module startup does not work correctly now. There is mnesia query issue in init function which causes empty set as a result. This bug was created with commit https://github.com/processone/ejabberd/commit/357e48fb6b60b72f050a438164a1d5590caca8f0 where where number of columns in route table has changed.
