### PR TITLE
ejabberd_c2s: Fix priority of 'certfile' option

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -297,14 +297,19 @@ process_terminated(State, _Reason) ->
 %%%===================================================================
 %%% xmpp_stream_in callbacks
 %%%===================================================================
-tls_options(#{lserver := LServer, tls_options := DefaultOpts}) ->
-    TLSOpts1 = case ejabberd_config:get_option(
-		      {c2s_certfile, LServer},
-		      ejabberd_config:get_option(
-			{domain_certfile, LServer})) of
-		   undefined -> DefaultOpts;
-		   CertFile -> lists:keystore(certfile, 1, DefaultOpts,
-					      {certfile, CertFile})
+tls_options(#{lserver := LServer, tls_options := DefaultOpts,
+	      stream_encrypted := Encrypted}) ->
+    TLSOpts1 = case {Encrypted, proplists:get_value(certfile, DefaultOpts)} of
+		   {true, CertFile} when CertFile /= undefined -> DefaultOpts;
+		   {_, _} ->
+		       case ejabberd_config:get_option(
+			      {c2s_certfile, LServer},
+			      ejabberd_config:get_option(
+				{domain_certfile, LServer})) of
+			   undefined -> DefaultOpts;
+			   CertFile -> lists:keystore(certfile, 1, DefaultOpts,
+						      {certfile, CertFile})
+		       end
 	       end,
     TLSOpts2 = case ejabberd_config:get_option(
                       {c2s_ciphers, LServer}) of


### PR DESCRIPTION
Use the `certfile` listener option rather than a `domain_certfile` for `ejabberd_c2s` listeners that have `tls: true` configured.  A `domain_certfile` should only be preferred for STARTTLS connections.