### PR TITLE
Let 'domain_certfile' take higher precedence

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -303,9 +303,9 @@ tls_options(#{lserver := LServer, tls_options := DefaultOpts,
 		   {true, CertFile} when CertFile /= undefined -> DefaultOpts;
 		   {_, _} ->
 		       case ejabberd_config:get_option(
-			      {c2s_certfile, LServer},
+			      {domain_certfile, LServer},
 			      ejabberd_config:get_option(
-				{domain_certfile, LServer})) of
+				{c2s_certfile, LServer})) of
 			   undefined -> DefaultOpts;
 			   CertFile -> lists:keystore(certfile, 1, DefaultOpts,
 						      {certfile, CertFile})

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -199,9 +199,9 @@ dirty_get_connections() ->
 -spec tls_options(binary(), [proplists:property()]) -> [proplists:property()].
 tls_options(LServer, DefaultOpts) ->
     TLSOpts1 = case ejabberd_config:get_option(
-		      {s2s_certfile, LServer},
+		      {domain_certfile, LServer},
 		      ejabberd_config:get_option(
-			{domain_certfile, LServer})) of
+			{s2s_certfile, LServer})) of
 		   undefined -> DefaultOpts;
 		   CertFile -> lists:keystore(certfile, 1, DefaultOpts,
 					      {certfile, CertFile})


### PR DESCRIPTION
If a `domain_certfile` is specified, use that instead of the `s2s_certfile` (or `c2s_certfile`).  This is how ejabberd behaved [until][1] version 17.01.

[1]: https://github.com/processone/ejabberd/commit/309bdfbe285c82726d2ce1406fc26c19a6b37bd9