### PR TITLE
Xep 0198 s2s

### DIFF
--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -427,7 +427,7 @@ start_connection(From, To, Opts) ->
 					  MaxS2SConnectionsNumber,
 					  MaxS2SConnectionsNumberPerNode, Opts);
 	     true ->
-		 %% We choose a connexion from the pool of opened ones.
+		 %% We choose a connection from the pool of opened ones.
 		 {ok, choose_connection(From, L)}
 	  end
     end.

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -176,9 +176,7 @@ handle_stream_start(_StreamStart, #{lserver := LServer} = State) ->
 	    send(State, xmpp:serr_host_unknown());
 	true ->
 	    ServerHost = ejabberd_router:host_of_route(LServer),
-	    UniqueId = p1_time_compat:unique_integer(),
-	    State1 = State#{server_host => ServerHost,
-	    				unique_id => UniqueId}, % for xep-0198 s2s
+	    State1 = State#{server_host => ServerHost}, 
 	    ejabberd_hooks:run_fold(s2s_in_stream_started, ServerHost, State1, [])
     end.
 
@@ -187,7 +185,8 @@ handle_stream_end(Reason, #{server_host := LServer} = State) ->
     ejabberd_hooks:run_fold(s2s_in_closed, LServer, State1, [Reason]).
     
 handle_stream_established(State) ->
-    set_idle_timeout(State#{established => true}).
+	UniqueId = p1_time_compat:unique_integer(), % for xep-0198 s2s
+    set_idle_timeout(State#{established => true, unique_id => UniqueId}).
 
 handle_auth_success(RServer, Mech, _AuthModule,
 		    #{sockmod := SockMod,

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -321,7 +321,7 @@ terminate(Reason, #{server := LServer, server_host := ServerHost,
     end,
     bounce_queue(State1),
     bounce_message_queue(State1),
-    ejabberd_hooks:run_fold(s2s_out_terminate, ServerHost, State, [Reason]).
+    ejabberd_hooks:run_fold(s2s_out_terminate, ServerHost, State1, [Reason]).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/src/mod_stream_mgmt.erl
+++ b/src/mod_stream_mgmt.erl
@@ -36,8 +36,8 @@
 %% adjust pending session timeout
 -export([get_resume_timeout/1, set_resume_timeout/2]).
 %% API (used by mod_stream_mgmt_s2s)
--export ([mgmt_queue_drop/2, mgmt_queue_add/2, check_queue_length/1,
-	  cancel_ack_timer/1, update_num_stanzas_in/2]).
+-export ([mgmt_queue_drop/2, mgmt_queue_add/2, cancel_ack_timer/1,
+	  update_num_stanzas_in/2]).
 
 -include("xmpp.hrl").
 -include("logger.hrl").

--- a/src/mod_stream_mgmt.erl
+++ b/src/mod_stream_mgmt.erl
@@ -35,6 +35,9 @@
 	 c2s_handle_recv/3]).
 %% adjust pending session timeout
 -export([get_resume_timeout/1, set_resume_timeout/2]).
+%% API (used by mod_stream_mgmt_s2s)
+-export ([mgmt_queue_drop/2, mgmt_queue_add/2, check_queue_length/1,
+	  cancel_ack_timer/1, update_num_stanzas_in/2]).
 
 -include("xmpp.hrl").
 -include("logger.hrl").

--- a/src/mod_stream_mgmt_s2s.erl
+++ b/src/mod_stream_mgmt_s2s.erl
@@ -682,14 +682,12 @@ check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
   when H > NumStanzasOut ->
     ?DEBUG("~s acknowledged ~B stanzas," 
            "but only ~B were sent ", [RServer, H, NumStanzasOut]),
-    State;
-    % mod_stream_mgmt:mgmt_queue_drop(State#{mgmt_stanzas_out => H}, NumStanzasOut);
+    mod_stream_mgmt:mgmt_queue_drop(State#{mgmt_stanzas_out => H}, NumStanzasOut);
 check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
                     remote_server := RServer} = State, H) ->
     ?DEBUG("~s acknowledged ~B of ~B "
            "stanzas", [RServer, H, NumStanzasOut]),
-    State.
-    % mod_stream_mgmt:mgmt_queue_drop(State, H).
+    mod_stream_mgmt:mgmt_queue_drop(State, H).
 
 -spec add_resent_delay_info(state(), stanza(), erlang:timestamp()) -> stanza().
 add_resent_delay_info(#{server_host := LServer}, El, Time) ->
@@ -717,7 +715,7 @@ resend_rack(#{mgmt_ack_timer := _,
               mgmt_queue := Queue,
               mgmt_stanzas_out := NumStanzasOut,
               mgmt_stanzas_req := NumStanzasReq} = State) ->
-    State1 = State, %mod_stream_mgmt:cancel_ack_timer(State),
+    State1 = mod_stream_mgmt:cancel_ack_timer(State),
     case NumStanzasReq < NumStanzasOut andalso not p1_queue:is_empty(Queue) of
         true -> send_rack(State1);
         false -> State1

--- a/src/mod_stream_mgmt_s2s.erl
+++ b/src/mod_stream_mgmt_s2s.erl
@@ -725,7 +725,6 @@ send(#{mod := Mod} = State, Pkt) ->
     Mod:send(State, Pkt).
 
 send_rack(#{mgmt_ack_timer := _} = State) ->
-    ?INFO_MSG("can't send request", []),
     State;
 send_rack(#{mgmt_xmlns := Xmlns,
             mgmt_stanzas_out := NumStanzasOut,

--- a/src/mod_stream_mgmt_s2s.erl
+++ b/src/mod_stream_mgmt_s2s.erl
@@ -5,11 +5,16 @@
 
 %% gen_mod API
 -export([start/2, stop/1, reload/3, depends/2, mod_opt_type/1]).
-%% hooks
+%% client part hooks
 -export([s2s_out_stream_init/2, s2s_out_stream_features/2,
-         s2s_out_packet/2, s2s_out_handle_recv/3, s2s_out_handle_send/3,
-         s2s_out_handle_info/2, s2s_out_closed/2,
-         s2s_out_terminate/2, s2s_out_established/1]).
+         s2s_out_packet/2, s2s_out_established/1]).
+        % s2s_out_packet/2, s2s_out_handle_recv/3, s2s_out_handle_send/3,
+         %s2s_out_handle_info/2, s2s_out_closed/2,
+        % s2s_out_terminate/2]). % , s2s_out_established/1]).
+%% server part hooks
+-export([s2s_in_post_auth_features/2, s2s_in_init/2,
+         s2s_in_authenticated_packet/2]).
+
 
 -include("xmpp.hrl").
 -include("logger.hrl").
@@ -17,12 +22,14 @@
 
 % replace ?
 -define(is_sm_packet(Pkt),
+        is_record(Pkt, sm_enable) or
         is_record(Pkt, sm_enabled) or
+        is_record(Pkt, sm_resume) or
         is_record(Pkt, sm_resumed) or
         is_record(Pkt, sm_a) or
         is_record(Pkt, sm_r)).
 
--type state() :: ejabberd_s2s_out:state().
+-type state() :: ejabberd_s2s_out:state(). % | ejabberd_s2s_in:state().
 
 %%%=============================================================================
 %%% API
@@ -32,38 +39,50 @@ start(Host, _Opts) ->
     ejabberd_hooks:add(s2s_out_authenticated_features, 
                        Host, ?MODULE, s2s_out_stream_features, 50),
     ejabberd_hooks:add(s2s_out_packet, Host, ?MODULE, s2s_out_packet, 5),
-    ejabberd_hooks:add(s2s_out_handle_recv, 
-                       Host, ?MODULE, s2s_out_handle_recv, 50),
-    ejabberd_hooks:add(s2s_out_handle_send, 
-                       Host, ?MODULE, s2s_out_handle_send, 50),
-    ejabberd_hooks:add(s2s_out_handle_info,
-                       Host, ?MODULE, s2s_out_handle_info, 50),
-    ejabberd_hooks:add(s2s_out_closed,
-                       Host, ?MODULE, s2s_out_closed, 50),
-    ejabberd_hooks:add(s2s_out_terminate,
-                       Host, ?MODULE, s2s_out_terminate, 50),
+    % ejabberd_hooks:add(s2s_out_handle_recv, 
+    %                    Host, ?MODULE, s2s_out_handle_recv, 50),
+    % ejabberd_hooks:add(s2s_out_handle_send, 
+    %                    Host, ?MODULE, s2s_out_handle_send, 50),
+    % ejabberd_hooks:add(s2s_out_handle_info,
+    %                    Host, ?MODULE, s2s_out_handle_info, 50),
+    % ejabberd_hooks:add(s2s_out_closed,
+    %                    Host, ?MODULE, s2s_out_closed, 50),
+    % ejabberd_hooks:add(s2s_out_terminate,
+    %                    Host, ?MODULE, s2s_out_terminate, 50),
     % delete after implementation of server part
     ejabberd_hooks:add(s2s_out_established,
-                       Host, ?MODULE, s2s_out_established, 50).
+                       Host, ?MODULE, s2s_out_established, 50),
+    %% server part
+    ejabberd_hooks:add(s2s_in_post_auth_features,
+                       Host, ?MODULE, s2s_in_post_auth_features, 50),
+    ejabberd_hooks:add(s2s_in_init, ?MODULE, s2s_in_init, 50),
+    ejabberd_hooks:add(s2s_in_authenticated_packet,
+                       Host, ?MODULE, s2s_in_authenticated_packet, 50).
 
 stop(Host) ->
     ejabberd_hooks:delete(s2s_out_init, Host, ?MODULE, s2s_out_stream_init, 50),
     ejabberd_hooks:delete(s2s_out_authenticated_features, 
                           Host, ?MODULE, s2s_out_stream_features, 50),
     ejabberd_hooks:delete(s2s_out_packet, Host, ?MODULE, s2s_out_packet, 50),
-    ejabberd_hooks:delete(s2s_out_handle_recv, 
-                          Host, ?MODULE, s2s_out_handle_recv, 50),
-    ejabberd_hooks:delete(s2s_out_handle_send, 
-                          Host, ?MODULE, s2s_out_handle_send, 50),
-    ejabberd_hooks:delete(s2s_out_handle_info,
-                          Host, ?MODULE, s2s_out_handle_info, 50),
-    ejabberd_hooks:delete(s2s_out_closed,
-                          Host, ?MODULE, s2s_out_closed, 50),
-    ejabberd_hooks:delete(s2s_out_terminate,
-                       Host, ?MODULE, s2s_out_terminate, 50),
+    % ejabberd_hooks:delete(s2s_out_handle_recv, 
+    %                       Host, ?MODULE, s2s_out_handle_recv, 50),
+    % ejabberd_hooks:delete(s2s_out_handle_send, 
+    %                       Host, ?MODULE, s2s_out_handle_send, 50),
+    % ejabberd_hooks:delete(s2s_out_handle_info,
+    %                       Host, ?MODULE, s2s_out_handle_info, 50),
+    % ejabberd_hooks:delete(s2s_out_closed,
+    %                       Host, ?MODULE, s2s_out_closed, 50),
+    % ejabberd_hooks:delete(s2s_out_terminate,
+    %                    Host, ?MODULE, s2s_out_terminate, 50),
     % delete after implementation of server part
     ejabberd_hooks:delete(s2s_out_established,
-                          Host, ?MODULE, s2s_out_established, 50).
+                          Host, ?MODULE, s2s_out_established, 50),
+    %% server part
+    ejabberd_hooks:delete(s2s_in_post_auth_features,
+                          Host, ?MODULE, s2s_in_post_auth_features, 50),
+    % ejabberd_hooks:delete(s2s_in_init, ?MODULE, s2s_in_init),
+    ejabberd_hooks:delete(s2s_in_authenticated_packet,
+                          Host, ?MODULE, s2s_in_authenticated_packet, 50).
 
 reload(_Host, _NewOpts, _OldOpts) ->
     ?WARNING_MSG("module ~s is reloaded, but new configuration will take "
@@ -71,17 +90,18 @@ reload(_Host, _NewOpts, _OldOpts) ->
 
 depends(_Host, _Opts) -> [].
 
+%% client part
 s2s_out_stream_init({ok, #{server_host := ServerHost, mod := Mod} = State}, Opts) ->
-    case proplists:get_value(resume, Opts) of
-        OldState when OldState /= undefined ->
-            #{mgmt_stanzas_in := H, mgmt_stanzas_out := NumStanzasOut, 
-              mgmt_queue := Queue, mgmt_privid := Id} = OldState,
-            State1 = State#{mgmt_queue => Queue,
-                            mgmt_stanzas_out => NumStanzasOut,
-                            mgmt_stanzas_in => H,
-                            mgmt_privid => Id},
-            {ok, State1#{mgmt_state => resume, mgmt_old_session => OldState}};
-        _ ->
+    % case proplists:get_value(resume, Opts) of
+    %     OldState when OldState /= undefined ->
+    %         #{mgmt_stanzas_in := H, mgmt_stanzas_out := NumStanzasOut, 
+    %           mgmt_queue := Queue, mgmt_privid := Id} = OldState,
+    %         State1 = State#{mgmt_queue => Queue,
+    %                         mgmt_stanzas_out => NumStanzasOut,
+    %                         mgmt_stanzas_in => H,
+    %                         mgmt_privid => Id},
+    %         {ok, State1#{mgmt_state => resume, mgmt_old_session => OldState}};
+    %     _ ->
             {ok, State#{mgmt_state => inactive,
                         mgmt_timeout => get_resume_timeout(ServerHost),
                         mgmt_queue_type => get_queue_type(ServerHost),
@@ -91,8 +111,8 @@ s2s_out_stream_init({ok, #{server_host := ServerHost, mod := Mod} = State}, Opts
                         mgmt_connection_timeout => get_connection_timeout(ServerHost),
                         mgmt_stanzas_in => 0,
                         mgmt_stanzas_out => 0,
-                        mgmt_stanzas_req => 0}}
-    end;
+                        mgmt_stanzas_req => 0}};
+    % end;
 s2s_out_stream_init(Acc, _Opts) ->
     Acc.
 
@@ -102,8 +122,8 @@ s2s_out_stream_features(#{mgmt_state := MgmtState,
                         #stream_features{sub_els = SubEls}) ->
     case check_stream_mgmt_support(SubEls) of
         Xmlns when Xmlns == ?NS_STREAM_MGMT_2; Xmlns == ?NS_STREAM_MGMT_3 ->
-            case MgmtState of
-                inactive -> 
+            % case MgmtState of
+            %     inactive -> 
                     State1 =                   
                         if Resume > 0 ->
                                 send(State, #sm_enable{xmlns = Xmlns,
@@ -115,22 +135,21 @@ s2s_out_stream_features(#{mgmt_state := MgmtState,
                     State1#{mgmt_xmlns => Xmlns,
                             mgmt_state => wait_for_enabled,
                             mgmt_queue => p1_queue:new(QueueType)};
-                _ -> % resume
-                    #{mgmt_stanzas_in := H, mgmt_privid := Id} = State,
-                    State1 = send(State, #sm_resume{h = H, previd = Id, xmlns = Xmlns}),
-                    State1#{mgmt_xmlns => Xmlns, mgmt_state => pending}
-            end;
+            %     _ -> % resume
+            %         #{mgmt_stanzas_in := H, mgmt_privid := Id} = State,
+            %         State1 = send(State, #sm_resume{h = H, previd = Id, xmlns = Xmlns}),
+            %         State1#{mgmt_xmlns => Xmlns, mgmt_state => pending}
+            % end;
         _ ->
             State
     end;
 s2s_out_stream_features(State, _) ->
     State.
 
-s2s_out_established(#{mgmt_state := resume} = State) ->
-    % register connection ?
-    #{mgmt_stanzas_in := H, mgmt_privid := Id} = State,
-    State1 = send(State, #sm_resume{h = H, previd = Id, xmlns = ?NS_STREAM_MGMT_3}),
-    State1#{mgmt_xmlns => ?NS_STREAM_MGMT_3, mgmt_state => pending};
+% s2s_out_established(#{mgmt_state := resume} = State) ->
+%     #{mgmt_stanzas_in := H, mgmt_privid := Id} = State,
+%     State1 = send(State, #sm_resume{h = H, previd = Id, xmlns = ?NS_STREAM_MGMT_3}),
+%     State1#{mgmt_xmlns => ?NS_STREAM_MGMT_3, mgmt_state => pending};
 s2s_out_established(#{mgmt_timeout := Resume,
                       mgmt_queue_type := QueueType} = State) ->
     Xmlns = ?NS_STREAM_MGMT_3,
@@ -149,100 +168,145 @@ s2s_out_established(#{mgmt_timeout := Resume,
 s2s_out_established(State) ->
     State.
 
-s2s_out_packet(#{mgmt_state := pending} = State, #sm_resumed{} = Pkt) ->
-    {stop, handle_resumed(Pkt, State)};
-s2s_out_packet(#{mgmt_state := MgmtState} = State, Pkt) 
+s2s_out_packet(#{mgmt_state := MgmtState} = State, Pkt)
   when ?is_sm_packet(Pkt) ->
-    if MgmtState == active -> % ; pending
-            {stop, perform_stream_mgmt(Pkt, State)};
-       MgmtState == wait_for_enabled ->
+    if MgmtState == wait_for_enabled ->
             {stop, negotiate_stream_mgmt(Pkt, State)};
        true ->
             {stop, State}
     end;
 s2s_out_packet(State, Pkt) ->
+    State.
+
+%% client part
+
+%% server part
+
+s2s_in_post_auth_features(Acc, _Host) ->
+    [#feature_sm{xmlns = ?NS_STREAM_MGMT_2},
+     #feature_sm{xmlns = ?NS_STREAM_MGMT_3}| Acc].
+
+s2s_in_init({ok, #{server_host := Host} = State}, _Opts) ->
+    Timeout = get_resume_timeout(Host),
+    MaxTimeout = get_max_resume_timeout(Host, Timeout),
+    {ok, State#{mgmt_state => inactive,
+                mgmt_timeout => Timeout,
+                mgmt_max_timeout => MaxTimeout,
+                mgmt_queue_type => get_queue_type(Host),
+                mgmt_stanzas_in => 0}};
+s2s_in_init(State, _Opts) ->
+    State.
+
+s2s_in_authenticated_packet(#{mgmt_state := MgmtState} = State, Pkt)
+  when ?is_sm_packet(Pkt) ->
+    if MgmtState == inactive ->
+            {stop, server_negotiate_stream_mgmt(Pkt, State)};
+       true ->
+            {stop, State}
+    end;
+s2s_in_authenticated_packet(State, Pkt) ->
     update_num_stanzas_in(State, Pkt).
 
-s2s_out_handle_recv(#{mgmt_state := wait_for_enabled,
-                      remote_server := RServer} = State, _El, #sm_failed{}) ->
-    ?DEBUG("Remote server ~s can't enable stream management", [RServer]),
-    State#{mgmt_state => inactive};
-s2s_out_handle_recv(#{mgmt_state := pending,
-                      remote_server := RServer,
-                      mgmt_old_session := OldState} = State, _El, #sm_failed{}) ->
-    ?DEBUG("Remote server ~s can't resume previous session", [RServer]),
-    State;
-s2s_out_handle_recv(#{lang := Lang} = State, El, {error, Why}) ->
-    Xmlns = xmpp:get_ns(El),
-    if Xmlns == ?NS_STREAM_MGMT_2; Xmlns == ?NS_STREAM_MGMT_3 ->
-            Txt = xmpp:io_format_error(Why),
-            Err = #sm_failed{reason = 'bad-request',
-                             text = xmpp:mk_text(Txt, Lang),
-                             xmlns = Xmlns},
-            send(State, Err);
-       true ->
-            State
-    end;
-s2s_out_handle_recv(State, El, Pkt) ->
-    State.
+
+
+%% server part
+
+% s2s_out_packet(#{mgmt_state := pending} = State, #sm_resumed{} = Pkt) ->
+%     {stop, handle_resumed(Pkt, State)};
+% s2s_out_packet(#{mgmt_state := MgmtState} = State, Pkt) 
+%   when ?is_sm_packet(Pkt) ->
+%     if MgmtState == active; MgmtState == pending ->
+%             {stop, perform_stream_mgmt(Pkt, State)};
+%        MgmtState == wait_for_enabled ->
+%             {stop, negotiate_stream_mgmt(Pkt, State)};
+%        true ->
+%             {stop, State}
+%     end;
+% s2s_out_packet(State, Pkt) ->
+%     update_num_stanzas_in(State, Pkt).
+
+% s2s_out_handle_recv(#{mgmt_state := wait_for_enabled,
+%                       remote_server := RServer} = State, _El, #sm_failed{}) ->
+%     ?DEBUG("Remote server ~s can't enable stream management", [RServer]),
+%     State#{mgmt_state => inactive};
+% s2s_out_handle_recv(#{mgmt_state := pending,
+%                       remote_server := RServer,
+%                       mod := Mod} = State, _El, #sm_failed{}) ->
+%     ?DEBUG("Remote server ~s can't resume previous session", [RServer]),
+%     Mod:stop(State);
+% s2s_out_handle_recv(#{lang := Lang} = State, El, {error, Why}) ->
+%     Xmlns = xmpp:get_ns(El),
+%     if Xmlns == ?NS_STREAM_MGMT_2; Xmlns == ?NS_STREAM_MGMT_3 ->
+%             Txt = xmpp:io_format_error(Why),
+%             Err = #sm_failed{reason = 'bad-request',
+%                              text = xmpp:mk_text(Txt, Lang),
+%                              xmlns = Xmlns},
+%             send(State, Err);
+%        true ->
+%             State
+%     end;
+% s2s_out_handle_recv(State, El, Pkt) ->
+%     State.
  
-s2s_out_handle_send(#{mgmt_state := MgmtState, lang := Lang} = State, Pkt, SendResult)
-  when MgmtState == active; MgmtState == wait_for_enabled ->
-    case Pkt of
-        _ when ?is_stanza(Pkt) ->
-            case mod_stream_mgmt:mgmt_queue_add(State, Pkt) of
-                #{mgmt_max_queue := exceeded} = State1 ->
-                    Err = xmpp:serr_policy_violation(
-                                <<"Too many unacked stanzas">>, Lang),
-                    send(State1, Err);
-                State1 when MgmtState == active, SendResult == ok ->
-                    send_rack(State1);
-                State1 ->
-                    State1
-            end;
-        _ ->
-            State
-    end;
-s2s_out_handle_send(State, _, _) ->
-    State.
+% s2s_out_handle_send(#{mgmt_state := MgmtState, lang := Lang} = State, Pkt, SendResult)
+%   when MgmtState == active; MgmtState == pending; MgmtState == wait_for_enabled ->
+%     case Pkt of
+%         _ when ?is_stanza(Pkt) ->
+%             Meta = xmpp:get_meta(Pkt),
+%             case maps:get(mgmt_is_resent, Meta, false) of
+%                 false ->
+%                     case mod_stream_mgmt:mgmt_queue_add(State, Pkt) of
+%                         #{mgmt_max_queue := exceeded} = State1 ->
+%                             Err = xmpp:serr_policy_violation(
+%                                         <<"Too many unacked stanzas">>, Lang),
+%                             send(State1, Err);
+%                         State1 when MgmtState /= wait_for_enabled, SendResult == ok ->
+%                             send_rack(State1);
+%                         State1 ->
+%                             State1
+%                     end;
+%                 true ->
+%                     State
+%             end;
+%         _ ->
+%             State
+%     end;
+% s2s_out_handle_send(State, _, _) ->
+%     State.
  
-s2s_out_handle_info(#{mgmt_ack_timer := TRef, remote_server := RServer,
-                      mod := Mod} = State, {timeout, TRef, ack_timeout}) ->
-    ?DEBUG("Timed out waiting for stream management "
-           "acknowledgement of ~s", [RServer]),
-    Mod:stop(State);
-    % State1 = Mod:close(State),
-    % {stop, transition_to_resume(State1)};
-s2s_out_handle_info(#{mgmt_state := resume,
-                      remote_server := RServer, mod := Mod} = State,
-                     {timeout, TRef, connection_timeout}) ->
-    ?DEBUG("Timed out waiting for connection "
-           "establishment with ~s for resumption", [RServer]),
-    % Mod:stop(State),
-    State;
-s2s_out_handle_info(State, _) ->
-    State.
-
-s2s_out_closed(#{mgmt_state := resume, mod := Mod} = State, _) ->
-    {stop, transition_to_resume(State#{stream_state => connecting})};
-% s2s_out_closed(#{mgmt_state := active} = State, _) ->
+% s2s_out_handle_info(#{mgmt_ack_timer := TRef, remote_server := RServer,
+%                       mod := Mod} = State, {timeout, TRef, ack_timeout}) ->
+%     ?DEBUG("Timed out waiting for stream management "
+%            "acknowledgement of ~s", [RServer]),
+%     Mod:stop(State);
+% s2s_out_handle_info(#{mgmt_state := resume,
+%                       remote_server := RServer, mod := Mod} = State,
+%                      {timeout, TRef, connection_timeout}) ->
+%     ?DEBUG("Timed out waiting for connection "
+%            "establishment with ~s for resumption", [RServer]),
+%     Mod:stop(State),
 %     State;
-s2s_out_closed(State, _) ->
-    State.
+% s2s_out_handle_info(State, _) ->
+%     State.
 
-% terminate - Mod:stop
-% fix: route messages if timeout = 0 or in pending state
+% s2s_out_closed(#{mgmt_state := resume, mod := Mod} = State, _) ->
+%     {stop, transition_to_resume(State#{stream_state => connecting})};
+% s2s_out_closed(State, _) ->
+%     State.
 
-% s2s_out_terminate(#{mgmt_state := resumed} = State, _Reason) ->
-%     {stop, State};
-% s2s_out_terminate(#{mgmt_state := resume} = State, _Reason) ->
-%     % bounce_errors(State),
-%     State;
+% % terminate - Mod:stop
+
 % s2s_out_terminate(#{mgmt_state := active} = State, _Reason) ->
 %     transition_to_resume(State);
+% s2s_out_terminate(#{mgmt_state := resume} = State, _Reason) ->
+%     bounce_errors(State),
+%     State;
+% % в данном состоянии что делать? 
+% s2s_out_terminate(#{mgmt_state := pending} = State, _Reason) ->
+%     State;
+% s2s_out_terminate(State, _Reason) ->
+%     State.
 
-s2s_out_terminate(State, _Reason) ->
-    State.
 
 %%%=============================================================================
 %%% Internal functions
@@ -270,31 +334,15 @@ check_stream_mgmt_support([El | Els], Res) ->
     end;
 check_stream_mgmt_support([], Res) -> Res.
 
-% mgmt_state := active, pending and pkt is sm packet
--spec perform_stream_mgmt(xmpp_element(), state()) -> state().
-perform_stream_mgmt(Pkt, #{mgmt_xmlns := Xmlns} = State) ->
-    case xmpp:get_ns(Pkt) of
-        Xmlns ->
-            case Pkt of
-                #sm_a{} ->
-                    handle_a(State, Pkt);
-                #sm_r{} ->
-                    handle_r(State);
-                _ ->
-                    send(State, #sm_failed{reason = 'bad-request', xmlns = Xmlns})
-            end;
-        _ ->
-            send(State, #sm_failed{reason = 'unsupported-version', xmlns = Xmlns})
-    end.
-
--spec negotiate_stream_mgmt(xmpp_element(), state()) -> state().
-negotiate_stream_mgmt(Pkt, #{mgmt_xmlns := Xmlns, 
-                             mgmt_state := MgmtState} = State) ->
+-spec server_negotiate_stream_mgmt(xmpp_element(), state()) -> state().
+server_negotiate_stream_mgmt(Pkt, State) ->
+    Xmlns = xmpp:get_ns(Pkt),
     case Pkt of
-        #sm_enabled{} ->
-            handle_enabled(State, Pkt);
-        _ when is_record(Pkt, sm_r);
-               is_record(Pkt, sm_a) ->
+        #sm_enable{} ->
+            handle_enable(State#{mgmt_xmlns => Xmlns}, Pkt);
+        _ when is_record(Pkt, sm_a);
+               is_record(Pkt, sm_r);
+               is_record(Pkt, sm_resume) ->
             Err = #sm_failed{reason = 'unexpected-request', xmlns = Xmlns},
             send(State, Err);
         _ ->
@@ -302,33 +350,49 @@ negotiate_stream_mgmt(Pkt, #{mgmt_xmlns := Xmlns,
             send(State, Err)
     end.
 
--spec handle_resumed(sm_resumed(), state()) -> state().
-handle_resumed(#sm_resumed{h = H, previd = Id}, 
-               #{mgmt_xmlns := Xmlns, remote_server := RServer,
-                 mgmt_old_session := OldState, mod := Mod} = State) ->
+handle_enable(#{remote_server := RServer,
+                mgmt_timeout := DefaultTimeout,
+                mgmt_max_timeout := MaxTimeout,
+                mgmt_xmlns := Xmlns,
+                mgmt_queue_type := QueueType} = State,
+              #sm_enable{resume = Resume, max = Max}) ->
+    Timeout =
+        if Resume == false ->
+                0;
+           Max /= undefined, Max > 0, Max =< MaxTimeout ->
+                Max;
+           true ->
+                DefaultTimeout
+        end,
+    Res = if Timeout > 0 ->
+                  ?INFO_MSG("Stream management with "
+                            "resumption enabled for ~s", [RServer]),
+                  #sm_enabled{resume = true,
+                              id = make_resume_id(State),
+                              max = Timeout, xmlns = Xmlns};
+             true ->
+                  ?INFO_MSG("Stream management enabled for ~s", [RServer]),
+                  #sm_enabled{xmlns = Xmlns}
+          end,
+    State1 = State#{mgmt_state => active,
+                    mgmt_timeout => Timeout,
+                    mgmt_queue => p1_queue:new(QueueType)},
+    send(State1, Res).
 
-    State1 = check_h_attribute(State, H),
-
-    State2 = resend_unacked_stanzas(State1),
-
-    State3 = send(State2#{mgmt_state => resumed}, #sm_r{xmlns = Xmlns}),
-
-    ?DEBUG("Resumed session with ~s", [RServer]),
-
-    {ok, State3}.
-
--spec resend_unacked_stanzas(state()) -> state().
-resend_unacked_stanzas(#{mgmt_state := MgmtState,
-                         mgmt_queue := Queue,
-                         remote_server := RServer} = State) 
-    when MgmtState == pending andalso ?qlen(Queue) > 0 ->
-    p1_queue:foldl(
-        fun({_, _Time, Pkt}, AccState) ->
-            % set is_resent =  true like in mod_stream_mgmt
-            send(AccState, Pkt)
-        end, State, Queue);
-resend_unacked_stanzas(State) -> 
-    State.
+-spec negotiate_stream_mgmt(xmpp_element(), state()) -> state().
+negotiate_stream_mgmt(Pkt, #{mgmt_xmlns := Xmlns} = State) ->
+    case Pkt of
+        #sm_enabled{} ->
+            handle_enabled(State, Pkt);
+        _ when is_record(Pkt, sm_a);
+               is_record(Pkt, sm_r);
+               is_record(Pkt, sm_resumed) ->
+            Err = #sm_failed{reason = 'unexpected-request', xmlns = Xmlns},
+            send(State, Err);
+        _ ->
+            Err = #sm_failed{reason = 'bad-request', xmlns = Xmlns},
+            send(State, Err)
+    end.
 
 -spec handle_enabled(state(), sm_enabled()) -> state().
 handle_enabled(#{remote_server := RServer,
@@ -350,125 +414,206 @@ handle_enabled(#{remote_server := RServer,
                     ?INFO_MSG("Stream management enabled for ~s", [RServer]),
                     State
              end,
+
+    State1#{mgmt_state => active, mgmt_timeout => Timeout}.
+
+% What should we encode?
+-spec make_resume_id(state()) -> binary().
+make_resume_id(#{owner := Owner, remote_server := RServer}) ->
+    misc:term_to_base64({RServer, Owner}).
+
+% % mgmt_state := active, pending and pkt is sm packet
+% -spec perform_stream_mgmt(xmpp_element(), state()) -> state().
+% perform_stream_mgmt(Pkt, #{mgmt_xmlns := Xmlns} = State) ->
+%     case xmpp:get_ns(Pkt) of
+%         Xmlns ->
+%             case Pkt of
+%                 #sm_a{} ->
+%                     handle_a(State, Pkt);
+%                 #sm_r{} ->
+%                     handle_r(State);
+%                 _ ->
+%                     send(State, #sm_failed{reason = 'bad-request', xmlns = Xmlns})
+%             end;
+%         _ ->
+%             send(State, #sm_failed{reason = 'unsupported-version', xmlns = Xmlns})
+%     end.
+
+% -spec negotiate_stream_mgmt(xmpp_element(), state()) -> state().
+% negotiate_stream_mgmt(Pkt, #{mgmt_xmlns := Xmlns} = State) ->
+%     case Pkt of
+%         #sm_enabled{} ->
+%             handle_enabled(State, Pkt);
+%         _ when is_record(Pkt, sm_r);
+%                is_record(Pkt, sm_a) ->
+%             Err = #sm_failed{reason = 'unexpected-request', xmlns = Xmlns},
+%             send(State, Err);
+%         _ ->
+%             Err = #sm_failed{reason = 'bad-request', xmlns = Xmlns},
+%             send(State, Err)
+%     end.
+
+% -spec handle_resumed(sm_resumed(), state()) -> state().
+% handle_resumed(#sm_resumed{h = H, previd = Id}, 
+%                #{mgmt_xmlns := Xmlns, remote_server := RServer} = State) ->
+%     State1 = check_h_attribute(State, H),
+%     State2 = resend_unacked_stanzas(State1),
+%     State3 = send(State2, #sm_r{xmlns = Xmlns}),
+%     ?DEBUG("Resumed session with ~s", [RServer]),
+%     {ok, State3}.
+
+% -spec resend_unacked_stanzas(state()) -> state().
+% resend_unacked_stanzas(#{mgmt_state := MgmtState,
+%                          mgmt_queue := Queue,
+%                          remote_server := RServer} = State) 
+%     when MgmtState == pending andalso ?qlen(Queue) > 0 ->
+%     p1_queue:foldl(
+%         fun({_, Time, Pkt}, AccState) ->
+%             NewPkt = mod_stream_mgmt:add_resent_delay_info(AccState, Pkt, Time),
+%             send(AccState, xmpp:put_meta(NewPkt, mgmt_is_resent, true))
+%         end, State, Queue);
+% resend_unacked_stanzas(State) -> 
+%     State.
+
+% -spec handle_enabled(state(), sm_enabled()) -> state().
+% handle_enabled(#{remote_server := RServer,
+%                  mgmt_timeout :=  DefaultTimeout,
+%                  mgmt_queue := Queue} = State,
+%                #sm_enabled{resume = Resume, max = Max, id = Id}) ->
+%     Timeout = if Resume == false ->
+%                     0;
+%                  Max /= undefined ->
+%                     Max;
+%                  true ->
+%                     DefaultTimeout
+%               end,
+%     State1 = if Timeout > 0 ->
+%                     ?INFO_MSG("Stream management with "
+%                               "resumption enabled for ~s", [RServer]),
+%                     State#{mgmt_privid => Id};
+%                 true ->
+%                     ?INFO_MSG("Stream management enabled for ~s", [RServer]),
+%                     State
+%              end,
     
-    State2 = 
-        case not p1_queue:is_empty(Queue) of
-            true ->
-                send_rack(State1);
-            _ ->
-                State1
-        end,
+%     State2 = 
+%         case not p1_queue:is_empty(Queue) of
+%             true ->
+%                 send_rack(State1);
+%             _ ->
+%                 State1
+%         end,
 
-    State2#{mgmt_state => active, mgmt_timeout => Timeout}.
+%     State2#{mgmt_state => active, mgmt_timeout => Timeout}.
 
--spec handle_r(state()) -> state().
-handle_r(#{mgmt_stanzas_in := H,
-           mgmt_xmlns := Xmlns} = State) ->
-    send(State, #sm_a{h = H, xmlns = Xmlns}).
+% -spec handle_r(state()) -> state().
+% handle_r(#{mgmt_stanzas_in := H,
+%            mgmt_xmlns := Xmlns} = State) ->
+%     send(State, #sm_a{h = H, xmlns = Xmlns}).
 
--spec handle_a(state(), sm_a()) -> state().
-handle_a(#{mgmt_stanzas_out := NumStanzasOut, 
-           remote_server := RServer} = State, #sm_a{h = H}) ->
-    State1 = check_h_attribute(State, H),
-    resend_rack(State1).
+% -spec handle_a(state(), sm_a()) -> state().
+% handle_a(#{mgmt_stanzas_out := NumStanzasOut, 
+%            remote_server := RServer} = State, #sm_a{h = H}) ->
+%     State1 = check_h_attribute(State, H),
+%     resend_rack(State1).
 
--spec transition_to_resume(state()) -> state().
-transition_to_resume(#{mgmt_state := active, mod := Mod,
-                       mgmt_timeout := 0} = State) ->
-    State; % route messages from queue
-transition_to_resume(#{mgmt_state := active, mod := Mod,
-                       remote_server := RServer,server_host := Server,
-                       mgmt_connection_timeout := Timeout} = State) ->
-    State1 = mod_stream_mgmt:cancel_ack_timer(State),
-    ?DEBUG("Try to connect to remote server ~s", [RServer]),
-    {ok, Pid} = 
-        ejabberd_s2s:start_connection(jid:make(Server), 
-                                      jid:make(RServer),
-                                      [{resume, State1}]),
+% -spec transition_to_resume(state()) -> state().
+% transition_to_resume(#{mgmt_state := active, mod := Mod,
+%                        mgmt_timeout := 0} = State) ->
+%     State; % route messages from queue
+% transition_to_resume(#{mgmt_state := active, mod := Mod,
+%                        remote_server := RServer,server_host := Server,
+%                        mgmt_connection_timeout := Timeout} = State) ->
+%     State1 = mod_stream_mgmt:cancel_ack_timer(State),
+%     ?DEBUG("Try to connect to remote server ~s", [RServer]),
+%     {ok, Pid} = 
+%         ejabberd_s2s:start_connection(jid:make(Server), 
+%                                       jid:make(RServer),
+%                                       [{resume, State1}]),
 
-    erlang:start_timer(Timeout, Pid, connection_timeout),
+%     erlang:start_timer(Timeout, Pid, connection_timeout),
 
-    State1;
-transition_to_resume(#{mgmt_state := resume,
-                       mod := Mod,
-                       remote_server := RServer} = State) ->    
-    Mod:connect(self()),
-    State;
-transition_to_resume(State) ->
-    State.
+%     State1;
+% transition_to_resume(#{mgmt_state := resume,
+%                        mod := Mod,
+%                        remote_server := RServer} = State) ->    
+%     Mod:connect(self()),
+%     State;
+% transition_to_resume(State) ->
+%     State.
 
-%% fix: filter some messages
+% % %% fix: filter some messages
 
-bounce_errors(#{mgmt_state := resume,
-                mgmt_queue := Queue} = State) 
-  when ?qlen(Queue) > 0 ->
-    p1_queue:foreach(
-        fun({_, _, Pkt}) ->
-                Error = xmpp:err_remote_server_timeout(),
-                ejabberd_router:route_error(Pkt, Error)
-        end, Queue);
-bounce_errors(State) ->
-    ok.
+% bounce_errors(#{mgmt_state := resume,
+%                 mgmt_queue := Queue} = State) 
+%   when ?qlen(Queue) > 0 ->
+%     p1_queue:foreach(
+%         fun({_, _, Pkt}) ->
+%                 Error = xmpp:err_remote_server_timeout(),
+%                 ejabberd_router:route_error(Pkt, Error)
+%         end, Queue);
+% bounce_errors(State) ->
+%     ok.
 
--spec route_unacked_stanzas(state()) -> state().
-route_unacked_stanzas(#{mgmt_queue := Queue, 
-                        mgmt_state := pending, 
-                        mgmt_xmlns := Xmlns} = State) 
-  when ?qlen(Queue) > 0 ->
-    State1 = send(State, #sm_enable{xmlns = Xmlns}),
-    p1_queue:foldl(
-        fun({_, _, Pkt}, AccState) ->
-                % set is_resend = true like in mod_stream_mgmt
-                send(AccState, Pkt)
-        end, State1, Queue);
-route_unacked_stanzas(_State) ->
-    ok.
+% % -spec route_unacked_stanzas(state()) -> state().
+% % route_unacked_stanzas(#{mgmt_queue := Queue, 
+% %                         mgmt_state := pending, 
+% %                         mgmt_xmlns := Xmlns} = State) 
+% %   when ?qlen(Queue) > 0 ->
+% %     State1 = send(State, #sm_enable{xmlns = Xmlns}),
+% %     p1_queue:foldl(
+% %         fun({_, _, Pkt}, AccState) ->
+% %                 % set is_resend = true like in mod_stream_mgmt
+% %                 send(AccState, Pkt)
+% %         end, State1, Queue);
+% % route_unacked_stanzas(_State) ->
+% %     ok.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% todo: import from mod_stream_mgmt.erl
 
--spec check_h_attribute(state(), non_neg_integer()) -> state().
-check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
-                    remote_server := RServer} = State, H)
-  when H > NumStanzasOut ->
-    ?DEBUG("~s acknowledged ~B stanzas," 
-           "but only ~B were sent ", [RServer, H, NumStanzasOut]),
-    mod_stream_mgmt:mgmt_queue_drop(State#{mgmt_stanzas_out => H}, NumStanzasOut);
-check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
-                    remote_server := RServer} = State, H) ->
-    ?DEBUG("~s acknowledged ~B of ~B "
-           "stanzas", [RServer, H, NumStanzasOut]),
-    mod_stream_mgmt:mgmt_queue_drop(State, H).
+% -spec check_h_attribute(state(), non_neg_integer()) -> state().
+% check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
+%                     remote_server := RServer} = State, H)
+%   when H > NumStanzasOut ->
+%     ?DEBUG("~s acknowledged ~B stanzas," 
+%            "but only ~B were sent ", [RServer, H, NumStanzasOut]),
+%     mod_stream_mgmt:mgmt_queue_drop(State#{mgmt_stanzas_out => H}, NumStanzasOut);
+% check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
+%                     remote_server := RServer} = State, H) ->
+%     ?DEBUG("~s acknowledged ~B of ~B "
+%            "stanzas", [RServer, H, NumStanzasOut]),
+%     mod_stream_mgmt:mgmt_queue_drop(State, H).
 
 -spec send(state(), xmpp_element()) -> state().
 send(#{mod := Mod} = State, Pkt) ->
     Mod:send(State, Pkt).
 
-send_rack(#{mgmt_ack_timer := _} = State) ->
-    State;
-send_rack(#{mgmt_xmlns := Xmlns,
-            mgmt_stanzas_out := NumStanzasOut,
-            mgmt_ack_timeout := AckTimeout} = State) ->
-    TRef = erlang:start_timer(AckTimeout, self(), ack_timeout),
-    State1 = State#{mgmt_ack_timer => TRef, mgmt_stanzas_req => NumStanzasOut},
-    send(State1, #sm_r{xmlns = Xmlns}).
+% send_rack(#{mgmt_ack_timer := _} = State) ->
+%     State;
+% send_rack(#{mgmt_xmlns := Xmlns,
+%             mgmt_stanzas_out := NumStanzasOut,
+%             mgmt_ack_timeout := AckTimeout} = State) ->
+%     TRef = erlang:start_timer(AckTimeout, self(), ack_timeout),
+%     State1 = State#{mgmt_ack_timer => TRef, mgmt_stanzas_req => NumStanzasOut},
+%     send(State1, #sm_r{xmlns = Xmlns}).
 
-resend_rack(#{mgmt_ack_timer := _,
-              mgmt_queue := Queue,
-              mgmt_stanzas_out := NumStanzasOut,
-              mgmt_stanzas_req := NumStanzasReq} = State) ->
-    State1 = State, % mod_stream_mgmt:cancel_ack_timer(State),
-    case NumStanzasReq < NumStanzasOut andalso not p1_queue:is_empty(Queue) of
-        true -> send_rack(State1);
-        false -> State1
-    end;
-resend_rack(State) ->
-    State.
+% resend_rack(#{mgmt_ack_timer := _,
+%               mgmt_queue := Queue,
+%               mgmt_stanzas_out := NumStanzasOut,
+%               mgmt_stanzas_req := NumStanzasReq} = State) ->
+%     State1 = State, % mod_stream_mgmt:cancel_ack_timer(State),
+%     case NumStanzasReq < NumStanzasOut andalso not p1_queue:is_empty(Queue) of
+%         true -> send_rack(State1);
+%         false -> State1
+%     end;
+% resend_rack(State) ->
+%     State.
 
 -spec update_num_stanzas_in(state(), xmpp_element()) -> state().
 update_num_stanzas_in(#{mgmt_state := MgmtState,
                         mgmt_stanzas_in := NumStanzasIn} = State, El)
-  when MgmtState == active ->
+  when MgmtState == active -> %; MgmtState == pending ->
     NewNum = case {xmpp:is_stanza(El), NumStanzasIn} of
          {true, 4294967295} ->
              0;
@@ -487,6 +632,13 @@ update_num_stanzas_in(State, _El) ->
 
 get_resume_timeout(Host) ->
     gen_mod:get_module_opt(Host, ?MODULE, resume_timeout, 300).
+
+get_max_resume_timeout(Host, ResumeTimeout) ->
+    case gen_mod:get_module_opt(Host, ?MODULE, max_resume_timeout) of
+        undefined -> ResumeTimeout;
+        Max when Max >= ResumeTimeout -> Max;
+        _ -> ResumeTimeout
+    end.
 
 get_queue_type(Host) ->
     case gen_mod:get_module_opt(Host, ?MODULE, queue_type) of
@@ -529,5 +681,5 @@ mod_opt_type(queue_type) ->
     fun(file) -> file;
        (ram) -> ram
     end;
-mod_opt_type(_) -> [max_ack_queue, ack_timeout, resume_timeout,
+mod_opt_type(_) -> [max_ack_queue, ack_timeout, resume_timeout, max_resume_timeout,
                     queue_type, max_unacked_stanzas, connection_timeout].

--- a/src/mod_stream_mgmt_s2s.erl
+++ b/src/mod_stream_mgmt_s2s.erl
@@ -72,7 +72,6 @@ reload(_Host, _NewOpts, _OldOpts) ->
 depends(_Host, _Opts) -> [].
 
 s2s_out_stream_init({ok, #{server_host := ServerHost, mod := Mod} = State}, Opts) ->
-    ?INFO_MSG("init pid ~p", [self()]),
     case proplists:get_value(resume, Opts) of
         OldState when OldState /= undefined ->
             #{mgmt_stanzas_in := H, mgmt_stanzas_out := NumStanzasOut, 

--- a/src/mod_stream_mgmt_s2s.erl
+++ b/src/mod_stream_mgmt_s2s.erl
@@ -33,7 +33,7 @@ start(Host, _Opts) ->
                        Host, ?MODULE, s2s_out_stream_features, 50),
     ejabberd_hooks:add(s2s_out_packet, Host, ?MODULE, s2s_out_packet, 5),
     ejabberd_hooks:add(s2s_out_handle_recv, 
-                       Host, ?MODULE, s2s_out_handle_recv, 1),
+                       Host, ?MODULE, s2s_out_handle_recv, 50),
     ejabberd_hooks:add(s2s_out_handle_send, 
                        Host, ?MODULE, s2s_out_handle_send, 50),
     ejabberd_hooks:add(s2s_out_handle_info,

--- a/src/mod_stream_mgmt_s2s.erl
+++ b/src/mod_stream_mgmt_s2s.erl
@@ -704,14 +704,12 @@ check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
   when H > NumStanzasOut ->
     ?DEBUG("~s acknowledged ~B stanzas," 
            "but only ~B were sent ", [RServer, H, NumStanzasOut]),
-    % mod_stream_mgmt:mgmt_queue_drop(State#{mgmt_stanzas_out => H}, NumStanzasOut);
-    State#{mgmt_stanzas_out => H};
+    mod_stream_mgmt:mgmt_queue_drop(State#{mgmt_stanzas_out => H}, NumStanzasOut);
 check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
                     remote_server := RServer} = State, H) ->
     ?DEBUG("~s acknowledged ~B of ~B "
            "stanzas", [RServer, H, NumStanzasOut]),
-    State.
-    % mod_stream_mgmt:mgmt_queue_drop(State, H).
+    mod_stream_mgmt:mgmt_queue_drop(State, H).
 
 -spec add_resent_delay_info(state(), stanza(), erlang:timestamp()) -> stanza().
 add_resent_delay_info(#{server_host := LServer}, El, Time) ->
@@ -740,7 +738,7 @@ resend_rack(#{mgmt_ack_timer := _,
               mgmt_queue := Queue,
               mgmt_stanzas_out := NumStanzasOut,
               mgmt_stanzas_req := NumStanzasReq} = State) ->
-    State1 = State, %mod_stream_mgmt:cancel_ack_timer(State),
+    State1 = mod_stream_mgmt:cancel_ack_timer(State),
     case NumStanzasReq < NumStanzasOut andalso not p1_queue:is_empty(Queue) of
         true -> send_rack(State1);
         false -> State1

--- a/src/mod_stream_mgmt_s2s.erl
+++ b/src/mod_stream_mgmt_s2s.erl
@@ -279,7 +279,8 @@ s2s_out_closed(#{mgmt_state := connecting} = State, _) ->
 s2s_out_closed(State, _) ->
     State.
 
-s2s_out_terminate(#{mgmt_state := active} = State, _Reason) ->
+s2s_out_terminate(#{mgmt_state := active, mgmt_queue := Queue} = State, _Reason) 
+  when ?qlen(Queue) > 0 ->
     transition_to_resume(State);
 s2s_out_terminate(#{mgmt_state := timeout,
                     mgmt_old_state := OldState} = State, _Reason) ->

--- a/src/mod_stream_mgmt_s2s.erl
+++ b/src/mod_stream_mgmt_s2s.erl
@@ -713,14 +713,12 @@ check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
   when H > NumStanzasOut ->
     ?DEBUG("~s acknowledged ~B stanzas," 
            "but only ~B were sent ", [RServer, H, NumStanzasOut]),
-    % mod_stream_mgmt:mgmt_queue_drop(State#{mgmt_stanzas_out => H}, NumStanzasOut);
-    State#{mgmt_stanzas_out => H};
+    mod_stream_mgmt:mgmt_queue_drop(State#{mgmt_stanzas_out => H}, NumStanzasOut);
 check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
                     remote_server := RServer} = State, H) ->
     ?DEBUG("~s acknowledged ~B of ~B "
            "stanzas", [RServer, H, NumStanzasOut]),
-    State.
-    % mod_stream_mgmt:mgmt_queue_drop(State, H).
+    mod_stream_mgmt:mgmt_queue_drop(State, H).
 
 -spec add_resent_delay_info(state(), stanza(), erlang:timestamp()) -> stanza().
 add_resent_delay_info(#{server_host := LServer}, El, Time) ->
@@ -750,7 +748,7 @@ resend_rack(#{mgmt_ack_timer := _,
               mgmt_queue := Queue,
               mgmt_stanzas_out := NumStanzasOut,
               mgmt_stanzas_req := NumStanzasReq} = State) ->
-    State1 = State , %mod_stream_mgmt:cancel_ack_timer(State),
+    State1 = mod_stream_mgmt:cancel_ack_timer(State),
     case NumStanzasReq < NumStanzasOut andalso not p1_queue:is_empty(Queue) of
         true -> send_rack(State1);
         false -> State1

--- a/src/mod_stream_mgmt_s2s.erl
+++ b/src/mod_stream_mgmt_s2s.erl
@@ -1,0 +1,512 @@
+-module(mod_stream_mgmt_s2s).
+-behaviour(gen_mod).
+-author('amuhar3@gmail.com').
+-protocol({xep, 198, '1.5.2'}).
+
+%% gen_mod API
+-export([start/2, stop/1, reload/3, depends/2, mod_opt_type/1]).
+%% hooks
+-export([s2s_out_stream_init/2, s2s_out_stream_features/2,
+         s2s_out_packet/2, s2s_out_handle_recv/3, s2s_out_handle_send/3,
+         s2s_out_handle_info/2, s2s_out_closed/2,
+         s2s_out_terminate/2, s2s_out_established/1]).
+
+-include("xmpp.hrl").
+-include("logger.hrl").
+-include("p1_queue.hrl").
+
+% replace ?
+-define(is_sm_packet(Pkt),
+        is_record(Pkt, sm_enabled) or
+        is_record(Pkt, sm_resumed) or
+        is_record(Pkt, sm_a) or
+        is_record(Pkt, sm_r)).
+
+-type state() :: ejabberd_s2s_out:state().
+
+%%%=============================================================================
+%%% API
+%%%=============================================================================
+start(Host, _Opts) ->
+    ejabberd_hooks:add(s2s_out_init, Host, ?MODULE, s2s_out_stream_init, 50),
+    ejabberd_hooks:add(s2s_out_authenticated_features, 
+                       Host, ?MODULE, s2s_out_stream_features, 50),
+    ejabberd_hooks:add(s2s_out_packet, Host, ?MODULE, s2s_out_packet, 5),
+    ejabberd_hooks:add(s2s_out_handle_recv, 
+                       Host, ?MODULE, s2s_out_handle_recv, 1),
+    ejabberd_hooks:add(s2s_out_handle_send, 
+                       Host, ?MODULE, s2s_out_handle_send, 50),
+    ejabberd_hooks:add(s2s_out_handle_info,
+                       Host, ?MODULE, s2s_out_handle_info, 50),
+    ejabberd_hooks:add(s2s_out_closed,
+                       Host, ?MODULE, s2s_out_closed, 50),
+    ejabberd_hooks:add(s2s_out_terminate,
+                       Host, ?MODULE, s2s_out_terminate, 50),
+    % delete after implementation of server part
+    ejabberd_hooks:add(s2s_out_established,
+                       Host, ?MODULE, s2s_out_established, 50).
+
+stop(Host) ->
+    ejabberd_hooks:delete(s2s_out_init, Host, ?MODULE, s2s_out_stream_init, 50),
+    ejabberd_hooks:delete(s2s_out_authenticated_features, 
+                          Host, ?MODULE, s2s_out_stream_features, 50),
+    ejabberd_hooks:delete(s2s_out_packet, Host, ?MODULE, s2s_out_packet, 50),
+    ejabberd_hooks:delete(s2s_out_handle_recv, 
+                          Host, ?MODULE, s2s_out_handle_recv, 50),
+    ejabberd_hooks:delete(s2s_out_handle_send, 
+                          Host, ?MODULE, s2s_out_handle_send, 50),
+    ejabberd_hooks:delete(s2s_out_handle_info,
+                          Host, ?MODULE, s2s_out_handle_info, 50),
+    ejabberd_hooks:delete(s2s_out_closed,
+                          Host, ?MODULE, s2s_out_closed, 50),
+    ejabberd_hooks:add(s2s_out_terminate,
+                       Host, ?MODULE, s2s_out_terminate, 50),
+    % delete after implementation of server part
+    ejabberd_hooks:delete(s2s_out_established,
+                          Host, ?MODULE, s2s_out_established, 50).
+
+reload(_Host, _NewOpts, _OldOpts) ->
+    ?WARNING_MSG("module ~s is reloaded, but new configuration will take "
+                 "effect for newly created s2s connections only", [?MODULE]).
+
+depends(_Host, _Opts) -> [].
+
+s2s_out_stream_init({ok, #{server_host := ServerHost} = State}, Opts) ->
+    case proplists:get_value(resume, Opts) of
+        OldState when OldState /= undefined ->
+            {ok, State#{mgmt_state => resume, mgmt_old_session => OldState}};
+        _ ->
+            Resume = get_resume_timeout(ServerHost),
+            MaxResume = get_max_resume_timeout(ServerHost, Resume),
+            {ok, State#{mgmt_state => inactive,
+                        mgmt_timeout => Resume,
+                        mgmt_max_timeout => MaxResume,
+                        mgmt_queue_type => get_queue_type(ServerHost),
+                        mgmt_max_queue => get_max_ack_queue(ServerHost),
+                        mgmt_ack_timeout => get_ack_timeout(ServerHost),
+                        mgmt_unacked_stanzas => get_max_unacked_stanzas(ServerHost),
+                        mgmt_stanzas_in => 0,
+                        mgmt_stanzas_out => 0,
+                        mgmt_stanzas_req => 0}}
+    end;
+s2s_out_stream_init(Acc, _Opts) ->
+    Acc.
+
+s2s_out_stream_features(#{mgmt_state := MgmtState,
+                          mgmt_timeout := Resume,
+                          mgmt_max_timeout := MaxResume,
+                          mgmt_old_session := OldState,
+                          mgmt_queue_type := QueueType} = State, 
+                        #stream_features{sub_els = SubEls}) ->
+    case check_stream_mgmt_support(SubEls, <<>>) of
+        Xmlns when Xmlns == ?NS_STREAM_MGMT_2; Xmlns == ?NS_STREAM_MGMT_3 ->
+            case MgmtState of
+                inactive -> 
+                    State1 =                   
+                        if Resume > 0 ->
+                                send(State, #sm_enable{xmlns = Xmlns,
+                                                       resume = true,
+                                                       max = MaxResume});
+                           true ->
+                                send(State, #sm_enable{xmlns = Xmlns})
+                        end,
+                    State1#{mgmt_xmlns => Xmlns,
+                            mgmt_state => wait_for_enabled,
+                            mgmt_queue => p1_queue:new(QueueType)};
+                _ -> % resume
+                    #{mgmt_privid := Id, mgmt_stanzas_in := H} = OldState,
+                    State1 = send(State, #sm_resume{h = H, previd = Id, xmlns = Xmlns}),
+                    State1#{mgmt_xmlns := Xmlns, mgmt_state => pending}
+            end;
+        _ ->
+            State
+    end;
+s2s_out_stream_features(State, _) ->
+    State.
+
+s2s_out_established(#{mgmt_state := resume,
+                      mgmt_old_session := OldState} = State) ->
+    #{mgmt_privid := Id, mgmt_stanzas_in := H} = OldState,
+    State1 = send(State, #sm_resume{h = H, previd = Id, xmlns = ?NS_STREAM_MGMT_3}),
+    State1#{mgmt_state => pending};
+s2s_out_established(#{mgmt_timeout := Resume,
+                      mgmt_max_timeout := MaxResume,
+                      mgmt_queue_type := QueueType} = State) ->
+    Xmlns = ?NS_STREAM_MGMT_3,
+    State1 = 
+        if Resume > 0 ->
+                send(State, #sm_enable{xmlns = Xmlns,
+                                       resume = true,
+                                       max = MaxResume});
+           true ->
+                send(State, #sm_enable{xmlns = Xmlns})
+        end,
+
+    State1#{mgmt_state => wait_for_enabled,
+            mgmt_xmlns => Xmlns,
+            mgmt_queue => p1_queue:new(QueueType)}; 
+s2s_out_established(State) ->
+    State.
+
+s2s_out_packet(#{mgmt_state := MgmtState} = State, #sm_resumed{} = Pkt) ->
+    handle_resumed(Pkt, State);
+s2s_out_packet(#{mgmt_state := MgmtState} = State, Pkt) 
+  when ?is_sm_packet(Pkt) ->
+    if MgmtState == active; MgmtState == pending ->
+            {stop, perform_stream_mgmt(Pkt, State)};
+       MgmtState == wait_for_enabled ->
+            {stop, negotiate_stream_mgmt(Pkt, State)};
+       true ->
+            {stop, State}
+    end;
+% s2s_out_packet(#{mgmt_state := wait_for_enabled,
+%                  remote_server := RServer} = State, #sm_failed{}) ->
+%     ?DEBUG("Remote server ~s can't enable stream management", [RServer]),
+%     State#{mgmt_state => inactive};
+% s2s_out_packet(#{mgmt_state := pending,
+%                  remote_server := RServer, mod := Mod} = State, #sm_failed{}) ->
+%     ?DEBUG("Remote server ~s can't resume previous session", [RServer]),
+%     Mod:stop(State#{mgmt_state => resume_failed}); % temp session
+s2s_out_packet(State, Pkt) ->
+    update_num_stanzas_in(State, Pkt).
+
+% s2s_out_handle_recv(#{lang := Lang} = State, El, {error, Why}) ->
+%     Xmlns = xmpp:get_ns(El),
+%     ?INFO_MSG("kjuh~p", [El]),
+%     if Xmlns == ?NS_STREAM_MGMT_2; Xmlns == ?NS_STREAM_MGMT_3 ->
+%             Txt = xmpp:io_format_error(Why),
+%             Err = #sm_failed{reason = 'bad-request',
+%                              text = xmpp:mk_text(Txt, Lang),
+%                              xmlns = Xmlns},
+%             send(State, Err);
+%        true ->
+%             State
+%     end;
+s2s_out_handle_recv(State, El, Pkt) ->
+    State.
+ 
+s2s_out_handle_send(#{mgmt_state := MgmtState, lang := Lang} = State, Pkt, ok)
+  when MgmtState == active; MgmtState == wait_for_enabled ->
+    case Pkt of
+        _ when ?is_stanza(Pkt) ->
+            case mgmt_queue_add(State, Pkt) of
+                #{mgmt_max_queue := exceeded} = State1 ->
+                    Err = xmpp:serr_policy_violation(
+                                <<"Too many unacked stanzas">>, Lang),
+                    send(State1, Err);
+                State1 when MgmtState == active ->
+                    send_rack(State1);
+                State1 ->
+                    State1
+            end;
+        _ ->
+            State
+    end;
+s2s_out_handle_send(State, _, _) ->
+    State.
+
+s2s_out_handle_info(#{mgmt_ack_timer := TRef, remote_server := RServer,
+                      mod := Mod} = State, {timeout, TRef, ack_timeout}) ->
+    ?DEBUG("Timed out waiting for stream management acknowledgement of ~p", [RServer]),
+    State1 = Mod:close(State),
+    {stop, new_connection(State1)};
+s2s_out_handle_info(State, _) ->
+    State.
+
+% handle_stream_end Mod:close 
+s2s_out_closed(State, {stream, _}) ->
+    State;
+s2s_out_closed(#{mgmt_state := active, mod := Mod} = State, _) ->
+    {stop, new_connection(State)};
+s2s_out_closed(State, _) ->
+    State.
+
+% terminate - Mod:stop 
+s2s_out_terminate(#{mgmt_state := resumed} = State, _Reason) ->
+    {stop, State};
+s2s_out_terminate(#{mgmt_state := MgmtState,
+                    mgmt_old_session := OldState} = State, _Reason) ->
+
+    % route_unacked_stanzas(State),
+    State;
+s2s_out_terminate(State, _Reason) ->
+    State.
+
+%%%=============================================================================
+%%% Internal functions
+%%%=============================================================================
+
+-spec check_stream_mgmt_support(Els :: [xmlel()], 
+                                Res :: binary()) -> binary().
+check_stream_mgmt_support([El | Els], Res) ->
+    case El of 
+        #xmlel{name = <<"sm">>, attrs = Attrs} ->
+            case fxml:get_attr(<<"xmlns">>, Attrs) of
+                {value, ?NS_STREAM_MGMT_3} ->
+                    ?NS_STREAM_MGMT_3;
+                {value, ?NS_STREAM_MGMT_2} ->
+                    check_stream_mgmt_support(Els, ?NS_STREAM_MGMT_2);
+                _ ->
+                    check_stream_mgmt_support(Els, Res)
+            end;
+        _ -> 
+            check_stream_mgmt_support(Els, Res)
+    end;
+check_stream_mgmt_support([], Res) -> Res.
+
+% mgmt_state := active, pending and pkt is sm packet
+-spec perform_stream_mgmt(xmpp_element(), state()) -> state().
+perform_stream_mgmt(Pkt, #{mgmt_xmlns := Xmlns} = State) ->
+    case xmpp:get_ns(Pkt) of
+        Xmlns ->
+            case Pkt of
+                #sm_a{} ->
+                    handle_a(State, Pkt);
+                #sm_r{} ->
+                    handle_r(State);
+                _ ->
+                    send(State, #sm_failed{reason = 'bad-request', xmlns = Xmlns})
+            end;
+        _ ->
+            send(State, #sm_failed{reason = 'unsupported-version', xmlns = Xmlns})
+    end.
+
+-spec negotiate_stream_mgmt(xmpp_element(), state()) -> state().
+negotiate_stream_mgmt(Pkt, #{mgmt_xmlns := Xmlns, 
+                             mgmt_state := MgmtState} = State) ->
+    case Pkt of
+        #sm_enabled{} ->
+            handle_enabled(State, Pkt);
+        _ when is_record(Pkt, sm_r);
+               is_record(Pkt, sm_a) ->
+            Err = #sm_failed{reason = 'unexpected-request', xmlns = Xmlns},
+            send(State, Err);
+        _ ->
+            Err = #sm_failed{reason = 'bad-request', xmlns = Xmlns},
+            send(State, Err)
+    end.
+
+-spec handle_resumed(sm_resumed(), state()) -> state().
+handle_resumed(#sm_resumed{h = H, previd = Id}, 
+               #{mgmt_xmlns := Xmlns, mgmt_old_session := OldState} = State) ->
+    
+    % session is resumed
+
+    #{mgmt_stanzas_out := NumStanzasOut, mgmt_queue := Queue} = OldState,
+
+    State1 = check_h_attribute(State#{mgmt_stanzas_out => NumStanzasOut,
+                                      mgmt_state => resumed,
+                                      mgmt_queue => Queue}, H),
+
+    State2 = resend_unacked_stanzas(State1),
+
+    {ok, send(State2, #sm_r{xmlns = Xmlns})}.
+
+-spec resend_unacked_stanzas(state()) -> state().
+resend_unacked_stanzas(#{mgmt_state := MgmtState,
+                         mgmt_queue := Queue,
+                         remote_server := RServer} = State) 
+    when MgmtState == pending andalso ?qlen(Queue) > 0 ->
+    p1_queue:foldl(
+        fun({_, Time, Pkt}, AccState) ->
+            send(AccState, Pkt)
+        end, State, Queue);
+resend_unacked_stanzas(State) -> 
+    State.
+
+-spec handle_enabled(state(), sm_enabled()) -> state().
+handle_enabled(#{remote_server := RHost,
+                 mgmt_timeout :=  DefaultTimeout,
+                 mgmt_max_timeout := MaxTimeout,
+                 mgmt_queue := Queue} = State,
+               #sm_enabled{resume = Resume, max = Max, id = Id}) ->
+    Timeout = if Resume == false ->
+                    0;
+                 Max /= undefined ->
+                    Max;
+                 true ->
+                    DefaultTimeout
+              end,
+    State1 = if Timeout > 0 ->
+                    ?INFO_MSG("Stream management with "
+                              "resumption enabled for ~s", [RHost]),
+                    State#{mgmt_privid => Id};
+                true ->
+                    ?INFO_MSG("Stream management enabled for ~s", [RHost]),
+                    State
+             end,
+    % Do we need it?
+    State2 = 
+        case not p1_queue:is_empty(Queue) of
+            true ->
+                send_rack(State1);
+            _ ->
+                State1
+        end,
+
+    State2#{mgmt_state => active, mgmt_timeout => Timeout}.
+
+-spec handle_r(state()) -> state().
+handle_r(#{mgmt_stanzas_in := H,
+           mgmt_xmlns := Xmlns} = State) ->
+    send(State, #sm_a{h = H, xmlns = Xmlns}).
+
+-spec handle_a(state(), sm_a()) -> state().
+handle_a(#{mgmt_stanzas_out := NumStanzasOut, 
+           remote_server := RServer} = State, #sm_a{h = H}) ->
+    check_h_attribute(State, H).
+
+-spec new_connection(state()) -> state().
+new_connection(#{mgmt_state := active, mod := Mod,
+                 mgmt_timeout := 0} = State) ->
+    Mod:stop(State);
+% we could stop this connection after resumption
+new_connection(#{remote_server := RServer, server_host := Server,
+                 mgmt_stanzas_in := H,mgmt_privid := Id} = State) ->
+    {ok, Pid} = ejabberd_s2s_out:start(Server, RServer, [{resume, State}]),
+    ejabberd_s2s_out:connect(Pid),
+    State;
+new_connection(State) ->
+    State.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% todo: import from mod_stream_mgmt.erl
+
+-spec check_h_attribute(state(), non_neg_integer()) -> state().
+check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
+                    remote_server := RServer} = State, H)
+  when H > NumStanzasOut ->
+    ?DEBUG("~s acknowledged ~B stanzas," 
+           "but only ~B were sent ", [RServer, H, NumStanzasOut]),
+    mgmt_queue_drop(State#{mgmt_stanzas_out => H}, NumStanzasOut);
+check_h_attribute(#{mgmt_stanzas_out := NumStanzasOut,
+                    remote_server := RServer} = State, H) ->
+    ?DEBUG("~s acknowledged ~B of ~B "
+           "stanzas", [RServer, H, NumStanzasOut]),
+    mgmt_queue_drop(State, H).
+
+-spec send(state(), xmpp_element()) -> state().
+send(#{mod := Mod} = State, Pkt) ->
+    Mod:send(State, Pkt).
+
+send_rack(#{mgmt_ack_timer := _} = State) ->
+    State;
+send_rack(#{mgmt_xmlns := Xmlns,
+            mgmt_stanzas_out := NumStanzasOut,
+            mgmt_ack_timeout := AckTimeout} = State) ->
+    TRef = erlang:start_timer(AckTimeout, self(), ack_timeout),
+    State1 = State#{mgmt_ack_timer => TRef, mgmt_stanzas_req => NumStanzasOut},
+    send(State1, #sm_r{xmlns = Xmlns}).
+
+-spec mgmt_queue_add(state(), xmpp_element()) -> state().
+mgmt_queue_add(#{mgmt_stanzas_out := NumStanzasOut,
+                 mgmt_queue := Queue} = State, Pkt) ->
+    NewNum = case NumStanzasOut of
+                 4294967295 -> 0;
+                 Num -> Num + 1
+             end,
+    Queue1 = p1_queue:in({NewNum, p1_time_compat:timestamp(), Pkt}, Queue),
+    State1 = State#{mgmt_queue => Queue1, mgmt_stanzas_out => NewNum},
+    check_queue_length(State1).
+
+-spec mgmt_queue_drop(state(), non_neg_integer()) -> state().
+mgmt_queue_drop(#{mgmt_queue := Queue} = State, NumHandled) ->
+    NewQueue = p1_queue:dropwhile(
+                 fun({N, _T, _E}) -> N =< NumHandled end, Queue),
+    State#{mgmt_queue => NewQueue}.
+
+-spec check_queue_length(state()) -> state().
+check_queue_length(#{mgmt_max_queue := Limit} = State)
+  when Limit == infinity; Limit == exceeded ->
+    State;
+check_queue_length(#{mgmt_queue := Queue, mgmt_max_queue := Limit} = State) ->
+    case p1_queue:len(Queue) > Limit of
+        true ->
+            State#{mgmt_max_queue => exceeded};
+        false ->
+            State
+    end.
+
+-spec update_num_stanzas_in(state(), xmpp_element()) -> state().
+update_num_stanzas_in(#{mgmt_state := MgmtState,
+                        mgmt_stanzas_in := NumStanzasIn} = State, El)
+  when MgmtState == active ->
+    NewNum = case {xmpp:is_stanza(El), NumStanzasIn} of
+         {true, 4294967295} ->
+             0;
+         {true, Num} ->
+             Num + 1;
+         {false, Num} ->
+             Num
+         end,
+    State#{mgmt_stanzas_in => NewNum};
+update_num_stanzas_in(State, _El) ->
+    State.
+
+-spec cancel_ack_timer(state()) -> state().
+cancel_ack_timer(#{mgmt_ack_timer := TRef} = State) ->
+    case erlang:cancel_timer(TRef) of
+        false -> 
+            receive {timeout, TRef, _} -> ok
+            after 0 -> ok
+            end;
+        _ ->
+            ok
+    end,
+    maps:remove(mgmt_ack_timer, State);
+cancel_ack_timer(State) ->
+    State.
+
+
+%%%=============================================================================
+%%% Configuration processing
+%%%=============================================================================
+
+get_resume_timeout(Host) ->
+    gen_mod:get_module_opt(Host, ?MODULE, resume_timeout, 300).
+
+get_max_resume_timeout(Host, ResumeTimeout) ->
+    case gen_mod:get_module_opt(Host, ?MODULE, max_resume_timeout) of
+        undefined -> ResumeTimeout;
+        Max when Max >= ResumeTimeout -> Max;
+        _ -> ResumeTimeout
+    end.
+
+get_queue_type(Host) ->
+    case gen_mod:get_module_opt(Host, ?MODULE, queue_type) of
+        undefined -> ejabberd_config:default_queue_type(Host);
+        Type -> Type
+    end.
+
+get_max_ack_queue(Host) ->
+    gen_mod:get_module_opt(Host, ?MODULE, max_ack_queue, 1000).
+
+get_ack_timeout(Host) ->
+    case gen_mod:get_module_opt(Host, ?MODULE, ack_timeout, 10) of
+        infinity -> infinity;
+        T -> timer:seconds(T)
+    end.
+
+get_max_unacked_stanzas(Host) ->
+    gen_mod:get_module_opt(Host, ?MODULE, max_unacked_stanzas, 0).
+
+mod_opt_type(max_unacked_stanzas) ->
+    fun(I) when is_integer(I), I >= 0 -> I end;
+mod_opt_type(max_ack_queue) ->
+    fun(I) when is_integer(I), I > 0 -> I;
+       (infinity) -> infinity
+    end;
+mod_opt_type(ack_timeout) ->
+    fun(I) when is_integer(I), I > 0 -> I;
+       (infinity) -> infinity
+    end;
+mod_opt_type(resume_timeout) ->
+    fun(I) when is_integer(I), I >= 0 -> I end;
+mod_opt_type(max_resume_timeout) ->
+    fun(I) when is_integer(I), I >= 0 -> I end;
+mod_opt_type(queue_type) ->
+    fun(file) -> file;
+       (ram) -> ram
+    end;
+mod_opt_type(_) -> [max_ack_queue, ack_timeout, resume_timeout,
+                    max_resume_timeout, queue_type, max_unacked_stanzas ].

--- a/test/ejabberd_SUITE.erl
+++ b/test/ejabberd_SUITE.erl
@@ -320,10 +320,10 @@ init_per_testcase(TestCase, OrigConfig) ->
             Password = ?config(password, Config),
             ejabberd_auth:try_register(User, Server, Password),
             open_session(bind(auth(connect(Config))));
-	_ when TestGroup == s2s_tests ->
+	_ when TestGroup == s2s_tests; TestGroup == sms2s_single ->
 	    auth(connect(starttls(connect(Config))));
-        _ ->
-            open_session(bind(auth(connect(Config))))
+  _ ->
+      open_session(bind(auth(connect(Config))))
     end.
 
 end_per_testcase(_TestCase, _Config) ->
@@ -520,7 +520,8 @@ s2s_tests() ->
        test_missing_to,
        test_invalid_from,
        bad_nonza,
-       codec_failure]}].
+       codec_failure]},
+      sms2s_tests:single_cases()].
 
 groups() ->
     [{ldap, [sequence], ldap_tests()},

--- a/test/ejabberd_SUITE_data/ejabberd.yml
+++ b/test/ejabberd_SUITE_data/ejabberd.yml
@@ -488,6 +488,8 @@ Welcome to this XMPP server."
   mod_stream_mgmt:
     max_ack_queue: 10
     resume_timeout: 3
+  mod_stream_mgmt_s2s:
+    resume_timeout: 3
   mod_time: []
   mod_version: []
 registration_timeout: infinity

--- a/test/sms2s_tests.erl
+++ b/test/sms2s_tests.erl
@@ -72,7 +72,7 @@ resume_failed(Config) ->
   ct:sleep(30000),
   ct:comment("Trying to resume timed out session"),
   send(Config, #sm_resume{previd = ID, h = 0, xmlns = ?NS_STREAM_MGMT_3}),
-  #sm_failed{reason = 'item-not-found'} = recv(Config),
+  #sm_failed{reason = 'item-not-found', h = 4} = recv(Config),
   disconnect(Config).
 
 

--- a/test/sms2s_tests.erl
+++ b/test/sms2s_tests.erl
@@ -1,0 +1,85 @@
+%%%-------------------------------------------------------------------
+%%% Author  : Anna Mukharram
+%%%-------------------------------------------------------------------
+
+-module(sms2s_tests).
+
+%% API
+-compile(export_all).
+
+-import(suite, [connect/1, send/2, recv/1, set_opt/3,
+				close_socket/1, disconnect/1]).
+
+-include("suite.hrl").
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+single_cases() ->
+    {sms2s_single, [sequence],
+     [single_test(enable),
+      single_test(resume),
+      single_test(resume_failed)]}.
+
+enable(Config) ->
+  Server = ?config(server, Config),
+  ServerJID = jid:make(<<"">>, Server, <<"">>),
+  From = ?config(stream_from, Config),
+  FromJID = jid:make(<<"">>, From, <<"">>),
+  Msg = #message{from = FromJID, to = ServerJID, type = headline,
+                 body = [#text{data = <<"body">>}]},
+  ct:comment("Stream management with resumption is enabled"),
+  send(Config, #sm_enable{resume = true, xmlns = ?NS_STREAM_MGMT_3}),
+  #sm_enabled{id = ID, resume = true} = recv(Config),
+  ct:comment("Initial request; 'h' should be 0"),
+  send(Config, #sm_r{xmlns = ?NS_STREAM_MGMT_3}),
+  #sm_a{h = 0} = recv(Config),
+  ct:comment("Sending three messages and requesting again; 'h' should be 3"),
+  send(Config, Msg),
+  send(Config, Msg),
+  send(Config, Msg),
+  send(Config, #sm_r{xmlns = ?NS_STREAM_MGMT_3}),
+  #sm_a{h = 3} = recv(Config),
+  ct:comment("Closing socket"),
+  close_socket(Config),
+  {save_config, set_opt(sm_previd, ID, Config)}.
+
+resume(Config) ->
+  {_, SMConfig} = ?config(saved_config, Config),
+  ID = ?config(sm_previd, SMConfig),
+  ct:comment("Resuming the session"),
+  send(Config, #sm_resume{previd = ID, h = 0, xmlns = ?NS_STREAM_MGMT_3}),
+  #sm_resumed{previd = ID, h = 3} = recv(Config),
+  ct:comment("Checking if the server counts stanzas correctly"),
+  Server = ?config(server, Config),
+  ServerJID = jid:make(<<"">>, Server, <<"">>),
+  From = ?config(stream_from, Config),
+  FromJID = jid:make(<<"">>, From, <<"">>),
+  Msg = #message{from = FromJID, to = ServerJID, type = headline,
+                 body = [#text{data = <<"body">>}]},
+  send(Config, Msg),
+  send(Config, #sm_r{xmlns = ?NS_STREAM_MGMT_3}),
+  #sm_a{h = 4} = recv(Config),
+  ct:comment("Closing socket"),
+  close_socket(Config),
+  {save_config, set_opt(sm_previd, ID, Config)}.
+
+resume_failed(Config) ->
+  {_, SMConfig} = ?config(saved_config, Config),
+  ID = ?config(sm_previd, SMConfig),
+  ct:comment("Waiting for the session to time out"),
+  ct:sleep(30000),
+  ct:comment("Trying to resume timed out session"),
+  send(Config, #sm_resume{previd = ID, h = 0, xmlns = ?NS_STREAM_MGMT_3}),
+  #sm_failed{reason = 'item-not-found'} = recv(Config),
+  disconnect(Config).
+
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+single_test(T) ->
+    list_to_atom("sms2s_" ++ atom_to_list(T)).
+
+


### PR DESCRIPTION
Pull request

This is the pull request for ["server-to-Server Stream Management Support for ejabberd"](https://summerofcode.withgoogle.com/dashboard/project/4727744578453504/details/) GSOC 2017 project.

During GSOC 2017 `mod_stream_mgmt_s2s` was implemented. To view documentation for server-to-server stream management module follow link:

https://github.com/Amuhar/docs_for_0198_s2s/blob/master/mod_stream_mgmt_s2s.md

Tests for server part of implementation are provided (module `sms2s_tests`). 