### PR TITLE
Quote $PEER in ping command to avoid hostnames containing "-" being interpreted as arithmetic

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -294,7 +294,7 @@ case $1 in
         PEER=${2:-$ERLANG_NODE}
         [ "$PEER" = "${PEER%.*}" ] && PS="-s"
         exec_cmd "$ERL" ${PS:--}name $(uid ping $(hostname $PS)) $ERLANG_OPTS \
-                 -noinput -hidden -eval 'io:format("~p~n",[net_adm:ping('"$PEER"')])' \
+                 -noinput -hidden -eval 'io:format("~p~n",[net_adm:ping('"'$PEER'"')])' \
                  -s erlang halt -output text
         ;;
     started)


### PR DESCRIPTION
When pinging a remote peer, if the hostname contains "-" it is being interpreted as an arithmetic expression, and failing. This fixes that by quoting the peer hostname.

Before:

[ejabberd@ip-172-62-0-64 ~]$ ejabberdctl ping ejabberd@ip-172-62-0-86
{"init terminating in do_boot",{badarith,[{erlang,'-',['ejabberd@ip',172],[]},{erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,670}]},{erl_eval,expr,5,[{file,"erl_eval.erl"},{line,469}]},{erl_eval,expr_list,6,[{file,"erl_eval.erl"},{line,878}]},{erl_eval,expr,5,[{file,"erl_eval.erl"},{line,404}]},{erl_eval,expr,5,[{file,"erl_eval.erl"},{line,228}]},{erl_eval,expr_list,6,[{file,"erl_eval.erl"},{line,878}]},{erl_eval,expr,5,[{file,"erl_eval.erl"},{line,404}]}]}}
init terminating in do_boot ()

Crash dump is being written to: /opt/ejabberd/logs/erl_crash_20170911-132800.dump...done


After:

[ejabberd@ip-172-62-0-64 ~]$ ejabberdctl ping ejabberd@ip-172-62-0-86
pong
