### PR TITLE
Increase max_fsm_queue and max_ack_queue sizes

### DIFF
--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -444,7 +444,7 @@ shaper:
 ## This option specifies the maximum number of elements in the queue
 ## of the FSM. Refer to the documentation for details.
 ##
-max_fsm_queue: 1000
+max_fsm_queue: 10000
 
 ###.   ====================
 ###'   ACCESS CONTROL LISTS

--- a/src/ejabberd_redis.erl
+++ b/src/ejabberd_redis.erl
@@ -45,7 +45,7 @@
 -define(SERVER, ?MODULE).
 -define(PROCNAME, 'ejabberd_redis_client').
 -define(TR_STACK, redis_transaction_stack).
--define(DEFAULT_MAX_QUEUE, 5000).
+-define(DEFAULT_MAX_QUEUE, 10000).
 -define(MAX_RETRIES, 1).
 -define(CALL_TIMEOUT, 60*1000). %% 60 seconds
 

--- a/src/mod_stream_mgmt.erl
+++ b/src/mod_stream_mgmt.erl
@@ -709,7 +709,7 @@ bounce_message_queue() ->
 %%%===================================================================
 get_max_ack_queue(Host, Opts) ->
     gen_mod:get_module_opt(Host, ?MODULE, max_ack_queue,
-			   gen_mod:get_opt(max_ack_queue, Opts, 1000)).
+			   gen_mod:get_opt(max_ack_queue, Opts, 5000)).
 
 get_resume_timeout(Host, Opts) ->
     gen_mod:get_module_opt(Host, ?MODULE, resume_timeout,


### PR DESCRIPTION
Increase the default `max_fsm_queue` value from 1,000 to 10,000 and `mod_stream_mgmt`'s default `max_ack_queue` size from 1,000 to 5,000.  The old defaults were becoming too small for certain workloads.