### PR TITLE
Fix badarg error when running get-deps on clean clone

### DIFF
--- a/plugins/override_opts.erl
+++ b/plugins/override_opts.erl
@@ -18,7 +18,8 @@ preprocess(Config, _Dirs) ->
 		  Val -> Val
 	      end,
     Config2 = rebar_config:set_xconf(Config, top_overrides, TopOverrides),
-    Config3 = case rebar_app_utils:load_app_file(Config2, _Dirs) of
+    try
+        Config3 = case rebar_app_utils:load_app_file(Config2, _Dirs) of
 		  {ok, C, AppName, _AppData} ->
 		      lists:foldl(fun({Type, AppName2, Opts}, Conf1) when
 					    AppName2 == AppName ->
@@ -28,5 +29,8 @@ preprocess(Config, _Dirs) ->
 				  end, C, TopOverrides);
 		  _ ->
 		      Config2
-    end,
-    {ok, Config3, []}.
+	end,
+	{ok, Config3, []}
+    catch
+        error:badarg -> {ok, Config2, []}
+    end.


### PR DESCRIPTION
This PR avoids a badarg error when running get-deps before ./configure has created src/ejabberd.app

I have a module that builds using rebar with ejabberd referenced as a dependency. Up until ejabberd 17.09 (specifically commit 05feab35c4) this worked ok. Now I get a badarg error during rebar get-deps run because the override_opts rebar plugin is trying to reference the app file before it has been created.

This PR 'avoids' that. There may be better ways to fix this, but this is what I came up with.

FYI the error is:

```
$ rebar -j1 -v get-deps
INFO:  Loading plugin override_deps_versions from /Users/stu/dev/ejabberd-clean/plugins/override_deps_versions.erl
INFO:  Loading plugin deps_erl_opts from /Users/stu/dev/ejabberd-clean/plugins/deps_erl_opts.erl
INFO:  Loading plugin override_opts from /Users/stu/dev/ejabberd-clean/plugins/override_opts.erl
Uncaught error in rebar_core: {'EXIT',
                               {badarg,
                                [{erlang,length,[undefined],[]},
                                 {lists,suffix,2,
                                  [{file,"lists.erl"},{line,205}]},
                                 {rebar_app_utils,consult_app_file,1,
                                  [{file,"src/rebar_app_utils.erl"},
                                   {line,173}]},
                                 {rebar_app_utils,load_app_file,2,
                                  [{file,"src/rebar_app_utils.erl"},
                                   {line,152}]},
                                 {override_opts,preprocess,2,
                                  [{file,
                                    "/Users/stu/dev/ejabberd-clean/plugins/override_opts.erl"},
                                   {line,21}]},
                                 {rebar_core,acc_modules,5,
                                  [{file,"src/rebar_core.erl"},{line,540}]},
                                 {rebar_core,process_dir1,7,
                                  [{file,"src/rebar_core.erl"},{line,247}]},
                                 {rebar_core,process_commands,2,
                                  [{file,"src/rebar_core.erl"},{line,93}]}]}}
```
