### PR TITLE
Add a workaround for FreeBSD sed

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -133,7 +133,7 @@ FILES_WILDCARD=$(call FILTER_DIRS,$(foreach w,$(1),$(wildcard $(w))))
 
 ifeq ($(MAKECMDGOALS),copy-files-sub)
 
-DEPS:=$(sort $(shell $(REBAR) -q list-deps|$(SED) -ne '/^[a-zA-Z0-9_-]\{1,\} \(TAG\|REV\)/s/^\([^ ]*\).*/\1/p'))
+DEPS:=$(sort $(shell $(REBAR) -q list-deps|$(SED) -rne '/^[a-zA-Z0-9_-]{1,} (TAG|REV)/s/^([^ ]*).*/\1/p'))
 
 DEPS_FILES=$(call FILES_WILDCARD,$(foreach DEP,$(DEPS),deps/$(DEP)/ebin/*.beam deps/$(DEP)/ebin/*.app deps/$(DEP)/priv/* deps/$(DEP)/priv/lib/* deps/$(DEP)/priv/bin/* deps/$(DEP)/include/*.hrl deps/$(DEP)/COPY* deps/$(DEP)/LICENSE* deps/$(DEP)/lib/*/ebin/*.beam deps/$(DEP)/lib/*/ebin/*.app))
 DEPS_FILES_FILTERED=$(filter-out %/epam %/eimp deps/elixir/ebin/elixir.app,$(DEPS_FILES))


### PR DESCRIPTION
I'm the maintainer for FreeBSD port `net-im/ejabberd`, and while updating it to 17.09, and I come across a quirk about FreeBSD `sed(1)`, that it does not interpret `\|` specially, when `sed(1)` is in basic regular expression mode:

```
λ printf "Some\\|thing\nMakefile\npatch\nFoo\nBar\n" |sed  -n -e '/\(\|\)/p'
Some\|thing
λ printf "Some\\|thing\nMakefile\npatch\nFoo\nBar\n" |sed  -n -e '/\(M\|p\)/p'
λ printf "Some\\|thing\nMakefile\npatch\nFoo\nBar\n" |sed  -n -e '/\(M\)/p'   
Makefile
```

`sed(1)` in extended-regular expression mode matches it fine though:

```
λ printf "Some\\|thing\nMakefile\npatch\nFoo\nBar\n" |sed  -r -n -e '/(M|p)/p'
Makefile
patch
```

And GNU `sed(1)` works fine with both expressions: 

```
λ printf "Some\\|thing\nMakefile\npatch\nFoo\nBar\n" |gsed  -n -e '/\(M\|p\)/p'
Makefile
patch
λ printf "Some\\|thing\nMakefile\npatch\nFoo\nBar\n" |gsed -r -n -e '/(M|p)/p' 
Makefile
patch
```

I will check, and file bug on FreeBSD side in case this is an unacceptable behaviour, but in the meantime, if we can commit the attached diff, that'll be great.

In case, you're not open to accepting this workaround, then in that case please close this pull-request, and I will just add this workaround downstream, which I am adding for `17.09` port anyways.

Thanks!