### PR TITLE
Set executable permission on mac_listener when installing

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -136,7 +136,7 @@ ifeq ($(MAKECMDGOALS),copy-files-sub)
 DEPS:=$(sort $(shell $(REBAR) -q list-deps|$(SED) -ne '/ TAG / s/ .*// p; / REV / s/ .*// p; / BRANCH / s/ .*// p'))
 
 DEPS_FILES=$(call FILES_WILDCARD,$(foreach DEP,$(DEPS),deps/$(DEP)/ebin/*.beam deps/$(DEP)/ebin/*.app deps/$(DEP)/priv/* deps/$(DEP)/priv/lib/* deps/$(DEP)/priv/bin/* deps/$(DEP)/include/*.hrl deps/$(DEP)/COPY* deps/$(DEP)/LICENSE* deps/$(DEP)/lib/*/ebin/*.beam deps/$(DEP)/lib/*/ebin/*.app))
-DEPS_FILES_FILTERED=$(filter-out %/epam %/eimp deps/elixir/ebin/elixir.app,$(DEPS_FILES))
+DEPS_FILES_FILTERED=$(filter-out %/epam %/eimp %/mac_listener deps/elixir/ebin/elixir.app,$(DEPS_FILES))
 DEPS_DIRS=$(sort deps/ $(foreach DEP,$(DEPS),deps/$(DEP)/) $(dir $(DEPS_FILES)))
 
 MAIN_FILES=$(filter-out %/configure.beam,$(call FILES_WILDCARD,ebin/*.beam ebin/*.app priv/msgs/*.msg priv/css/*.css priv/img/*.png priv/js/*.js priv/lib/* include/*.hrl COPYING))
@@ -162,6 +162,9 @@ $(call TO_DEST,deps/epam/priv/bin/epam): $(LIBDIR)/%: deps/epam/priv/bin/epam $(
 	$(INSTALL) -m 750 $(O_USER) $< $@
 
 $(call TO_DEST,deps/eimp/priv/bin/eimp): $(LIBDIR)/%: deps/eimp/priv/bin/eimp $(call TO_DEST,deps/eimp/priv/bin/)
+	$(INSTALL) -m 755 $(O_USER) $< $@
+
+$(call TO_DEST,deps/fs/priv/mac_listener): $(LIBDIR)/%: deps/fs/priv/mac_listener $(call TO_DEST,deps/fs/priv/)
 	$(INSTALL) -m 755 $(O_USER) $< $@
 
 $(call TO_DEST,priv/sql/lite.sql): sql/lite.sql $(call TO_DEST,priv/sql)


### PR DESCRIPTION
Fixes this:

```
2017-12-01 12:20:25 =CRASH REPORT====
  crasher:
    initial call: fs_server:init/1
    pid: <0.323.0>
    registered_name: []
    exception error: {eacces,[{erlang,open_port,[{spawn_executable,"/Users/stu/my-ejabberd/lib/fs-2.12.0/priv/mac_listener"},[stream,exit_status,{line,16384},{args,["-F",<<"/Users/stu/my-ejabberd/etc/ejabberd/ssl">>]},{cd,<<"/Users/stu/my-ejabberd/etc/ejabberd/ssl">>}]],[]},{fs_server,init,1,[{file,"src/fs_server.erl"},{line,11}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,365}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,333}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
    ancestors: ['119507313sup',ejabberd_pkix,ejabberd_sup,<0.65.0>]
    message_queue_len: 0
    messages: []
    links: [<0.322.0>]
    dictionary: []
    trap_exit: false
    status: running
    heap_size: 610
    stack_size: 27
    reductions: 441
  neighbours:
2017-12-01 12:20:25 =SUPERVISOR REPORT====
     Supervisor: {local,'119507313sup'}
     Context:    start_error
     Reason:     {eacces,[{erlang,open_port,[{spawn_executable,"/Users/stu/my-ejabberd/lib/fs-2.12.0/priv/mac_listener"},[stream,exit_status,{line,16384},{args,["-F",<<"/Users/stu/my-ejabberd/etc/ejabberd/ssl">>]},{cd,<<"/Users/stu/my-ejabberd/etc/ejabberd/ssl">>}]],[]},{fs_server,init,1,[{file,"src/fs_server.erl"},{line,11}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,365}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,333}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,247}]}]}
     Offender:   [{pid,undefined},{id,fs_server},{mfargs,{fs_server,start_link,['119507313file','119507313',fsevents,<<"/Users/stu/my-ejabberd/etc/ejabberd/ssl">>,<<"/Users/stu/my-ejabberd/etc/ejabberd/ssl">>]}},{restart_type,permanent},{shutdown,5000},{child_type,worker}]
```
