### PR TITLE
Use /bin/sh as the explicit shell when using su in ejabberdctl.

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -110,7 +110,7 @@ export ERL_LIBS
 exec_cmd()
 {
     case $EXEC_CMD in
-        as_install_user) su -c '"$0" "$@"' "$INSTALLUSER" -- "$@" ;;
+        as_install_user) su -s /bin/sh -c '"$0" "$@"' "$INSTALLUSER" -- "$@" ;;
         as_current_user) "$@" ;;
     esac
 }


### PR DESCRIPTION
Some distributions (such as Fedora) use /sbin/nologin as the login
shell for the ejabberd user. The newer version of ejabberdctl uses
su to perform the command if the INSTALLUSER invokes the script.
This commit adjusts the call to su so that it passes /bin/sh as
the shell to use so that it will work correctly when the ejabberd
user's shell is set to nologin.

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>

We are open to contributions for ejabberd, as GitHub pull requests (PR).
Here are a few points to consider before submitting your PR. (You can
remove the whole text after reading.)

1. Does this PR address an issue? Please reference it in the PR
   description.

2. Have you properly described the proposed change?

3. Please make sure the change is atomic and does only touch the needed
   modules. If you have other changes/fixes to provide, please submit
   them as separate PRs.

4. If your change or new feature involves storage backends, did you make
   sure your change works with all backends?

5. Do you provide tests? How can we check the behavior of the code?

6. Did you consider documentation changes in the
   processone/docs.ejabberd.im repository?
