### PR TITLE
Support pubsub#publish-options PRECONDITIONs

### DIFF
--- a/src/node_flat.erl
+++ b/src/node_flat.erl
@@ -105,6 +105,7 @@ features() ->
 	<<"persistent-items">>,
 	<<"publish">>,
 	<<"publish-only-affiliation">>,
+	<<"publish-options">>,
 	<<"purge-nodes">>,
 	<<"retract-items">>,
 	<<"retrieve-affiliations">>,

--- a/src/node_mb.erl
+++ b/src/node_mb.erl
@@ -93,6 +93,7 @@ features() ->
 	<<"outcast-affiliation">>,
 	<<"persistent-items">>,
 	<<"publish">>,
+	<<"publish-options">>,
 	<<"purge-nodes">>,
 	<<"retract-items">>,
 	<<"retrieve-affiliations">>,

--- a/src/node_pep.erl
+++ b/src/node_pep.erl
@@ -87,6 +87,7 @@ features() ->
 	<<"outcast-affiliation">>,
 	<<"persistent-items">>,
 	<<"publish">>,
+	<<"publish-options">>,
 	<<"purge-nodes">>,
 	<<"retract-items">>,
 	<<"retrieve-affiliations">>,


### PR DESCRIPTION
Add support for publishing options as per the [current][1] [wording][2] of XEP-0060.

Recent Conversations versions (and maybe other clients) need this to make [OMEMO][3] work without presence subscription.

[1]: https://github.com/xsf/xeps/pull/481
[2]: https://xmpp.org/extensions/xep-0060.html#publisher-publish-options
[3]: https://conversations.im/omemo/