### PR TITLE
privacy_tests: Omit test for 'subscribe' presence

### DIFF
--- a/test/privacy_tests.erl
+++ b/test/privacy_tests.erl
@@ -709,7 +709,7 @@ check_other_blocked(Config, Reason) ->
 	      #presence{type = error} = Err =
 		  send_recv(Config, #presence{type = Type, to = PeerJID}),
 	      #stanza_error{reason = Reason} = xmpp:get_error(Err)
-      end, [subscribe, subscribed, unsubscribe, unsubscribed]).
+      end, [subscribed, unsubscribe, unsubscribed]).
 
 send_presences(Config) ->
     PeerJID = ?config(peer, Config),


### PR DESCRIPTION
With commit b54e1e49ba6794725bead67d530b50ab89ce078b, sending `subscribe` presence to a blocked JID generates roster pushes which the privacy tests currently fail to handle.