### PR TITLE
Fix example config macro names

### DIFF
--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -257,9 +257,9 @@ listen:
   ##   request_handlers:
   ##     "": mod_http_upload
   ##   tls: true
-  ##   protocol_options: 'TLSOPTS'
-  ##   dhfile: 'DHFILE'
-  ##   ciphers: 'CIPHERS'
+  ##   protocol_options: 'TLS_OPTIONS'
+  ##   dhfile: 'DH_FILE'
+  ##   ciphers: 'TLS_CIPHERS'
 
 ## Disabling digest-md5 SASL authentication. digest-md5 requires plain-text
 ## password storage (see auth_password_format option).


### PR DESCRIPTION
These were missed in https://github.com/processone/ejabberd/commit/c26b56679e06ef8b88734030de11c6b885f9bb78 I guess.