### PR TITLE
Issue: mod_muc.erl expect wrong return value

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -107,8 +107,7 @@
 -callback unregister_online_user(binary(), ljid(), binary(), binary()) -> any().
 -callback count_online_rooms_by_user(binary(), binary(), binary()) -> non_neg_integer().
 -callback get_online_rooms_by_user(binary(), binary(), binary()) -> [{binary(), binary()}].
--callback get_subscribed_rooms(binary(), binary(), jid()) ->
-    {ok, [{ljid(), binary(), [binary()]}]} | {error, any()}.
+-callback get_subscribed_rooms(binary(), binary(), jid()) -> [ljid()] | [].
 
 %%====================================================================
 %% API
@@ -727,7 +726,7 @@ iq_get_register_info(ServerHost, Host, From, Lang) ->
 	       instructions = [Inst], fields = Fields},
     #register{nick = Nick,
 	      registered = Registered,
-	      instructions = 
+	      instructions =
 		  translate:translate(
 		    Lang, <<"You need a client that supports x:data "
 			    "to register the nickname">>),


### PR DESCRIPTION
Dialyzer checks always failed because the return value of the function 'get_subscribed_rooms' in 'mod_muc_sql' is different to the defined value in 'mod_muc'. Fix was to update the return value in 'mod_muc.erl'.


