### PR TITLE
Validate additional listen opts

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -999,6 +999,9 @@ opt_type(_) ->
 		     (max_stanza_size) -> fun((timeout()) -> timeout());
 		     (max_fsm_queue) -> fun((timeout()) -> timeout());
 		     (stream_management) -> fun((boolean()) -> boolean());
+		     (inet) -> fun((boolean()) -> boolean());
+		     (inet6) -> fun((boolean()) -> boolean());
+		     (backlog) -> fun((timeout()) -> timeout());
 		     (atom()) -> [atom()].
 listen_opt_type(access) -> fun acl:access_rules_validator/1;
 listen_opt_type(shaper) -> fun acl:shaper_rules_validator/1;
@@ -1031,13 +1034,18 @@ listen_opt_type(stream_management) ->
     ?ERROR_MSG("listening option 'stream_management' is ignored: "
 	       "use mod_stream_mgmt module", []),
     fun(B) when is_boolean(B) -> B end;
+listen_opt_type(inet) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(inet6) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(backlog) ->
+    fun(I) when is_integer(I), I>0 -> I end;
 listen_opt_type(O) ->
     StreamOpts = mod_stream_mgmt:mod_options(?MYNAME),
     case lists:keyfind(O, 1, StreamOpts) of
 	false ->
 	    [access, shaper, certfile, ciphers, dhfile, cafile,
 	     protocol_options, tls, tls_compression, starttls,
-	     starttls_required, tls_verify, zlib, max_fsm_queue];
+	     starttls_required, tls_verify, zlib, max_fsm_queue,
+	     backlog, inet, inet6];
 	_ ->
 	    ?ERROR_MSG("Listening option '~s' is ignored: use '~s' "
 		       "option from mod_stream_mgmt module", [O, O]),

--- a/src/ejabberd_http.erl
+++ b/src/ejabberd_http.erl
@@ -994,6 +994,10 @@ listen_opt_type(default_host) ->
     fun(A) -> A end;
 listen_opt_type(custom_headers) ->
     fun expand_custom_headers/1;
+listen_opt_type(inet) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(inet6) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(backlog) ->
+    fun(I) when is_integer(I), I>0 -> I end;
 listen_opt_type(_) ->
     %% TODO
     fun(A) -> A end.

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -358,6 +358,9 @@ change_shaper(#{shaper := ShaperName, server_host := ServerHost} = State,
 		     (supervisor) -> fun((boolean()) -> boolean());
 		     (max_stanza_type) -> fun((timeout()) -> timeout());
 		     (max_fsm_queue) -> fun((pos_integer()) -> pos_integer());
+		     (inet) -> fun((boolean()) -> boolean());
+		     (inet6) -> fun((boolean()) -> boolean());
+		     (backlog) -> fun((timeout()) -> timeout());
 		     (atom()) -> [atom()].
 listen_opt_type(shaper) -> fun acl:shaper_rules_validator/1;
 listen_opt_type(certfile = Opt) ->
@@ -381,6 +384,10 @@ listen_opt_type(max_stanza_size) ->
     end;
 listen_opt_type(max_fsm_queue) ->
     fun(I) when is_integer(I), I>0 -> I end;
+listen_opt_type(inet) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(inet6) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(backlog) ->
+    fun(I) when is_integer(I), I>0 -> I end;
 listen_opt_type(_) ->
     [shaper, certfile, ciphers, dhfile, cafile, protocol_options,
-     tls_compression, tls, max_fsm_queue].
+     tls_compression, tls, max_fsm_queue, backlog, inet, inet6].

--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -291,6 +291,9 @@ transform_listen_option(Opt, Opts) ->
 					   [{binary(), binary() | undefined}]);
 		     (max_stanza_type) -> fun((timeout()) -> timeout());
 		     (max_fsm_queue) -> fun((pos_integer()) -> pos_integer());
+		     (inet) -> fun((boolean()) -> boolean());
+		     (inet6) -> fun((boolean()) -> boolean());
+		     (backlog) -> fun((timeout()) -> timeout());
 		     (atom()) -> [atom()].
 listen_opt_type(access) -> fun acl:access_rules_validator/1;
 listen_opt_type(shaper_rule) -> fun acl:shaper_rules_validator/1;
@@ -328,7 +331,11 @@ listen_opt_type(max_stanza_size) ->
     end;
 listen_opt_type(max_fsm_queue) ->
     fun(I) when is_integer(I), I>0 -> I end;
+listen_opt_type(inet) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(inet6) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(backlog) ->
+    fun(I) when is_integer(I), I>0 -> I end;
 listen_opt_type(_) ->
     [access, shaper_rule, certfile, ciphers, dhfile, cafile, tls,
      protocol_options, tls_compression, password, hosts, check_from,
-     max_fsm_queue, global_routes].
+     max_fsm_queue, global_routes, backlog, inet, inet6].

--- a/src/ejabberd_stun.erl
+++ b/src/ejabberd_stun.erl
@@ -172,8 +172,10 @@ listen_opt_type(turn_max_permissions) ->
     end;
 listen_opt_type(server_name) ->
     fun iolist_to_binary/1;
+listen_opt_type(backlog) ->
+    fun(I) when is_integer(I), I>0 -> I end;
 listen_opt_type(_) ->
     [shaper, auth_type, auth_realm, tls, certfile, turn_min_port,
      turn_max_port, turn_max_allocations, turn_max_permissions,
-     server_name].
+     server_name, backlog].
 -endif.

--- a/src/ejabberd_xmlrpc.erl
+++ b/src/ejabberd_xmlrpc.erl
@@ -581,5 +581,9 @@ listen_opt_type(maxsessions) ->
     fun(I) when is_integer(I), I>0 -> I end;
 listen_opt_type(timeout) ->
     fun(I) when is_integer(I), I>0 -> I end;
+listen_opt_type(inet) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(inet6) -> fun(B) when is_boolean(B) -> B end;
+listen_opt_type(backlog) ->
+    fun(I) when is_integer(I), I>0 -> I end;
 listen_opt_type(_) ->
-    [access_commands, maxsessions, timeout].
+    [access_commands, maxsessions, timeout, backlog, inet, inet6].


### PR DESCRIPTION
The options "inet", "inet6" and "backlog" are valid listen options, but are
currently logged as errors (even though they do work):

2018-02-28 16:08:44.141 [error] <0.338.0>@ejabberd_listener:validate_module_option:630 unknown listen option 'backlog' for 'ejabberd_c2s' will be likely ignored, available options are: access, shaper, certfile, ciphers, dhfile, cafile, client_cafile, protocol_options, tls, tls_compression, starttls, starttls_required, tls_verify, zlib, max_fsm_queue

This adds the necessary validators so they are correctly recognized.
