### PR TITLE
Add support for specifying accepted Client CAs

### DIFF
--- a/src/ejabberd_pkix.erl
+++ b/src/ejabberd_pkix.erl
@@ -28,7 +28,8 @@
 %% API
 -export([start_link/0, add_certfile/1, format_error/1, opt_type/1,
 	 get_certfile/1, try_certfile/1, route_registered/1,
-	 config_reloaded/0, certs_dir/0, ca_file/0, get_default_certfile/0]).
+	 config_reloaded/0, certs_dir/0, ca_file/0, client_ca_file/0,
+	 get_default_certfile/0]).
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 	 terminate/2, code_change/3]).
@@ -181,6 +182,10 @@ opt_type(ca_file) ->
     fun(Path) ->
 	    binary_to_list(misc:try_read_file(Path))
     end;
+opt_type(client_ca_file) ->
+    fun(Path) ->
+	    binary_to_list(misc:try_read_file(Path))
+    end;
 opt_type(certfiles) ->
     fun(CertList) ->
 	    [binary_to_list(Path) || Path <- CertList]
@@ -191,7 +196,7 @@ opt_type(O) when O == c2s_certfile; O == s2s_certfile; O == domain_certfile ->
 	    misc:try_read_file(File)
     end;
 opt_type(_) ->
-    [ca_path, ca_file, certfiles, c2s_certfile, s2s_certfile, domain_certfile].
+    [ca_path, ca_file, client_ca_file, certfiles, c2s_certfile, s2s_certfile, domain_certfile].
 
 %%%===================================================================
 %%% gen_server callbacks
@@ -607,6 +612,10 @@ ca_dir() ->
 -spec ca_file() -> string() | undefined.
 ca_file() ->
     ejabberd_config:get_option(ca_file).
+
+-spec client_ca_file() -> string() | undefined.
+client_ca_file() ->
+    ejabberd_config:get_option(client_ca_file).
 
 -spec certs_dir() -> string().
 certs_dir() ->

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -227,10 +227,15 @@ tls_options(LServer, DefaultOpts) ->
 		   CAFile -> lists:keystore(cafile, 1, TLSOpts4,
 					    {cafile, CAFile})
 	       end,
+    TLSOpts6 = case get_client_cafile(LServer) of
+		   undefined -> TLSOpts5;
+		   ClientCAFile -> lists:keystore(client_cafile, 1, TLSOpts5,
+					    {client_cafile, ClientCAFile})
+	       end,
     case ejabberd_config:get_option({s2s_tls_compression, LServer}) of
 	undefined -> TLSOpts5;
-	false -> [compression_none | TLSOpts5];
-	true -> lists:delete(compression_none, TLSOpts5)
+	false -> [compression_none | TLSOpts6];
+	true -> lists:delete(compression_none, TLSOpts6)
     end.
 
 -spec tls_required(binary()) -> boolean().
@@ -282,6 +287,15 @@ get_cafile(LServer) ->
     case ejabberd_config:get_option({s2s_cafile, LServer}) of
 	undefined ->
 	    ejabberd_pkix:ca_file();
+	File ->
+	    File
+    end.
+
+-spec get_client_cafile(binary()) -> file:filename_all() | undefined.
+get_client_cafile(LServer) ->
+    case ejabberd_config:get_option({s2s_client_cafile, LServer}) of
+	undefined ->
+	    ejabberd_pkix:client_ca_file();
 	File ->
 	    File
     end.


### PR DESCRIPTION
This adds config option client_cafile (and c2s/s2s variants) to allow
specifying accepted CAs for client certificates.

We are open to contributions for ejabberd, as GitHub pull requests (PR).
Here are a few points to consider before submitting your PR. (You can
remove the whole text after reading.)

Note: this requires https://github.com/processone/fast_tls/pull/32 to be accepted first (and ejabberd's fast_tls dependency updated)