### PR TITLE
feat: add hook for sending packet from component

### DIFF
--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -185,13 +185,13 @@ handle_auth_failure(_, Mech, Reason,
 	       Reason]),
     State.
 
-handle_authenticated_packet(Pkt0, #{server := Server, ip := {IP, _}, lang := Lang} = State)
+handle_authenticated_packet(Pkt0, #{ip := {IP, _}, lang := Lang} = State)
   when ?is_stanza(Pkt0) ->
     Pkt = xmpp:put_meta(Pkt0, ip, IP),
     From = xmpp:get_from(Pkt),
     case check_from(From, State) of
 	true ->
-        {Pkt2, State2} = ejabberd_hooks:run_fold(component_send_packet, Server, {Pkt, State}, []),
+        {Pkt2, State2} = ejabberd_hooks:run_fold(component_send_packet, {Pkt, State}, []),
         case Pkt2 of
             drop ->
                 ok;


### PR DESCRIPTION
Hi. This PR added new  hook `component_send_packet` for sending packet from components. Callback function must accept one argument `{Pkt, ComponentState}` and should yield `drop` or `{NewPkt, NewComponentState}`.
