### PR TITLE
Check packet in callback functions of 'user_send_packet' hook

### DIFF
--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -139,13 +139,15 @@ iq_handler(#iq{type = get, lang = Lang} = IQ)->
 
 -spec user_send_packet({stanza(), ejabberd_c2s:state()})
       -> {stanza(), ejabberd_c2s:state()} | {stop, {stanza(), ejabberd_c2s:state()}}.
-user_send_packet({Packet, C2SState}) ->
+user_send_packet({Packet, C2SState}) when Packet =/= drop ->
     From = xmpp:get_from(Packet),
     To = xmpp:get_to(Packet),
     case check_and_forward(From, To, Packet, sent) of
 	{stop, Pkt} -> {stop, {Pkt, C2SState}};
 	Pkt -> {Pkt, C2SState}
-    end.
+    end;
+user_send_packet(Acc) ->
+    Acc.
 
 -spec user_receive_packet({stanza(), ejabberd_c2s:state()})
       -> {stanza(), ejabberd_c2s:state()} | {stop, {stanza(), ejabberd_c2s:state()}}.

--- a/src/mod_service_log.erl
+++ b/src/mod_service_log.erl
@@ -55,10 +55,12 @@ depends(_Host, _Opts) ->
     [].
 
 -spec log_user_send({stanza(), ejabberd_c2s:state()}) -> {stanza(), ejabberd_c2s:state()}.
-log_user_send({Packet, C2SState}) ->
+log_user_send({Packet, C2SState}) when Packet =/= drop ->
     From = xmpp:get_from(Packet),
     log_packet(Packet, From#jid.lserver),
-    {Packet, C2SState}.
+    {Packet, C2SState};
+log_user_send(Acc) ->
+    Acc.
 
 -spec log_user_receive({stanza(), ejabberd_c2s:state()}) -> {stanza(), ejabberd_c2s:state()}.
 log_user_receive({Packet, C2SState}) ->


### PR DESCRIPTION
Hi. We wrote some filtering modules for c2s packets and we used `user_send_packet` hook. Our hook callback has priority 1 and sometimes it yields `drop` instead of `NewPkt`.When our module drops some packets we see lots of error messages in logs. For example [here](https://github.com/processone/ejabberd/blob/ea87bdfbe57027b2160bb4ff9d5500ae54126123/src/mod_carboncopy.erl#L143) `xmpp:get_from(drop)` causes function clause error. So i have created this PR. I preferred guard `Pkt =/= drop` over [these](https://github.com/processone/xmpp/blob/master/include/xmpp.hrl#L32) 4 guards.