### PR TITLE
ejabberdctl: fix parameters parsing

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -41,19 +41,17 @@ case $(id -un) in
 esac
 
 # parse command line parameters
-for arg; do
-    case $arg in
-        -n|--node) ERLANG_NODE_ARG=$2; shift;;
-        -s|--spool) SPOOL_DIR=$2; shift;;
-        -l|--logs) LOGS_DIR=$2; shift;;
-        -f|--config) EJABBERD_CONFIG_PATH=$2; shift;;
-        -c|--ctl-config) EJABBERDCTL_CONFIG_PATH=$2; shift;;
-        -d|--config-dir) ETC_DIR=$2; shift;;
-        -t|--no-timeout) NO_TIMEOUT="--no-timeout";;
-        --) :;;
+while [ $# -gt 0 ]; do
+    case $1 in
+        -n|--node) ERLANG_NODE_ARG=$2; shift 2;;
+        -s|--spool) SPOOL_DIR=$2; shift 2;;
+        -l|--logs) LOGS_DIR=$2; shift 2;;
+        -f|--config) EJABBERD_CONFIG_PATH=$2; shift 2;;
+        -c|--ctl-config) EJABBERDCTL_CONFIG_PATH=$2; shift 2;;
+        -d|--config-dir) ETC_DIR=$2; shift 2;;
+        -t|--no-timeout) NO_TIMEOUT="--no-timeout"; shift;;
         *) break;;
     esac
-    shift
 done
 
 # define ejabberd variables if not already defined from the command line


### PR DESCRIPTION
This PR proposes a fix for the `ejabberdctl` parameter parser, which currently does not allow passing multiple parameters of the form `--param arg`.

Example:
```console
$ ejabberdctl --spool /dir1 --logs /dir2 foreground
```

The above command line will be parsed as follows
1. `for` sets `arg` to `--spool`
1. `case $arg` sets `SPOOL_DIR` to `/dir1` and `shift`s
1. `shift` is called again; `$@` is now `--logs`, `/dir2`, and `foreground`
1. `for` sets `arg` to `/dir1` (because `shift` had no effect on the list passed to `for`)
1. `case $arg` calls `break`

The `main` part of `ejabberdctl` in turn fails because `$@` is as seen in (3).