### PR TITLE
Route balancing using jumping consistent hashing algorithm (#2215)

### DIFF
--- a/include/ejabberd_router.hrl
+++ b/include/ejabberd_router.hrl
@@ -2,6 +2,8 @@
 
 -type local_hint() :: integer() | {apply, atom(), atom()}.
 
+-type balancing_algorithm() :: dynamic | fix_number | consistent_hashing.
+
 -record(route, {domain :: binary() | '_',
 		server_host :: binary() | '_',
 		pid :: undefined | pid(),

--- a/rebar.config
+++ b/rebar.config
@@ -31,6 +31,7 @@
         {p1_oauth2, ".*", {git, "https://github.com/processone/p1_oauth2", {tag, "0.6.3"}}},
         {jose, ".*", {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.8.4"}}},
         {eimp, ".*", {git, "https://github.com/processone/eimp", {tag, "1.0.5"}}},
+        {jch, ".*", {git, "https://github.com/darach/jch-erl", {tag, "0.2.3"}}},
         {if_var_true, stun, {stun, ".*", {git, "https://github.com/processone/stun", {tag, "1.0.22"}}}},
         {if_var_true, sip, {esip, ".*", {git, "https://github.com/processone/esip", {tag, "1.0.23"}}}},
         {if_var_true, mysql, {p1_mysql, ".*", {git, "https://github.com/processone/p1_mysql",

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -54,7 +54,8 @@
 	 is_my_host/1,
 	 clean_cache/1,
 	 config_reloaded/0,
-	 get_backend/0]).
+	 get_backend/0,
+	 get_domain_balancing_algorithm/1]).
 
 -export([start_link/0]).
 
@@ -67,6 +68,8 @@
 
 %% This value is used in SIP and Megaco for a transaction lifetime.
 -define(IQ_TIMEOUT, 32000).
+
+-define(MAX_PHASH_RANGE, 4294967296).
 
 -include("ejabberd.hrl").
 -include("logger.hrl").
@@ -394,8 +397,9 @@ do_route(_Pkt, _Route) ->
 balancing_route(From, To, Packet, Rs) ->
     LDstDomain = To#jid.lserver,
     Value = get_domain_balancing(From, To, LDstDomain),
-    case get_component_number(LDstDomain) of
-	undefined ->
+
+    case get_domain_balancing_algorithm(LDstDomain) of
+	dynamic ->
 	    case [R || R <- Rs, node(R#route.pid) == node()] of
 		[] ->
 		    R = lists:nth(erlang:phash(Value, length(Rs)), Rs),
@@ -404,10 +408,15 @@ balancing_route(From, To, Packet, Rs) ->
 		    R = lists:nth(erlang:phash(Value, length(LRs)), LRs),
 		    do_route(Packet, R)
 	    end;
-	_ ->
+	fix_number ->
 	    SRs = lists:ukeysort(#route.local_hint, Rs),
 	    R = lists:nth(erlang:phash(Value, length(SRs)), SRs),
-	    do_route(Packet, R)
+	    do_route(Packet, R);
+	consistent_hashing ->
+		  SRs = lists:ukeysort(#route.local_hint, Rs),
+			Rn = jch:ch(erlang:phash(Value, ?MAX_PHASH_RANGE), length(SRs)),
+			R = lists:nth(Rn + 1, SRs),
+			do_route(Packet, R)
     end.
 
 -spec get_component_number(binary()) -> pos_integer() | undefined.
@@ -424,6 +433,18 @@ get_domain_balancing(From, To, LDomain) ->
 	bare_source -> jid:remove_resource(jid:tolower(From));
 	bare_destination -> jid:remove_resource(jid:tolower(To))
     end.
+
+-spec get_domain_balancing_algorithm(binary()) -> balancing_algorithm().
+get_domain_balancing_algorithm(LDomain) ->
+	case ejabberd_config:get_option({domain_balancing_algorithm, LDomain}) of
+		AlgorithmName when  AlgorithmName == undefined; AlgorithmName == fix_number ->
+			case get_component_number(LDomain) of
+				undefined -> dynamic;
+				_ -> fix_number
+			end;
+		AlgorithmName ->
+			AlgorithmName
+	end.
 
 -spec get_backend() -> module().
 get_backend() ->


### PR DESCRIPTION
1. Added new balancing algorithm (detailed explanation in #2215)
2. Added configuration option  ```domain_balancing_algorithm``` with possible values: ```dynamic```, ```fix_number``` and ```consistent_hashing``` where:
- ```dynamic``` behaves like in situation when ```domain_balancing_component_number ``` has not been set
- ```fix_number``` behaves like in situation when ```domain_balancing_component_number ``` has been set
- ```consistent_hashing``` is the new algorithm explained in #2215

3. When ```domain_balancing_algorithm``` is not set, fallback to ```domain_balancing_component_number ``` logic is used
