### PR TITLE
Fix compiling issue in elixir umbrella app

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -82,8 +82,8 @@ defmodule Ejabberd.Mixfile do
 
   defp deps_include(deps) do
     base = case Mix.Project.deps_paths()[:ejabberd] do
-      nil -> "deps"
-      _ -> ".."
+      nil -> unless Mix.Project.umbrella?(), do: "deps", else: "../../deps"
+      _   -> unless Mix.Project.umbrella?(), do: "..",   else: "../../"
     end
     Enum.map(deps, fn dep -> base<>"/#{dep}/include" end)
   end


### PR DESCRIPTION
Fixes the issue when compiling ejabberd in an Elixir umbrella app structure where deps is located at `../../deps` instead of `deps` I do a simple check to verify that it's an umbrella app with `Mix.Project.umbrella?/0` and then return the right path. this issue is occurring when require ejabberd in `my_umbrella_app/apps/my_umbrella_app_web/mix.exs`.