### PR TITLE
Resolve elixir compilation warnings

### DIFF
--- a/lib/ct_formatter.ex
+++ b/lib/ct_formatter.ex
@@ -1,7 +1,7 @@
 defmodule ExUnit.CTFormatter do
   @moduledoc false
 
-  use GenEvent
+  @behaviour :gen_event
 
   import ExUnit.Formatter, only: [format_time: 2, format_test_failure: 5,
                                   format_test_case_failure: 5]
@@ -22,6 +22,10 @@ defmodule ExUnit.CTFormatter do
       invalids_counter: 0
     }
     {:ok, config}
+  end
+
+  def handle_call(_, config) do
+    {:ok, :ok, config}
   end
 
   def handle_event({:suite_started, _opts}, config) do

--- a/lib/ejabberd/config/config.ex
+++ b/lib/ejabberd/config/config.ex
@@ -49,8 +49,8 @@ defmodule Ejabberd.Config do
   """
   def get_ejabberd_opts do
     get_general_opts()
-    |> Dict.put(:modules, get_modules_parsed_in_order())
-    |> Dict.put(:listeners, get_listeners_parsed_in_order())
+    |> Keyword.put(:modules, get_modules_parsed_in_order())
+    |> Keyword.put(:listeners, get_listeners_parsed_in_order())
     |> Ejabberd.Config.OptsFormatter.format_opts_for_ejabberd
   end
 


### PR DESCRIPTION
This PR resolves all the following compile warnings:

```shell
warning: the GenEvent module is deprecated, see its documentation for alternatives
  lib/ct_formatter.ex:4

warning: Dict.put/3 is deprecated. Use the Map module for working with maps or the Keyword module for working with keyword lists
Found at 2 locations:
  lib/ejabberd/config/config.ex:52
  lib/ejabberd/config/config.ex:53

warning: GenEvent.__using__/1 is deprecated. Use one of the alternatives described in the documentation for the GenEvent module
  lib/ct_formatter.ex:4
```