### PR TITLE
mod_muc: Increase default 'max_user_conferences' value

### DIFF
--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -1002,7 +1002,7 @@ mod_options(Host) ->
      {max_room_id, infinity},
      {max_room_name, infinity},
      {max_rooms_discoitems, 100},
-     {max_user_conferences, 10},
+     {max_user_conferences, 100},
      {max_users, 200},
      {max_users_admin_threshold, 5},
      {max_users_presence, 1000},


### PR DESCRIPTION
Let up to 100 clients of a given account join MUC rooms by default.   The old default value (10) can be too small, e.g., when users join many (private) rooms with multiple devices.  It was probably chosen back when private group chat wasn't a thing.