### PR TITLE
Use lua scripting to clear redis sessions.

### DIFF
--- a/src/ejabberd_sm_redis.erl
+++ b/src/ejabberd_sm_redis.erl
@@ -37,7 +37,6 @@
 -export([init/1, handle_cast/2, handle_call/3, handle_info/2,
 	 terminate/2, code_change/3, start_link/0]).
 
--include("ejabberd.hrl").
 -include("ejabberd_sm.hrl").
 -include("logger.hrl").
 
@@ -160,7 +159,7 @@ handle_info({redis_message, ?SM_KEY, Data}, State) ->
     end,
     {noreply, State};
 handle_info(Info, State) ->
-    ?ERROR_MSG("unexpected info: ~p in cluster server", [Info]),
+    ?ERROR_MSG("unexpected info: ~p ", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->


### PR DESCRIPTION
I had come across https://github.com/processone/ejabberd/issues/1905. @zinid suggested to submit a PR for improving the behavior using lua.  

In the proposed new session management scheme, an additional key which associates session to node mapping is maintained in redis. This is done because we need to find out the node to session association without it being deserialized in ejabberd. A recursive call is made to redis server for cleaning all the sessions, since lua-timeout might occur in the presence of large amount of sessions. 
