### PR TITLE
Enforce pubsub option required/rejected attributes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -25,7 +25,7 @@
         {fast_tls, ".*", {git, "https://github.com/processone/fast_tls", {tag, "1.0.23"}}},
         {stringprep, ".*", {git, "https://github.com/processone/stringprep", {tag, "1.0.12"}}},
         {fast_xml, ".*", {git, "https://github.com/processone/fast_xml", {tag, "1.1.32"}}},
-        {xmpp, ".*", {git, "https://github.com/processone/xmpp", "c98ee04"}},
+        {xmpp, ".*", {git, "https://github.com/processone/xmpp", "007a716"}},
         {fast_yaml, ".*", {git, "https://github.com/processone/fast_yaml", {tag, "1.0.15"}}},
         {jiffy, ".*", {git, "https://github.com/davisp/jiffy", {tag, "0.14.8"}}},
         {p1_oauth2, ".*", {git, "https://github.com/processone/p1_oauth2", {tag, "0.6.3"}}},


### PR DESCRIPTION
XEP-0060 states that 'node' and 'jid' attributes to <options> element MUST NOT
be included when <options> are specified at same time as <subscribe> :

https://xmpp.org/extensions/xep-0060.html#subscriber-configure-subandconfig

mod_pubsub will require 'node' and 'jid' attributes on standalone pubsub
options requests, and reject subscribe requests that have options that include
either 'node' or 'jid'

Note: this depends on PR https://github.com/processone/xmpp/pull/34