### PR TITLE
Make it possible to join extauth pools

### DIFF
--- a/src/ejabberd_auth_external.erl
+++ b/src/ejabberd_auth_external.erl
@@ -118,9 +118,11 @@ opt_type(extauth_instances) ->
     fun (V) when is_integer(V), V > 0 -> V end;
 opt_type(extauth_program) ->
     fun (V) -> binary_to_list(iolist_to_binary(V)) end;
+opt_type(extauth_pool_name) ->
+    fun (V) -> iolist_to_binary(V) end;
 opt_type(extauth_pool_size) ->
     fun(I) when is_integer(I), I>0 -> I end;
 opt_type(_) ->
-    [extauth_program, extauth_pool_size,
+    [extauth_program, extauth_pool_size, extauth_pool_name,
      %% Deprecated:
      extauth_cache, extauth_instances].

--- a/src/extauth.erl
+++ b/src/extauth.erl
@@ -82,7 +82,12 @@ prog_name(Host) ->
 
 -spec pool_name(binary()) -> atom().
 pool_name(Host) ->
-    list_to_atom("extauth_pool_" ++ binary_to_list(Host)).
+    case ejabberd_config:get_option({extauth_pool_name, Host}) of
+	undefined ->
+	    list_to_atom("extauth_pool_" ++ binary_to_list(Host));
+	Name ->
+	    list_to_atom("extauth_pool_" ++ binary_to_list(Name))
+    end.
 
 -spec worker_name(atom(), integer()) -> atom().
 worker_name(Pool, N) ->


### PR DESCRIPTION
When several domains/hosts are served by a single ejabberd instance, each of them starts its own extauth pool. This can result in a huge number of child processes, making reloads/restarts slow and memory-consuming.

With this PR, multiple hosts can share the extauth pool, when the administrator believes this is necessary/possible for their setup.