### PR TITLE
fix for freetds UTF-8 corruption

### DIFF
--- a/src/ejabberd_sql.erl
+++ b/src/ejabberd_sql.erl
@@ -1034,6 +1034,7 @@ init_mssql(Host) ->
     FreeTDS = io_lib:fwrite("[~s]~n"
 			    "\thost = ~s~n"
 			    "\tport = ~p~n"
+			    "\tclient charset = UTF-8~n"
 			    "\ttds version = 7.1~n",
 			    [Host, Server, Port]),
     ODBCINST = io_lib:fwrite("[freetds]~n"


### PR DESCRIPTION
This fix adresses issue https://github.com/processone/ejabberd/issues/2404 of corrupted UTF-8 chars.

FreeTDS has paramter "client charset" that should be set to UTF-8 for MAM archive to work correctly.

Also, there is uncovered ( as for now ) issue in private rosters with UTF-8 cyrillic named groups: such groups make roster competely broken. Common XMPP clients like Gajim report trace like 
https://dev.gajim.org/gajim/gajim/issues/9295. 
Steps to reproduce
1. Configure ejabberd for MS SQL roster store
2. Create cyrillic named group with one contact in it using Gajim
3. Restart Gajim
Gajim now is unable to decode the roster.

This fix adresses this issue too.
