### PR TITLE
Expect mnesia_up event when joining cluster

### DIFF
--- a/src/mod_muc_mnesia.erl
+++ b/src/mod_muc_mnesia.erl
@@ -340,6 +340,8 @@ handle_cast(_Msg, State) ->
 handle_info({mnesia_system_event, {mnesia_down, Node}}, State) ->
     clean_table_from_bad_node(Node),
     {noreply, State};
+handle_info({mnesia_system_event, {mnesia_up, _Node}}, State) ->
+    {noreply, State};
 handle_info(Info, State) ->
     ?ERROR_MSG("unexpected info: ~p", [Info]),
     {noreply, State}.


### PR DESCRIPTION
I have an Elixir project that wraps `ejabberd`, when I call `ejabberd_admin:join_cluster` I always get error logs like this:

```
13:39:06.115 [error] unexpected info: {mnesia_system_event,{mnesia_up,'app@node2'}}
```

Doing some quick reading it seems this event is safe to expect, hope this is a good way to fix this.