### PR TITLE
ejabberd_regexp: Support Unicode

### DIFF
--- a/src/ejabberd_regexp.erl
+++ b/src/ejabberd_regexp.erl
@@ -36,7 +36,7 @@ exec({ReM, ReF, ReA}, {RgM, RgF, RgA}) ->
 -spec run(binary(), binary()) -> match | nomatch | {error, any()}.
 
 run(String, Regexp) ->
-    case exec({re, run, [String, Regexp, [{capture, none}]]},
+    case exec({re, run, [String, Regexp, [{capture, none}, unicode]]},
 	      {regexp, first_match, [binary_to_list(String),
                                      binary_to_list(Regexp)]})
 	of


### PR DESCRIPTION
My use-case was restricting valid JIDs for `mod_register` using a `user_regexp` such as `^[\\p{Xan}_.-]{2,40}$"`, where `\p{Xan}` [matches][1] all alphanumeric characters of all Unicode scripts.

[1]: https://www.pcre.org/original/doc/html/pcresyntax.html#SEC6