### PR TITLE
Config template recommend "open" access_model

### DIFF
--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -188,7 +188,7 @@ modules:
       - "flat"
       - "pep"
     force_node_config:
-      ## Comment out the following lines to enable OMEMO support
+      ## Change from "whitelist" to "open" to enable OMEMO support
       ## See https://github.com/processone/ejabberd/issues/2425
       "eu.siacs.conversations.axolotl.*":
         access_model: whitelist


### PR DESCRIPTION
...instead of "comment out", as many seem to misunderstand what and why should be or not be commented out
