### PR TITLE
Add (commented) reference to ca_file in the example config

### DIFF
--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -39,6 +39,10 @@ certfiles:
   - "/etc/letsencrypt/live/localhost/fullchain.pem"
   - "/etc/letsencrypt/live/localhost/privkey.pem"
 
+## If you're getting s2s errors such as "unable to get local issuer certificate",
+## uncomment this option and point it to the proper path for ca-certificates.crt 
+## ca_file: /etc/ssl/certs/ca-certificates.crt
+
 listen:
   -
     port: 5222


### PR DESCRIPTION
As discussed in #2186: make sure that the `ca_file` option is documented in the example config.

On at least Ubuntu 18.04 systems, s2s connections that require SSL will fail if this option is not set.

I don't understand the root cause, perhaps @zinid can fill in some details. I read https://www.happyassassin.net/2015/01/12/a-note-about-ssltls-trusted-certificate-stores-and-platforms/ and checked `openssl version -a` on my system, which reports `OPENSSLDIR: "/usr/lib/ssl"`. Looks like that's valid; `/usr/lib/ssl/certs` is a symlink to `/etc/ssl/certs`..