### PR TITLE
Fix wording of ejabberd_captcha

### DIFF
--- a/src/ejabberd_captcha.erl
+++ b/src/ejabberd_captcha.erl
@@ -101,8 +101,8 @@ create_captcha(SID, From, To, Lang, Limiter, Args) ->
 		mk_ocr_field(Lang, CID, Type)],
 	  X = #xdata{type = form, fields = Fs},
 	  Captcha = #xcaptcha{xdata = X},
-	  BodyString = {<<"Your messages to ~s are being blocked. "
-			  "To unblock them, visit ~s">>, [JID, get_url(Id)]},
+	  BodyString = {<<"Your subscription request and/or messages to ~s are being blocked. "
+			  "To unblock the subscription request, visit ~s">>, [JID, get_url(Id)]},
 	  Body = xmpp:mk_text(BodyString, Lang),
 	  OOB = #oob_x{url = get_url(Id)},
 	  Tref = erlang:send_after(?CAPTCHA_LIFETIME, ?MODULE,


### PR DESCRIPTION
This PR changes the wording of `ejabberd_captcha` to make it more clear to strangers, that solving the captcha will only unblock their subscription request.

Edit: related issue: #2644 