### PR TITLE
Fix tiny typo in configuration file

### DIFF
--- a/config/ejabberd.yml
+++ b/config/ejabberd.yml
@@ -588,7 +588,7 @@ modules:
   ## mod_proxy65: {}
   mod_pubsub:
     access_createnode: pubsub_createnode
-    ## reduces resource comsumption, but XEP incompliant
+    ## reduces resource consumption, but XEP incompliant
     ignore_pep_from_offline: true
     ## XEP compliant, but increases resource comsumption
     ## ignore_pep_from_offline: false

--- a/config/ejabberd.yml
+++ b/config/ejabberd.yml
@@ -590,7 +590,7 @@ modules:
     access_createnode: pubsub_createnode
     ## reduces resource consumption, but XEP incompliant
     ignore_pep_from_offline: true
-    ## XEP compliant, but increases resource comsumption
+    ## XEP compliant, but increases resource consumption
     ## ignore_pep_from_offline: false
     last_item_cache: false
     plugins:


### PR DESCRIPTION
This PR fixes the "comsumption" to "consumption" in `ejabberd.yml`.

I'm sorry for the small PR but that typo kept bugging me.