### PR TITLE
Privacy lists: set from/to on packet *before* calling privacy_check_p…

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -638,15 +638,16 @@ route_probe_reply(From, #{jid := To,
     Subscription = get_subscription(To, From),
     if IsAnotherResource orelse
        Subscription == both orelse Subscription == from ->
-	    Packet = misc:add_delay_info(LastPres, To, TS),
-	    case privacy_check_packet(State, Packet, out) of
+	    Packet = xmpp:set_from_to(LastPres, To, From),
+	    Packet2 = misc:add_delay_info(Packet, To, TS),
+	    case privacy_check_packet(State, Packet2, out) of
 		deny ->
 		    ok;
 		allow ->
 		    ejabberd_hooks:run(presence_probe_hook,
 				       LServer,
 				       [From, To, self()]),
-		    ejabberd_router:route(xmpp:set_from_to(Packet, To, From))
+		    ejabberd_router:route(Packet2)
 	    end;
        true ->
 	    ok


### PR DESCRIPTION
ejabberd_c2s must set the correct from/to on the packet *before* handing it over to privacy_check_packet.

Reproduction:
- log in with two clients
- set client 2 to be invisible using XEP-0016
- client 1 client won't see presence anymore
- log out client 1 and log in again
- observe that client 2 will respond to the presence probe, while it shouldn't
