### PR TITLE
Add 'xml' format to mod_muc_log

### DIFF
--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -306,7 +306,7 @@ remove_mam_for_user_with_peer(User, Server, Peer) ->
     end.
 
 -spec get_room_config([muc_roomconfig:property()], mod_muc_room:state(),
-		      jid(), binary()) -> [muc_roomconfig:property()].
+		      undefined | jid(), binary()) -> [muc_roomconfig:property()].
 get_room_config(Fields, RoomState, _From, _Lang) ->
     Config = RoomState#state.config,
     Fields ++ [{mam, Config#config.mam}].


### PR DESCRIPTION
Add 'xml' format to mod_muc_log

This format will write the MUC messages into an XML file. The file will
contain stanzas (`<message>` for the messages, <presence> for joining, leaving
and nick changes and `<iq type='set'>` for root configuration changes).
Every stanzas will contain a `<address>` element with the JID of the user
sending the message and a `<delay xmlns='urn:xmpp:delay'>` element with the
time of the stanza. All messages for a day will be in a
`<muclog xmlns='https://ejabberd.im/muclog'>` element.
