### PR TITLE
acl for mam preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Version NEXT
+# Version 19.02
 
-*
+* New acl "access_preferences" for mam preferences
 
 # Version 18.12
 

--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -631,15 +631,21 @@ process_iq(#iq{from = #jid{luser = LUser, lserver = LServer},
 				     default = Default,
 				     always = Always0,
 				     never = Never0}]} = IQ) ->
-    Always = lists:usort(get_jids(Always0)),
-    Never = lists:usort(get_jids(Never0)),
-    case write_prefs(LUser, LServer, LServer, Default, Always, Never) of
-	ok ->
-	    NewPrefs = prefs_el(Default, Always, Never, NS),
-	    xmpp:make_iq_result(IQ, NewPrefs);
-	_Err ->
-	    Txt = <<"Database failure">>,
-	    xmpp:make_error(IQ, xmpp:err_internal_server_error(Txt, Lang))
+	Rule = gen_mod:get_module_opt(LServer, ?MODULE, access_preferences),
+	case acl:match_rule(LServer, Rule, jid:make(LUser, LServer)) of
+    allow ->
+        Always = lists:usort(get_jids(Always0)),
+        Never = lists:usort(get_jids(Never0)),
+        case write_prefs(LUser, LServer, LServer, Default, Always, Never) of
+        ok ->
+            NewPrefs = prefs_el(Default, Always, Never, NS),
+            xmpp:make_iq_result(IQ, NewPrefs);
+        _Err ->
+            Txt = <<"Database failure">>,
+            xmpp:make_error(IQ, xmpp:err_internal_server_error(Txt, Lang))
+        end;
+    deny ->
+        xmpp:make_error(IQ, xmpp:err_not_allowed())
     end;
 process_iq(#iq{from = #jid{luser = LUser, lserver = LServer},
 	       to = #jid{lserver = LServer}, lang = Lang,
@@ -1257,7 +1263,9 @@ mod_opt_type(default) ->
 mod_opt_type(request_activates_archiving) ->
     fun (B) when is_boolean(B) -> B end;
 mod_opt_type(clear_archive_on_room_destroy) ->
-    fun (B) when is_boolean(B) -> B end.
+    fun (B) when is_boolean(B) -> B end;
+mod_opt_type(access_preferences) ->
+    fun acl:access_rules_validator/1.
 
 mod_options(Host) ->
     [{assume_mam_usage, false},
@@ -1265,6 +1273,7 @@ mod_options(Host) ->
      {request_activates_archiving, false},
      {compress_xml, false},
      {clear_archive_on_room_destroy, true},
+     {access_preferences, all},
      {db_type, ejabberd_config:default_db(Host, ?MODULE)},
      {use_cache, ejabberd_config:use_cache(Host)},
      {cache_size, ejabberd_config:cache_size(Host)},


### PR DESCRIPTION
I'd like to keep users from changing default mam policy. Therefore I propose a new option of mod_mam `access_prefernces` which defaults to true.

I will happily write an entry for the documentation if my PR is accepted.