### PR TITLE
only destroy rooms if mam is enabled

### DIFF
--- a/src/mod_muc_admin.erl
+++ b/src/mod_muc_admin.erl
@@ -840,10 +840,16 @@ decide_room(unused, {_Room_name, _Host, Room_pid}, ServerHost, Last_allowed) ->
     end;
 decide_room(empty, {Room_name, Host, _Room_pid}, ServerHost, _Last_allowed) ->
     case gen_mod:is_loaded(ServerHost, mod_mam) of
-        true ->
-        mod_mam:is_empty_for_room(ServerHost, Room_name, Host);
-        _ ->
-        false
+    true ->
+	    Room_options = get_room_options(Room_name, Host),
+	    case lists:keyfind(<<"mam">>, 1, Room_options) of
+	    {<<"mam">>, <<"true">>} ->
+		    mod_mam:is_empty_for_room(ServerHost, Room_name, Host);
+	    _ ->
+		    false
+	    end;
+    _ ->
+	    false
     end.
 
 seconds_to_days(S) ->


### PR DESCRIPTION
When using `ejabberdctl rooms_empty_list` or `ejabberdctl rooms_empty_destroy` only select rooms that are have mam enabled. Otherwise you may accidently destroy rooms which seem to be unsused due to archive being empty
