### PR TITLE
allow room recreate for admins even if nonempty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Admin
 - The minimum required Erlang/OTP version is now 19.1
 
+* MUC
+- Service admins are allowed to recreate room even if archiv is nonempty
+
 # Version 19.02
 
 * Admin


### PR DESCRIPTION
https://github.com/processone/ejabberd/commit/5e7f234ac8b7becf77e0090a4424885766590377 prevents re-creation of a room if it's archive is non-empty in order to prevent unauthorized access to messages from a room that existed before. This is generally a good idea privacy-wise.

Nevertheless, service-owners should be able to re-create the room.

This PR allows it. 