### PR TITLE
Origin header validation on websocket connection

### DIFF
--- a/src/ejabberd_http_ws.erl
+++ b/src/ejabberd_http_ws.erl
@@ -371,5 +371,7 @@ opt_type(websocket_ping_interval) ->
     fun (I) when is_integer(I), I >= 0 -> I end;
 opt_type(websocket_timeout) ->
     fun (I) when is_integer(I), I > 0 -> I end;
+opt_type(websocket_origin) ->
+    fun (O) -> O end;
 opt_type(_) ->
-    [websocket_ping_interval, websocket_timeout].
+    [websocket_ping_interval, websocket_timeout, websocket_origin].

--- a/src/ejabberd_websocket.erl
+++ b/src/ejabberd_websocket.erl
@@ -66,7 +66,8 @@ check(_Path, Headers) ->
     RequiredHeaders = [{'Upgrade', <<"websocket">>},
                        {'Connection', ignore}, {'Host', ignore},
                        {<<"Sec-Websocket-Key">>, ignore},
-                       {<<"Sec-Websocket-Version">>, <<"13">>}],
+                       {<<"Sec-Websocket-Version">>, <<"13">>},
+                       {<<"Origin">>, get_origin()}],
 
     F = fun ({Tag, Val}) ->
 		case lists:keyfind(Tag, 1, Headers) of
@@ -406,3 +407,6 @@ websocket_close(Socket, WsHandleLoopPid,
 websocket_close(Socket, WsHandleLoopPid, SocketMode, _CloseCode) ->
     WsHandleLoopPid ! closed,
     SocketMode:close(Socket).
+
+get_origin() ->
+    ejabberd_config:get_option({websocket_origin, ejabberd_config:get_myname()}, ignore).


### PR DESCRIPTION
At present, ejabberd is not protected against CSRF attacks on websocket connection. This PR adds optional validation for ```Origin``` header to protect against connections from other domains than given in config (```websocket_origin``` option). This kind of protection can be provided by layer7 load balancer (ex. haproxy + lua), but, thanks to this PR, the lower layer load balancer can get chosen for a specific ejabberd implementation while still providing a secure websocket connection.