### PR TITLE
SQL for pgsql - set family in marks

### DIFF
--- a/sql/pg.new.sql
+++ b/sql/pg.new.sql
@@ -282,7 +282,7 @@ CREATE TABLE vcard_search (
     server_host text NOT NULL,
     fn text NOT NULL,
     lfn text NOT NULL,
-    family text NOT NULL,
+    "family" text NOT NULL,
     lfamily text NOT NULL,
     given text NOT NULL,
     lgiven text NOT NULL,

--- a/sql/pg.sql
+++ b/sql/pg.sql
@@ -125,7 +125,7 @@ CREATE TABLE vcard_search (
     lusername text PRIMARY KEY,
     fn text NOT NULL,
     lfn text NOT NULL,
-    family text NOT NULL,
+    "family" text NOT NULL,
     lfamily text NOT NULL,
     given text NOT NULL,
     lgiven text NOT NULL,

--- a/src/mod_vcard_sql.erl
+++ b/src/mod_vcard_sql.erl
@@ -137,7 +137,7 @@ search(LServer, Data, AllowReturnAll, MaxMatch) ->
 		    end,
 	   case catch ejabberd_sql:sql_query(
 			LServer,
-			[<<"select username, fn, family, given, "
+			[<<"select username, fn, \"family\", given, "
 			   "middle,        nickname, bday, ctry, "
 			   "locality,        email, orgname, orgunit "
 			   "from vcard_search ">>,


### PR DESCRIPTION
It is reserved by the cockroachdb implementation: https://www.cockroachlabs.com/docs/v2.1/column-families.html#main-content

Not importent, I am just playing a little bit ...
