### PR TITLE
Fix #2540 Ejabberd doesnt compile as mix umbrella project dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -96,9 +96,13 @@ defmodule Ejabberd.Mixfile do
   end
 
   defp deps_include(deps) do
-    base = case Mix.Project.deps_paths()[:ejabberd] do
-      nil -> "deps"
-      _ -> ".."
+    base = if Mix.Project.umbrella?() do
+      "../../deps"
+    else
+      case Mix.Project.deps_paths()[:ejabberd] do
+        nil -> "deps"
+        _ -> ".."
+      end
     end
     Enum.map(deps, fn dep -> base<>"/#{dep}/include" end)
   end


### PR DESCRIPTION
This PR fixes #2540. It is not perfect way but it works for most of cases. The problem remains when given project has custom ```deps_path``` configuration but as I know there is no way to get this config option from dependencie's ```mix.exs``` level.
