### PR TITLE
Protect against bad muc#owner requests

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3245,7 +3245,9 @@ process_iq_owner(From, #iq{type = get, lang = Lang,
 	    end;
        true ->
 	    {error, xmpp:err_bad_request()}
-    end.
+    end;
+process_iq_owner(_, _, _) ->
+	  {error, xmpp:err_bad_request()}.
 
 -spec is_allowed_log_change(muc_roomconfig:result(), state(), jid()) -> boolean().
 is_allowed_log_change(Options, StateData, From) ->


### PR DESCRIPTION
Because the [entry](https://github.com/processone/ejabberd/blob/6c0d6f07740479d830b121d0b7e6fa1bd846a4ab/src/mod_muc_room.erl#L286) matches more than [the function header](https://github.com/processone/ejabberd/blob/6c0d6f07740479d830b121d0b7e6fa1bd846a4ab/src/mod_muc_room.erl#L3177-L3181), if for example a `muc#owner` `set` request comes in without any sub elements, it would crash the muc_room due to `:function_clause` (non-match).

This commit fixes this potential vulnerability by catching all `muc#owner` requests that fall through and return a generic bad request error.