### PR TITLE
mod_multicast service discovery bugfix

### DIFF
--- a/src/mod_multicast.erl
+++ b/src/mod_multicast.erl
@@ -289,7 +289,7 @@ iq_disco_info(From, Lang, State) ->
 			       type = <<"multicast">>,
 			       name = translate:translate(Lang, Name)}],
        features = [?NS_DISCO_INFO, ?NS_DISCO_ITEMS, ?NS_VCARD, ?NS_ADDRESS],
-       xdata = iq_disco_info_extras(From, State)}.
+       xdata = [iq_disco_info_extras(From, State)]}.
 
 iq_vcard(Lang) ->
     #vcard_temp{fn = <<"ejabberd/mod_multicast">>,


### PR DESCRIPTION
Resolves the issue detailed in https://github.com/processone/ejabberd/issues/2965. 
Essentially c2s_handle_info crashes when specifying limits in the configuration, during a service discovery.

I haven't tested this on master (18.09) but the problematic code appears to still be present master.
