### PR TITLE
Custom exit message is not broadcast

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2418,7 +2418,8 @@ send_new_presence(NJID, Reason, IsInitialPresence, StateData, OldStateData) ->
 	  last_presence = Presence0} = UserInfo =
 	maps:get(jid:tolower(LJID), StateData#state.users),
     {Role1, Presence1} =
-        case presence_broadcast_allowed(NJID, StateData) of
+        case (presence_broadcast_allowed(NJID, StateData) orelse
+         presence_broadcast_allowed(NJID, OldStateData)) of
             true -> {Role0, Presence0};
             false -> {none, #presence{type = unavailable}}
         end,


### PR DESCRIPTION
During exit user sends presence with Custom exit message
```xml
<presence
    from='hag66@shakespeare.lit/pda'
    to='coven@chat.shakespeare.lit/thirdwitch'
    type='unavailable'>
  <status>gone where the goblins go</status>
</presence>
```
Other participants receive

```xml
<presence
    from='coven@chat.shakespeare.lit/thirdwitch'
    to='crone1@shakespeare.lit/desktop'
    type='unavailable'>
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <item affiliation='member'
          jid='hag66@shakespeare.lit/pda'
          role='none'/>
  </x>
</presence>
```
Expected to get status

```xml
<presence
    from='coven@chat.shakespeare.lit/thirdwitch'
    to='crone1@shakespeare.lit/desktop'
    type='unavailable'>
  <x xmlns='http://jabber.org/protocol/muc#user'>
    <item affiliation='member'
          jid='hag66@shakespeare.lit/pda'
          role='none'/>
  </x>
  <status>gone where the goblins go</status>
</presence>
```
Parameter **presence_broadcast** is not specified in the configuration