### PR TITLE
Add option for JWT field name containing JID

### DIFF
--- a/src/ejabberd_auth_jwt.erl
+++ b/src/ejabberd_auth_jwt.erl
@@ -86,6 +86,7 @@ use_cache(_) ->
 %%%----------------------------------------------------------------------
 check_jwt_token(User, Server, Token) ->
     JWK = ejabberd_option:jwt_key(Server),
+    JidField = ejabberd_option:jwt_jid_field(Server),
     try jose_jwt:verify(JWK, Token) of
         {true, {jose_jwt, Fields}, Signature} ->
             ?DEBUG("jwt verify: ~p - ~p~n", [Fields, Signature]),
@@ -97,7 +98,7 @@ check_jwt_token(User, Server, Token) ->
                     Now = erlang:system_time(second),
                     if
                         Exp > Now ->
-                            case maps:find(<<"jid">>, Fields) of
+                            case maps:find(JidField, Fields) of
                                 error ->
                                     false;
                                 {ok, SJID} ->
@@ -121,6 +122,3 @@ check_jwt_token(User, Server, Token) ->
             false
     end.
 
-%% TODO: auth0 username is defined in 'jid' field, but we should
-%% allow customizing the name of the field containing the username
-%% to adapt to custom claims.

--- a/src/ejabberd_option.erl
+++ b/src/ejabberd_option.erl
@@ -51,6 +51,7 @@
 -export([hosts/0]).
 -export([include_config_file/0, include_config_file/1]).
 -export([jwt_auth_only_rule/0, jwt_auth_only_rule/1]).
+-export([jwt_jid_field/0, jwt_jid_field/1]).
 -export([jwt_key/0, jwt_key/1]).
 -export([language/0, language/1]).
 -export([ldap_backups/0, ldap_backups/1]).
@@ -430,6 +431,13 @@ jwt_auth_only_rule() ->
 -spec jwt_auth_only_rule(global | binary()) -> atom().
 jwt_auth_only_rule(Host) ->
     ejabberd_config:get_option({jwt_auth_only_rule, Host}).
+
+-spec jwt_jid_field() -> binary().
+jwt_jid_field() ->
+    jwt_jid_field(global).
+-spec jwt_jid_field(global | binary()) -> binary().
+jwt_jid_field(Host) ->
+    ejabberd_config:get_option({jwt_jid_field, Host}).
 
 -spec jwt_key() -> jose_jwk:key() | 'undefined'.
 jwt_key() ->

--- a/src/ejabberd_options.erl
+++ b/src/ejabberd_options.erl
@@ -415,6 +415,8 @@ opt_type(jwt_key) ->
                       econf:fail({read_file, Reason, Path})
               end
       end);
+opt_type(jwt_jid_field) ->
+    econf:binary();
 opt_type(jwt_auth_only_rule) ->
     econf:atom().
 
@@ -643,6 +645,7 @@ options() ->
      {websocket_ping_interval, timer:seconds(60)},
      {websocket_timeout, timer:minutes(5)},
      {jwt_key, undefined},
+     {jwt_jid_field, <<"jid">>},
      {jwt_auth_only_rule, none}].
 
 -spec globals() -> [atom()].


### PR DESCRIPTION
Addresses this TODO:

TODO: auth0 username is defined in 'jid' field, but we should
allow customizing the name of the field containing the username
to adapt to custom claims.
