### PR TITLE
Use a numeric value for loglevel

### DIFF
--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -17,7 +17,7 @@
 hosts:
   - localhost
 
-loglevel: info
+loglevel: 4
 
 ## If you already have certificates, list them here
 # certfiles:


### PR DESCRIPTION
`loglevel` accepts numeric values (see https://docs.ejabberd.im/admin/configuration/#logging), not log level's names.

