### PR TITLE
Fix "ejabberd_iq" processing of the IQ id for proc delivery

### DIFF
--- a/src/ejabberd_cluster_mnesia.erl
+++ b/src/ejabberd_cluster_mnesia.erl
@@ -108,7 +108,7 @@ get_node_by_id(Hash) ->
     try binary_to_integer(Hash) of
 	I -> match_node_id(I)
     catch _:_ ->
-	    node()
+        throw({badmatch, Hash})
     end.
 
 -spec send({atom(), node()}, term()) -> boolean().
@@ -150,5 +150,5 @@ match_node_id(I, [Node|Nodes]) ->
 	I -> Node;
 	_ -> match_node_id(I, Nodes)
     end;
-match_node_id(_I, []) ->
-    node().
+match_node_id(I, []) ->
+    throw({badmatch, I}).

--- a/src/mod_proxy65_service.erl
+++ b/src/mod_proxy65_service.erl
@@ -214,7 +214,11 @@ process_bytestreams(#iq{type = set, lang = Lang, from = InitiatorJID, to = To,
     ACL = mod_proxy65_opt:access(ServerHost),
     case acl:match_rule(ServerHost, ACL, InitiatorJID) of
 	allow ->
-	    Node = ejabberd_cluster:get_node_by_id(To#jid.lresource),
+	    Node = try
+		       ejabberd_cluster:get_node_by_id(To#jid.lresource)
+		   catch _:{badmatch, _} ->
+		       node()
+		   end,
 	    Target = jid:encode(jid:tolower(TargetJID)),
 	    Initiator = jid:encode(jid:tolower(InitiatorJID)),
 	    SHA1 = str:sha(<<SID/binary, Initiator/binary, Target/binary>>),


### PR DESCRIPTION
"ejabberd_iq" seems to be an IQ handler for internal usage (see "mod_ping") where the routing is based on the information encoded in the IQ id field ('rr-').

The last field of such an "rr-" id is the hash of the node.
"ejabberd_iq" uses "ejabber_cluster:node_id" for the encoding & "ejabberd_cluster:get_node_by_id" for the decoding of this field.

Even if the "node_id()" method has no Pid parameter, I guess the Proc provided in the "ejabberd_iq:route" method must be a process on the executing node.

If my assumption is right, there is a close link between the Node and the Proc and if the Node information could not be decoded, there is no chance to seek any process to deliver the IQ result...

In fact, the "ejabberd_iq:decode_id" does it right by catching a {badmatch, xxx} exception and proceed with standard routing when no Node could be matched, perfect.

decode_id(<<"rr-", ID/binary>>) ->
    try
      ...
    catch _:{badmatch, _} ->
	    error
    end;

Miserably, "ejabberd_cluster" never throws such an exception, but returns any node on the current cluster !?


With the following fix, a Proc is able to MAM query a room hosted on a remote cluster through XMPP federation (S2S).