### PR TITLE
enable odbc in mix build

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -120,6 +120,7 @@ defmodule Ejabberd.Mixfile do
   defp cond_apps do
     for {:true, app} <- [{config(:redis), :eredis},
                          {config(:mysql), :p1_mysql},
+                         {config(:odbc), :odbc},
                          {config(:pgsql), :p1_pgsql},
                          {config(:sqlite), :sqlite3},
                          {config(:zlib), :ezlib}], do:


### PR DESCRIPTION
I'd like to use the official ejabberd docker image with odbc database connectivity. Therefore this change is necessary in addtition to a change in docker-ejabberd:

See https://github.com/processone/docker-ejabberd/issues/50 and https://github.com/processone/docker-ejabberd/pull/51.
