### PR TITLE
change publisher from text to varchar for mssql

### DIFF
--- a/sql/mssql.sql
+++ b/sql/mssql.sql
@@ -209,7 +209,7 @@ WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, ALLOW_ROW_LOCKS = ON, ALLOW
 CREATE TABLE [dbo].[pubsub_item] (
         [nodeid] [bigint] NULL,
         [itemid] [varchar] (255) NOT NULL,
-        [publisher] [text] NOT NULL,
+        [publisher] [varchar] (250) NOT NULL,
         [creation] [varchar] (32) NOT NULL,
         [modification] [varchar] (32) NOT NULL,
         [payload] [text] NOT NULL DEFAULT ''


### PR DESCRIPTION
While testing with mssql I found the following problem in the log:

```
[error] SQL query 'select itemid from pubsub_item where nodeid=1 and (publisher='user1@localhost' or publisher like 'user1@localhost/%' escape '^') order by modification desc' failed: <<"[FreeTDS][SQL Server]The data types text and varchar are incompatible in the equal to operator.">>
[error] SQL query 'Q118290566' at {node_flat_sql,870} failed: <<"[FreeTDS][SQL Server]The data types text and varchar are incompatible in the equal to operator.">>
```
This PR seems to fix it.
