### PR TITLE
Fixed HTTP PUT body parsing error

### DIFF
--- a/src/ejabberd_http.erl
+++ b/src/ejabberd_http.erl
@@ -400,21 +400,16 @@ extract_path_query(#state{request_method = Method,
 	    ?DEBUG("Error decoding URL '~p': ~p", [Path, Error]),
 	    {State, false};
         {LPath, _Query} ->
-	    case Method of
-		'PUT' ->
-		    {State, {LPath, [], Trail}};
-		'POST' ->
-		    case recv_data(State) of
-			{ok, Data} ->
-			    LQuery = case catch parse_urlencoded(Data) of
-					 {'EXIT', _Reason} -> [];
-					 LQ -> LQ
-				     end,
-			    {State, {LPath, LQuery, Data}};
-			error ->
-			    {State, false}
-		    end
-	    end
+            case recv_data(State) of
+                {ok, Data} ->
+                    LQuery = case catch parse_urlencoded(Data) of
+                                 {'EXIT', _Reason} -> [];
+                                 LQ -> LQ
+                             end,
+                    {State, {LPath, LQuery, Data}};
+                error ->
+                    {State, false}
+            end
     end;
 extract_path_query(State) ->
     {State, false}.


### PR DESCRIPTION
Think I found a bug in ejabberd_http module. Process (process) function called from HTTP handler module trims body for large PUT requests (it seems that this depends on length of header). I guess that PUT can be handled the same way as POST, when this patch is applied Ejabberd correctly parses the body.