### PR TITLE
sql_type should be taken for LServer, not LHost

### DIFF
--- a/src/mod_mam_sql.erl
+++ b/src/mod_mam_sql.erl
@@ -105,7 +105,7 @@ store(Pkt, LServer, {LUser, LHost}, Type, Peer, Nick, _Dir, TS) ->
 	      jid:tolower(Peer)),
     Body = fxml:get_subtag_cdata(Pkt, <<"body">>),
     SType = misc:atom_to_binary(Type),
-    SqlType = ejabberd_option:sql_type(LHost),
+    SqlType = ejabberd_option:sql_type(LServer),
     XML = case mod_mam_opt:compress_xml(LServer) of
 	      true ->
 		  J1 = case Type of


### PR DESCRIPTION
sql_type option should be retrieved for the main domain, not the MUC subdomain
