### PR TITLE
Always show MucSub subscribers nicks (#3206)

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -4311,7 +4311,7 @@ process_iq_mucsub(From, #iq{type = get, lang = Lang,
 		     fun(_, #subscriber{jid = J, nick = N, nodes = Nodes}, Acc) ->
 			 case ShowJid of
 			     true ->
-				 [#muc_subscription{jid = J, events = Nodes}|Acc];
+				 [#muc_subscription{jid = J, nick = N, events = Nodes}|Acc];
 			     _ ->
 				 [#muc_subscription{nick = N, events = Nodes}|Acc]
 			 end


### PR DESCRIPTION
Related to https://github.com/processone/ejabberd/issues/3206
Changes behaviour of: https://docs.ejabberd.im/developer/xmpp-clients-bots/extensions/muc-sub/#getting-list-of-subscribers-of-a-room

Always return subscriber nick in reply to get subscribers list, even if we have rights to see full JID.