### PR TITLE
Bump jiffy so it compiles on older GCC

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -95,7 +95,7 @@ defmodule Ejabberd.Mixfile do
      {:p1_mysql, "~> 1.0"},
      {:mqtree, "~> 1.0"},
      {:p1_pgsql, "~> 1.1"},
-     {:jiffy, "~> 1.0"},
+     {:jiffy, "~> 1.0.4"},
      {:p1_oauth2, "~> 0.6.1"},
      {:distillery, "~> 2.0"},
      {:pkix, "~> 1.0"},

--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
         {xmpp, ".*", {git, "https://github.com/processone/xmpp", "c23e66ebac8fdec4aa08c8926091b0dcf6dacf22"}},
         {fast_yaml, ".*", {git, "https://github.com/processone/fast_yaml", {tag, "1.0.24"}}},
 	{yconf, ".*", {git, "https://github.com/processone/yconf", {tag, "1.0.4"}}},
-        {jiffy, ".*", {git, "https://github.com/davisp/jiffy", {tag, "1.0.1"}}},
+        {jiffy, ".*", {git, "https://github.com/davisp/jiffy", {tag, "1.0.4"}}},
         {p1_oauth2, ".*", {git, "https://github.com/processone/p1_oauth2", {tag, "0.6.6"}}},
         {pkix, ".*", {git, "https://github.com/processone/pkix", {tag, "1.0.5"}}},
         {jose, ".*", {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.9.0"}}},


### PR DESCRIPTION
...like 4.4.7 used in RH/CentOS 6

FYI I didn't bump it in https://github.com/processone/ejabberd/blob/master/mix.lock since I don't know where that hash comes from exactly.