### PR TITLE
Enable STUN/TURN support by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,12 +213,12 @@ AC_ARG_ENABLE(system_deps,
 esac],[if test "x$system_deps" = "x"; then system_deps=false; fi])
 
 AC_ARG_ENABLE(stun,
-[AC_HELP_STRING([--enable-stun], [enable STUN/TURN support (default: no)])],
+[AC_HELP_STRING([--enable-stun], [enable STUN/TURN support (default: yes)])],
 [case "${enableval}" in
   yes) stun=true ;;
   no)  stun=false ;;
   *) AC_MSG_ERROR(bad value ${enableval} for --enable-stun) ;;
-esac],[if test "x$stun" = "x"; then stun=false; fi])
+esac],[if test "x$stun" = "x"; then stun=true; fi])
 
 AC_ARG_ENABLE(sip,
 [AC_HELP_STRING([--enable-sip], [enable SIP support (default: no)])],

--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -58,6 +58,13 @@ listen:
       /admin: ejabberd_web_admin
       /.well-known/acme-challenge: ejabberd_acme
   -
+    port: 3478
+    transport: udp
+    module: ejabberd_stun
+    use_turn: true
+    ## The server's public IPv4 address:
+    # turn_ip: 203.0.113.3
+  -
     port: 1883
     ip: "::"
     module: mod_mqtt


### PR DESCRIPTION
The popularity of audio/video calls, which usually require a STUN/TURN server, is increasing.  It would therefore be nice to build ejabberd with STUN/TURN support by default, and to have it enabled in the sample configuration file.