### PR TITLE
Allow room owner to enter room without password

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2217,6 +2217,10 @@ check_password(owner, _Affiliation, _Packet, _From,
 	       _StateData) ->
     %% Don't check pass if user is owner in MUC service (access_admin option)
     true;
+check_password(_ServiceAffiliation, owner, _Packet, _From,
+		_StateData) ->
+   %% Don't check pass if user affiliation is owner of this room
+   true;
 check_password(_ServiceAffiliation, Affiliation, Packet,
 	       From, StateData) ->
     case (StateData#state.config)#config.password_protected


### PR DESCRIPTION
Allowing owners to enter room without password is useful as sometimes room owners forget the room password so they can not enter the room.
