### PR TITLE
Increase default shaper values

### DIFF
--- a/ejabberd.yml.example
+++ b/ejabberd.yml.example
@@ -127,8 +127,8 @@ api_permissions:
       - connected_users_number
 
 shaper:
-  normal: 1000
-  fast: 50000
+  normal: 20000
+  fast: 200000
 
 shaper_rules:
   max_user_sessions: 10


### PR DESCRIPTION
The `normal` shaper value of 1,000 B/s in the example configuration, which is applied to `ejabberd_c2s` connections, delays the negotiation of audio/video streams significantly.  Clients such as Movim or Conversations generate up to 15 kB of Jingle traffic to negotiate the streams, so it takes up to 15 seconds until the streams are established after a call is accepted.

On the servers I operate myself, I had bumped the `normal`/`fast` shapers to 50,000/500,000 B/s a long time ago (as the old defaults seemed too restrictive to me).  Therefore, we hadn't noticed this problem during our A/V tests.  This PR bumps the shaper values in the example configuration file to the slightly more conservative values 20,000 and 200,000.