### PR TITLE
Make SQL query more generic for MSSQL compatibility

### DIFF
--- a/src/node_flat_sql.erl
+++ b/src/node_flat_sql.erl
@@ -897,12 +897,12 @@ select_affiliation_subscriptions(Nidx, GenKey, SubKey) ->
     GJ = encode_jid(GenKey),
     SJ = encode_jid(SubKey),
     case catch ejabberd_sql:sql_query_t(
-	?SQL("select jid = %(GJ)s as @(G)b, @(affiliation)s, @(subscriptions)s from "
+	?SQL("select @(jid)s, @(affiliation)s, @(subscriptions)s from "
 	     " pubsub_state where nodeid=%(Nidx)d and jid in (%(GJ)s, %(SJ)s)"))
     of
 	{selected, Res} ->
 	    lists:foldr(
-		fun({true, A, S}, {_, Subs}) ->
+		fun({Jid, A, S}, {_, Subs}) when Jid == GJ ->
 		    {decode_affiliation(A), Subs ++ decode_subscriptions(S)};
 		   ({_, _, S}, {Aff, Subs}) ->
 		       {Aff, Subs ++ decode_subscriptions(S)}


### PR DESCRIPTION
This changes get rid of simple calculate field from node_flat_sql module
and closes issue #3270.
Used SQL syntax is not compatible with MSSQL.
Just do compare a field on ejabberd side (do not use different query for MSSQL.).


