### PR TITLE
Allow passing Erlang VM args through vm.args config file

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -60,6 +60,8 @@ done
 : "${SPOOL_DIR:="{{localstatedir}}/lib/ejabberd"}"
 : "${EJABBERD_CONFIG_PATH:="$ETC_DIR/ejabberd.yml"}"
 : "${EJABBERDCTL_CONFIG_PATH:="$ETC_DIR/ejabberdctl.cfg"}"
+# Allows passing extra Erlang command-line arguments in vm.args file
+: "${VMARGS:="$ETC_DIR/vm.args"}"
 [ -f "$EJABBERDCTL_CONFIG_PATH" ] && . "$EJABBERDCTL_CONFIG_PATH"
 [ -n "$ERLANG_NODE_ARG" ] && ERLANG_NODE="$ERLANG_NODE_ARG"
 [ "$ERLANG_NODE" = "${ERLANG_NODE%.*}" ] && S="-s"
@@ -77,6 +79,8 @@ if [ -n "$INET_DIST_INTERFACE" ] ; then
         ERLANG_OPTS="$ERLANG_OPTS -kernel inet_dist_use_interface $INET_DIST_INTERFACE2"
     fi
 fi
+# if vm.args file exists in config directory, pass it to Erlang VM
+[ -f "$VMARGS" ] && ERLANG_OPTS="$ERLANG_OPTS -args_file $VMARGS"
 ERL_LIBS={{libdir}}
 ERL_CRASH_DUMP="$LOGS_DIR"/erl_crash_$(date "+%Y%m%d-%H%M%S").dump
 ERL_INETRC="$ETC_DIR"/inetrc


### PR DESCRIPTION
This can be used to define the Erlang cookie in a place that feels less foreign to
non Erlang users.

It will work with the upcoming Homebrew recipes, as the Homebrew recipes will generate that cookie at install time.

Fixes #3343

Drawback: Cookie will be visible in process list (`ps -aux`). It should not be a big deal as listing process requires local access already. It can be hidden from other users by using a security enhanced Linux kernel like SELinux.

Example usage: Add a file vm.args in your config dir (close to your ejabberd.yml and ejabberdctl.cfg file) and add the following line:
```
-setcookie SomeLongAndRandomSecureString
```