### PR TITLE
Update base64url dep for rebar3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,7 +18,7 @@
 %%%
 %%%----------------------------------------------------------------------
 
-{deps, [{base64url, ".*", {git, "https://github.com/dvv/base64url.git", {tag, "v1.0"}}},
+{deps, [{base64url, ".*", {git, "https://github.com/dvv/base64url.git", {tag, "1.0.1"}}},
         {cache_tab, ".*", {git, "https://github.com/processone/cache_tab", {tag, "1.0.25"}}},
         {eimp, ".*", {git, "https://github.com/processone/eimp", {tag, "1.0.17"}}},
         {if_var_true, elixir,


### PR DESCRIPTION
Update base64url version to match available hex package to support
compilation with rebar3