### PR TITLE
Use include_lib() to include headers from dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -89,9 +89,6 @@
 
 {erl_opts, [nowarn_deprecated_function,
             {i, "include"},
-            {i, "deps/fast_xml/include"},
-            {i, "deps/p1_utils/include"},
-            {i, "deps/xmpp/include"},
             {if_version_above, "20", {d, 'DEPRECATED_GET_STACKTRACE'}},
             {if_version_below, "21", {d, 'USE_OLD_HTTP_URI'}},
             {if_version_below, "22", {d, 'LAGER'}},

--- a/src/ejabberd_auth.erl
+++ b/src/ejabberd_auth.erl
@@ -48,7 +48,7 @@
 
 -export([auth_modules/1, convert_to_scram/1]).
 
--include("scram.hrl").
+-include_lib("xmpp/include/scram.hrl").
 -include("logger.hrl").
 
 -define(SALT_LENGTH, 16).

--- a/src/ejabberd_auth_anonymous.erl
+++ b/src/ejabberd_auth_anonymous.erl
@@ -45,7 +45,7 @@
 	 plain_password_required/1]).
 
 -include("logger.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 
 start(Host) ->
     ejabberd_hooks:add(sm_register_connection_hook, Host,

--- a/src/ejabberd_auth_jwt.erl
+++ b/src/ejabberd_auth_jwt.erl
@@ -34,7 +34,7 @@
          user_exists/2, use_cache/1
         ]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 
 %%%----------------------------------------------------------------------

--- a/src/ejabberd_auth_mnesia.erl
+++ b/src/ejabberd_auth_mnesia.erl
@@ -37,7 +37,7 @@
 -export([need_transform/1, transform/1]).
 
 -include("logger.hrl").
--include("scram.hrl").
+-include_lib("xmpp/include/scram.hrl").
 -include("ejabberd_auth.hrl").
 
 -record(reg_users_counter, {vhost = <<"">> :: binary(),

--- a/src/ejabberd_auth_sql.erl
+++ b/src/ejabberd_auth_sql.erl
@@ -35,7 +35,7 @@
 	 remove_user/2, store_type/1, plain_password_required/1,
 	 export/1, which_users_exists/2]).
 
--include("scram.hrl").
+-include_lib("xmpp/include/scram.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").
 -include("ejabberd_auth.hrl").

--- a/src/ejabberd_bosh.erl
+++ b/src/ejabberd_bosh.erl
@@ -43,7 +43,7 @@
 	 code_change/4]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_http.hrl").
 -include("bosh.hrl").
 

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -47,7 +47,7 @@
 	 reply/2, copy_state/2, set_timeout/2, route/2, format_reason/2,
 	 host_up/1, host_down/1, send_ws_ping/1, bounce_message_queue/2]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("mod_roster.hrl").
 -include("translate.hrl").

--- a/src/ejabberd_captcha.erl
+++ b/src/ejabberd_captcha.erl
@@ -42,7 +42,7 @@
 	 host_up/1, host_down/1,
 	 config_reloaded/0, process_iq/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("ejabberd_http.hrl").
 -include("translate.hrl").

--- a/src/ejabberd_http.erl
+++ b/src/ejabberd_http.erl
@@ -37,7 +37,7 @@
 -export([init/3]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_http.hrl").
 -include_lib("kernel/include/file.hrl").
 

--- a/src/ejabberd_http_ws.erl
+++ b/src/ejabberd_http_ws.erl
@@ -36,7 +36,7 @@
 
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/ejabberd_iq.erl
+++ b/src/ejabberd_iq.erl
@@ -34,7 +34,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 	 terminate/2, code_change/3]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("ejabberd_stacktrace.hrl").
 

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -47,7 +47,7 @@
 
 -include("logger.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_stacktrace.hrl").
 -include("translate.hrl").
 

--- a/src/ejabberd_oauth.erl
+++ b/src/ejabberd_oauth.erl
@@ -54,7 +54,7 @@
          oauth_add_client_implicit/3,
          oauth_remove_client/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("ejabberd_http.hrl").
 -include("ejabberd_web_admin.hrl").

--- a/src/ejabberd_oauth_rest.erl
+++ b/src/ejabberd_oauth_rest.erl
@@ -36,7 +36,7 @@
 
 -include("ejabberd_oauth.hrl").
 -include("logger.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 
 init() ->
     rest:start(ejabberd_config:get_myname()),

--- a/src/ejabberd_oauth_sql.erl
+++ b/src/ejabberd_oauth_sql.erl
@@ -37,7 +37,7 @@
 
 -include("ejabberd_oauth.hrl").
 -include("ejabberd_sql_pt.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("logger.hrl").
 
 init() ->

--- a/src/ejabberd_piefxis.erl
+++ b/src/ejabberd_piefxis.erl
@@ -40,9 +40,9 @@
 
 -define(CHUNK_SIZE, 1024*20). %20k
 
--include("scram.hrl").
+-include_lib("xmpp/include/scram.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 -include("mod_roster.hrl").
 

--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -69,7 +69,7 @@
 
 -include("logger.hrl").
 -include("ejabberd_router.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_stacktrace.hrl").
 
 -callback init() -> any().

--- a/src/ejabberd_router_multicast.erl
+++ b/src/ejabberd_router_multicast.erl
@@ -42,7 +42,7 @@
 	 terminate/2, code_change/3]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(route_multicast, {domain = <<"">> :: binary() | '_',
 			  pid = self() :: pid()}).

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -52,7 +52,7 @@
 -export([get_info_s2s_connections/1]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_commands.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 -include("ejabberd_stacktrace.hrl").

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -41,7 +41,7 @@
 -export([stop_async/1, close/1, close/2, send/2, update_state/2, establish/1,
 	 host_up/1, host_down/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 
 -type state() :: xmpp_stream_in:state().

--- a/src/ejabberd_s2s_out.erl
+++ b/src/ejabberd_s2s_out.erl
@@ -39,7 +39,7 @@
 -export([start/3, start_link/3, connect/1, close/1, close/2, stop_async/1, send/2,
 	 route/2, establish/1, update_state/2, host_up/1, host_down/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("translate.hrl").
 

--- a/src/ejabberd_service.erl
+++ b/src/ejabberd_service.erl
@@ -35,7 +35,7 @@
 %% API
 -export([send/2, close/1, close/2, stop_async/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("translate.hrl").
 

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -85,7 +85,7 @@
 	 handle_info/2, terminate/2, code_change/3]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_commands.hrl").
 -include("ejabberd_sm.hrl").
 -include("ejabberd_stacktrace.hrl").

--- a/src/ejabberd_web.erl
+++ b/src/ejabberd_web.erl
@@ -33,7 +33,7 @@
 
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/ejabberd_web_admin.erl
+++ b/src/ejabberd_web_admin.erl
@@ -35,7 +35,7 @@
 
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/ejabberd_websocket.erl
+++ b/src/ejabberd_websocket.erl
@@ -45,7 +45,7 @@
 
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/ejabberd_xmlrpc.erl
+++ b/src/ejabberd_xmlrpc.erl
@@ -39,7 +39,7 @@
 -include("ejabberd_http.hrl").
 -include("mod_roster.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state,
 	{auth = noauth        :: noauth | map(),

--- a/src/gen_iq_handler.erl
+++ b/src/gen_iq_handler.erl
@@ -35,7 +35,7 @@
 -deprecated([{add_iq_handler, 6}, {handle, 5}, {iqdisc, 1}]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 -include("ejabberd_stacktrace.hrl").
 

--- a/src/gen_pubsub_node.erl
+++ b/src/gen_pubsub_node.erl
@@ -25,7 +25,7 @@
 
 -module(gen_pubsub_node).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -type(host() :: mod_pubsub:host()).
 -type(nodeId() :: mod_pubsub:nodeId()).

--- a/src/gen_pubsub_nodetree.erl
+++ b/src/gen_pubsub_nodetree.erl
@@ -36,7 +36,7 @@
 	ServerHost :: binary(),
 	Opts :: [any()]) -> atom().
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -callback terminate(Host :: host(), ServerHost :: binary()) -> atom().
 

--- a/src/jd2ejd.erl
+++ b/src/jd2ejd.erl
@@ -31,7 +31,7 @@
 -export([import_file/1, import_dir/1]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 %%%----------------------------------------------------------------------
 %%% API

--- a/src/misc.erl
+++ b/src/misc.erl
@@ -50,7 +50,7 @@
 	     {encode_base64, 1}]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include_lib("kernel/include/file.hrl").
 
 -type distance_cache() :: #{{string(), string()} => non_neg_integer()}.

--- a/src/mod_adhoc.erl
+++ b/src/mod_adhoc.erl
@@ -39,7 +39,7 @@
 	 mod_options/1, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 start(Host, _Opts) ->

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -85,7 +85,7 @@
 -include("mod_roster.hrl").
 -include("mod_privacy.hrl").
 -include("ejabberd_sm.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 %%%
 %%% gen_mod

--- a/src/mod_admin_update_sql.erl
+++ b/src/mod_admin_update_sql.erl
@@ -37,7 +37,7 @@
 
 -include("logger.hrl").
 -include("ejabberd_commands.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_sql_pt.hrl").
 -include("translate.hrl").
 

--- a/src/mod_announce.erl
+++ b/src/mod_announce.erl
@@ -51,7 +51,7 @@
 	 announce_all_hosts_motd_delete/1]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_announce.hrl").
 -include("translate.hrl").
 

--- a/src/mod_announce_mnesia.erl
+++ b/src/mod_announce_mnesia.erl
@@ -31,7 +31,7 @@
 	 get_motd/1, is_motd_user/2, set_motd_user/2, import/3]).
 -export([need_transform/1, transform/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_announce.hrl").
 -include("logger.hrl").
 

--- a/src/mod_announce_sql.erl
+++ b/src/mod_announce_sql.erl
@@ -32,7 +32,7 @@
 	 get_motd/1, is_motd_user/2, set_motd_user/2, import/3,
 	 export/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_announce.hrl").
 -include("ejabberd_sql_pt.hrl").
 -include("logger.hrl").

--- a/src/mod_avatar.erl
+++ b/src/mod_avatar.erl
@@ -31,7 +31,7 @@
 -export([pubsub_publish_item/6, vcard_iq_convert/1, vcard_iq_publish/1,
 	 get_sm_features/5]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("pubsub.hrl").
 -include("translate.hrl").

--- a/src/mod_block_strangers.erl
+++ b/src/mod_block_strangers.erl
@@ -34,7 +34,7 @@
 
 -export([filter_packet/1, filter_offline_msg/1, filter_subscription/2]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("translate.hrl").
 

--- a/src/mod_blocking.erl
+++ b/src/mod_blocking.erl
@@ -33,7 +33,7 @@
 	 disco_features/5, mod_options/1, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 -include("translate.hrl").
 

--- a/src/mod_bosh.erl
+++ b/src/mod_bosh.erl
@@ -40,7 +40,7 @@
 
 -include("logger.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_http.hrl").
 -include("bosh.hrl").
 -include("translate.hrl").

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -53,7 +53,7 @@
 
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_caps.hrl").
 -include("translate.hrl").
 

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -42,7 +42,7 @@
 -export([list/2]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -type direction() :: sent | received.

--- a/src/mod_client_state.erl
+++ b/src/mod_client_state.erl
@@ -42,7 +42,7 @@
 	 c2s_copy_session/2, c2s_session_resumed/1]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -define(CSI_QUEUE_MAX, 100).

--- a/src/mod_configure.erl
+++ b/src/mod_configure.erl
@@ -39,7 +39,7 @@
 	 depends/2, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_sm.hrl").
 -include("translate.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").

--- a/src/mod_delegation.erl
+++ b/src/mod_delegation.erl
@@ -42,7 +42,7 @@
 	 disco_local_identity/5, disco_sm_identity/5]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -type route_type() :: ejabberd_sm | ejabberd_local.

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -42,7 +42,7 @@
 
 -include("logger.hrl").
 -include("translate.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 -include("mod_roster.hrl").
 

--- a/src/mod_fail2ban.erl
+++ b/src/mod_fail2ban.erl
@@ -42,7 +42,7 @@
 -include_lib("stdlib/include/ms_transform.hrl").
 -include("ejabberd_commands.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -define(CLEAN_INTERVAL, timer:minutes(10)).

--- a/src/mod_http_api.erl
+++ b/src/mod_http_api.erl
@@ -32,7 +32,7 @@
 -export([start/2, stop/1, reload/3, process/2, depends/2,
 	 mod_options/1, mod_doc/0]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("ejabberd_http.hrl").
 -include("ejabberd_stacktrace.hrl").

--- a/src/mod_http_upload.erl
+++ b/src/mod_http_upload.erl
@@ -87,7 +87,7 @@
 	 expand_host/2]).
 
 -include("ejabberd_http.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("translate.hrl").
 

--- a/src/mod_http_upload_quota.erl
+++ b/src/mod_http_upload_quota.erl
@@ -52,7 +52,7 @@
 %% ejabberd_hooks callback.
 -export([handle_slot_request/6]).
 
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("logger.hrl").
 -include("translate.hrl").
 -include_lib("kernel/include/file.hrl").

--- a/src/mod_jidprep.erl
+++ b/src/mod_jidprep.erl
@@ -41,7 +41,7 @@
 
 -include("logger.hrl").
 -include("translate.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 %%--------------------------------------------------------------------
 %% gen_mod callbacks.

--- a/src/mod_last.erl
+++ b/src/mod_last.erl
@@ -38,7 +38,7 @@
 	 register_user/2, depends/2, privacy_check_packet/4]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 -include("mod_last.hrl").
 -include("translate.hrl").

--- a/src/mod_legacy_auth.erl
+++ b/src/mod_legacy_auth.erl
@@ -29,7 +29,7 @@
 %% hooks
 -export([c2s_unauthenticated_packet/2, c2s_stream_features/2]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -type c2s_state() :: ejabberd_c2s:state().

--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -44,7 +44,7 @@
 	 is_empty_for_user/2, is_empty_for_room/3, check_create_room/4,
 	 process_iq/3, store_mam_message/7, make_id/0, wrap_as_mucsub/2, select/7]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("mod_muc_room.hrl").
 -include("ejabberd_commands.hrl").

--- a/src/mod_mam_mnesia.erl
+++ b/src/mod_mam_mnesia.erl
@@ -32,7 +32,7 @@
 	 is_empty_for_user/2, is_empty_for_room/3]).
 
 -include_lib("stdlib/include/ms_transform.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("mod_mam.hrl").
 

--- a/src/mod_mam_sql.erl
+++ b/src/mod_mam_sql.erl
@@ -33,7 +33,7 @@
 	 is_empty_for_user/2, is_empty_for_room/3, select_with_mucsub/6]).
 
 -include_lib("stdlib/include/ms_transform.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_mam.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_metrics.erl
+++ b/src/mod_metrics.erl
@@ -29,7 +29,7 @@
 -behaviour(gen_mod).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -export([start/2, stop/1, mod_opt_type/1, mod_options/1, depends/2, reload/3]).

--- a/src/mod_mix.erl
+++ b/src/mod_mix.erl
@@ -41,7 +41,7 @@
 	 process_mam_query/1,
 	 process_pubsub_query/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("translate.hrl").
 -include("ejabberd_stacktrace.hrl").

--- a/src/mod_mix_pam.erl
+++ b/src/mod_mix_pam.erl
@@ -33,7 +33,7 @@
 	 remove_user/2,
 	 process_iq/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("translate.hrl").
 

--- a/src/mod_mqtt_session.erl
+++ b/src/mod_mqtt_session.erl
@@ -28,7 +28,7 @@
 
 -include("logger.hrl").
 -include("mqtt.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(state, {vsn = ?VSN            :: integer(),
                 version               :: undefined | mqtt_version(),

--- a/src/mod_mqtt_ws.erl
+++ b/src/mod_mqtt_ws.erl
@@ -29,7 +29,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 	 terminate/2, code_change/3, format_status/2]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_http.hrl").
 -include("logger.hrl").
 

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -75,7 +75,7 @@
 	 mod_opt_type/1, mod_options/1, depends/2]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_muc.hrl").
 -include("mod_muc_room.hrl").
 -include("translate.hrl").

--- a/src/mod_muc_admin.erl
+++ b/src/mod_muc_admin.erl
@@ -44,7 +44,7 @@
 	 web_page_host/3, mod_options/1, get_commands_spec/0, find_hosts/1]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_muc.hrl").
 -include("mod_muc_room.hrl").
 -include("ejabberd_http.hrl").

--- a/src/mod_muc_log.erl
+++ b/src/mod_muc_log.erl
@@ -42,7 +42,7 @@
 	 mod_opt_type/1, mod_options/1, depends/2, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_muc_room.hrl").
 -include("translate.hrl").
 

--- a/src/mod_muc_mnesia.erl
+++ b/src/mod_muc_mnesia.erl
@@ -43,7 +43,7 @@
 
 -include("mod_muc.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 
 -record(state, {}).

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -66,7 +66,7 @@
 	 code_change/4]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 -include("mod_muc_room.hrl").
 -include("ejabberd_stacktrace.hrl").

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -40,7 +40,7 @@
 -export([set_affiliation/6, set_affiliations/4, get_affiliation/5,
 	 get_affiliations/3, search_affiliation/4]).
 
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("mod_muc.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_multicast.erl
+++ b/src/mod_multicast.erl
@@ -45,7 +45,7 @@
 
 -include("logger.hrl").
 -include("translate.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(multicastc, {rserver :: binary(),
 		     response,

--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -69,7 +69,7 @@
 
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/mod_offline_mnesia.erl
+++ b/src/mod_offline_mnesia.erl
@@ -32,7 +32,7 @@
 	 remove_all_messages/2, count_messages/2, import/1]).
 -export([need_transform/1, transform/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_offline.hrl").
 -include("logger.hrl").
 

--- a/src/mod_offline_sql.erl
+++ b/src/mod_offline_sql.erl
@@ -32,7 +32,7 @@
 	 read_message/3, remove_message/3, read_all_messages/2,
 	 remove_all_messages/2, count_messages/2, import/1, export/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_offline.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_ping.erl
+++ b/src/mod_ping.erl
@@ -35,7 +35,7 @@
 
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("translate.hrl").
 

--- a/src/mod_pres_counter.erl
+++ b/src/mod_pres_counter.erl
@@ -32,7 +32,7 @@
 
 -include("logger.hrl").
 -include("translate.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -record(pres_counter,
 	{dir, start, count, logged = false}).

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -41,7 +41,7 @@
 	 mod_opt_type/1, mod_options/1, depends/2]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 -include("translate.hrl").
 

--- a/src/mod_privacy_mnesia.erl
+++ b/src/mod_privacy_mnesia.erl
@@ -32,7 +32,7 @@
 	 remove_list/3, use_cache/1, import/1]).
 -export([need_transform/1, transform/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 -include("logger.hrl").
 

--- a/src/mod_privacy_sql.erl
+++ b/src/mod_privacy_sql.erl
@@ -34,7 +34,7 @@
 
 -export([item_to_raw/1, raw_to_item/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_privacy.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_private.erl
+++ b/src/mod_private.erl
@@ -40,7 +40,7 @@
 -export([get_commands_spec/0, bookmarks_to_pep/2]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_private.hrl").
 -include("ejabberd_commands.hrl").
 -include("translate.hrl").

--- a/src/mod_private_mnesia.erl
+++ b/src/mod_private_mnesia.erl
@@ -31,7 +31,7 @@
 	 use_cache/1, import/3]).
 -export([need_transform/1, transform/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_private.hrl").
 -include("logger.hrl").
 

--- a/src/mod_private_sql.erl
+++ b/src/mod_private_sql.erl
@@ -29,7 +29,7 @@
 -export([init/2, set_data/3, get_data/3, get_all_data/2, del_data/2,
 	 import/3, export/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_private.hrl").
 -include("ejabberd_sql_pt.hrl").
 -include("logger.hrl").

--- a/src/mod_privilege.erl
+++ b/src/mod_privilege.erl
@@ -41,7 +41,7 @@
 	 process_presence_out/1, process_presence_in/1]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -type roster_permission() :: both | get | set.

--- a/src/mod_proxy65_service.erl
+++ b/src/mod_proxy65_service.erl
@@ -38,7 +38,7 @@
 	 delete_listener/1, route/1]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 -include("ejabberd_stacktrace.hrl").
 

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -40,7 +40,7 @@
 -protocol({xep, 248, '0.2'}).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("pubsub.hrl").
 -include("mod_roster.hrl").
 -include("translate.hrl").

--- a/src/mod_push.erl
+++ b/src/mod_push.erl
@@ -51,7 +51,7 @@
 
 -include("ejabberd_commands.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -define(PUSH_CACHE, push_cache).

--- a/src/mod_push_keepalive.erl
+++ b/src/mod_push_keepalive.erl
@@ -36,7 +36,7 @@
 	 c2s_handle_cast/2, c2s_handle_info/2, c2s_stanza/3]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -define(PUSH_BEFORE_TIMEOUT_PERIOD, 120000). % 2 minutes.

--- a/src/mod_push_mnesia.erl
+++ b/src/mod_push_mnesia.erl
@@ -35,7 +35,7 @@
 
 -include_lib("stdlib/include/ms_transform.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_push.hrl").
 
 %%%-------------------------------------------------------------------

--- a/src/mod_push_sql.erl
+++ b/src/mod_push_sql.erl
@@ -31,7 +31,7 @@
 	 lookup_sessions/3, lookup_sessions/2, lookup_sessions/1,
 	 delete_session/3, delete_old_sessions/2, export/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").
 -include("mod_push.hrl").

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -38,7 +38,7 @@
 	 format_error/1, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 start(Host, _Opts) ->

--- a/src/mod_register_web.erl
+++ b/src/mod_register_web.erl
@@ -60,7 +60,7 @@
 
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("ejabberd_http.hrl").
 

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -54,7 +54,7 @@
 	 depends/2, set_item_and_notify_clients/3]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_roster.hrl").
 -include("ejabberd_http.hrl").
 -include("ejabberd_web_admin.hrl").

--- a/src/mod_roster_mnesia.erl
+++ b/src/mod_roster_mnesia.erl
@@ -37,7 +37,7 @@
 
 -include("mod_roster.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 %%%===================================================================
 %%% API

--- a/src/mod_roster_sql.erl
+++ b/src/mod_roster_sql.erl
@@ -38,7 +38,7 @@
 -include("mod_roster.hrl").
 -include("ejabberd_sql_pt.hrl").
 -include("logger.hrl").
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 
 %%%===================================================================
 %%% API

--- a/src/mod_s2s_dialback.erl
+++ b/src/mod_s2s_dialback.erl
@@ -33,7 +33,7 @@
 	 s2s_in_features/2, s2s_out_init/2, s2s_out_closed/2,
 	 s2s_out_tls_verify/2]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("translate.hrl").
 

--- a/src/mod_service_log.erl
+++ b/src/mod_service_log.erl
@@ -34,7 +34,7 @@
 
 -include("logger.hrl").
 -include("translate.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 start(Host, _Opts) ->
     ejabberd_hooks:add(user_send_packet, Host, ?MODULE,

--- a/src/mod_shared_roster.erl
+++ b/src/mod_shared_roster.erl
@@ -43,7 +43,7 @@
 
 -include("logger.hrl").
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -include("mod_roster.hrl").
 

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -43,7 +43,7 @@
 	 depends/2, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_roster.hrl").
 -include("eldap.hrl").
 -include("translate.hrl").

--- a/src/mod_shared_roster_mnesia.erl
+++ b/src/mod_shared_roster_mnesia.erl
@@ -37,7 +37,7 @@
 -include("mod_roster.hrl").
 -include("mod_shared_roster.hrl").
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 %%%===================================================================
 %%% API

--- a/src/mod_shared_roster_sql.erl
+++ b/src/mod_shared_roster_sql.erl
@@ -35,7 +35,7 @@
 	 add_user_to_group/3, remove_user_from_group/3, import/3,
 	 export/1]).
 
--include("jid.hrl").
+-include_lib("xmpp/include/jid.hrl").
 -include("mod_roster.hrl").
 -include("mod_shared_roster.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_sic.erl
+++ b/src/mod_sic.erl
@@ -35,7 +35,7 @@
 	 process_sm_iq/1, mod_options/1, depends/2, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 start(Host, _Opts) ->

--- a/src/mod_stats.erl
+++ b/src/mod_stats.erl
@@ -35,7 +35,7 @@
 	 mod_options/1, depends/2, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 start(Host, _Opts) ->

--- a/src/mod_stream_mgmt.erl
+++ b/src/mod_stream_mgmt.erl
@@ -37,9 +37,9 @@
 %% adjust pending session timeout / access queue
 -export([get_resume_timeout/1, set_resume_timeout/2, queue_find/2]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
--include("p1_queue.hrl").
+-include_lib("p1_utils/include/p1_queue.hrl").
 -include("translate.hrl").
 
 -define(STREAM_MGMT_CACHE, stream_mgmt_cache).

--- a/src/mod_stun_disco.erl
+++ b/src/mod_stun_disco.erl
@@ -55,7 +55,7 @@
 
 -include("logger.hrl").
 -include("translate.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -define(STUN_MODULE, ejabberd_stun).
 

--- a/src/mod_time.erl
+++ b/src/mod_time.erl
@@ -36,7 +36,7 @@
 	 mod_options/1, depends/2, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 start(Host, _Opts) ->

--- a/src/mod_vcard.erl
+++ b/src/mod_vcard.erl
@@ -44,7 +44,7 @@
 -export([route/1]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_vcard.hrl").
 -include("translate.hrl").
 -include("ejabberd_stacktrace.hrl").

--- a/src/mod_vcard_ldap.erl
+++ b/src/mod_vcard_ldap.erl
@@ -40,7 +40,7 @@
 
 -include("logger.hrl").
 -include("eldap.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -define(PROCNAME, ejabberd_mod_vcard_ldap).

--- a/src/mod_vcard_mnesia.erl
+++ b/src/mod_vcard_mnesia.erl
@@ -33,7 +33,7 @@
 -export([need_transform/1, transform/1]).
 -export([mod_opt_type/1, mod_options/1, mod_doc/0]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_vcard.hrl").
 -include("logger.hrl").
 -include("translate.hrl").

--- a/src/mod_vcard_sql.erl
+++ b/src/mod_vcard_sql.erl
@@ -32,7 +32,7 @@
 	 search_fields/1, search_reported/1, import/3, export/1]).
 -export([is_search_supported/1]).
 
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("mod_vcard.hrl").
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").

--- a/src/mod_vcard_xupdate.erl
+++ b/src/mod_vcard_xupdate.erl
@@ -37,7 +37,7 @@
 -export([compute_hash/1]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -define(VCARD_XUPDATE_CACHE, vcard_xupdate_cache).

--- a/src/mod_version.erl
+++ b/src/mod_version.erl
@@ -35,7 +35,7 @@
 	 mod_opt_type/1, mod_options/1, depends/2, mod_doc/0]).
 
 -include("logger.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 start(Host, _Opts) ->

--- a/src/node_flat.erl
+++ b/src/node_flat.erl
@@ -34,7 +34,7 @@
 -author('christophe.romain@process-one.net').
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,

--- a/src/node_flat_sql.erl
+++ b/src/node_flat_sql.erl
@@ -35,7 +35,7 @@
 
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_sql_pt.hrl").
 -include("translate.hrl").
 

--- a/src/nodetree_tree.erl
+++ b/src/nodetree_tree.erl
@@ -41,7 +41,7 @@
 -include_lib("stdlib/include/ms_transform.hrl").
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -export([init/3, terminate/2, options/0, set_node/1,

--- a/src/nodetree_tree_sql.erl
+++ b/src/nodetree_tree_sql.erl
@@ -39,7 +39,7 @@
 
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_sql_pt.hrl").
 -include("translate.hrl").
 

--- a/src/prosody2ejabberd.erl
+++ b/src/prosody2ejabberd.erl
@@ -27,8 +27,8 @@
 %% API
 -export([from_dir/1]).
 
--include("scram.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/scram.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("logger.hrl").
 -include("mod_roster.hrl").
 -include("mod_offline.hrl").

--- a/src/pubsub_subscription.erl
+++ b/src/pubsub_subscription.erl
@@ -38,7 +38,7 @@
     read_subscription/3, write_subscription/4]).
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -define(PUBSUB_DELIVER, <<"pubsub#deliver">>).

--- a/src/pubsub_subscription_sql.erl
+++ b/src/pubsub_subscription_sql.erl
@@ -34,7 +34,7 @@
     get_options_xform/2, parse_options_xform/1]).
 
 -include("pubsub.hrl").
--include("xmpp.hrl").
+-include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 
 -define(PUBSUB_DELIVER, <<"pubsub#deliver">>).


### PR DESCRIPTION
Similar to pull request #1446 but also cleans up rebar.config (and I have signed CLA).

Depends on xmpp library with https://github.com/processone/xmpp/pull/51 included

Fixes #2788
