### PR TITLE
Fix syntax for lager dependency version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -37,7 +37,7 @@
         {idna, ".*", {git, "https://github.com/benoitc/erlang-idna", {tag, "6.0.0"}}},
         {jiffy, ".*", {git, "https://github.com/davisp/jiffy", {tag, "1.0.5"}}},
         {jose, ".*", {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.9.0"}}},
-        {lager, ".*", {git, "https://github.com/erlang-lager/lager", "3.6.10"}},
+        {lager, ".*", {git, "https://github.com/erlang-lager/lager", {tag, "3.6.10"}}},
         {if_var_true, tools,
          {luerl, ".*", {git, "https://github.com/rvirding/luerl", {tag, "v0.3"}}}},
         {mqtree, ".*", {git, "https://github.com/processone/mqtree", {tag, "1.0.10"}}},


### PR DESCRIPTION
Add 'tag' to lager dependency so that build with rebar3 will pull from
hex package instead of git checkout matching other dependencies