### PR TITLE
Allow for filtering outgoing s2s stanzas

### DIFF
--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -351,8 +351,11 @@ route(Packet) ->
 	{ok, Pid} when is_pid(Pid) ->
 	    ?DEBUG("Sending to process ~p~n", [Pid]),
 	    #jid{lserver = MyServer} = From,
-	    ejabberd_hooks:run(s2s_send_packet, MyServer, [Packet]),
-	    ejabberd_s2s_out:route(Pid, Packet);
+	    case ejabberd_hooks:run_fold(s2s_send_packet, MyServer, Packet,
+					 []) of
+		drop -> ok;
+		Packet1 -> ejabberd_s2s_out:route(Pid, Packet1)
+	    end;
 	{error, Reason} ->
 	    Lang = xmpp:get_lang(Packet),
 	    Err = case Reason of

--- a/src/mod_metrics.erl
+++ b/src/mod_metrics.erl
@@ -103,10 +103,11 @@ user_receive_packet({Packet, #{jid := #jid{lserver = LServer}} = C2SState}) ->
     push(LServer, user_receive_packet),
     {Packet, C2SState}.
 
--spec s2s_send_packet(stanza()) -> any().
+-spec s2s_send_packet(stanza()) -> stanza().
 s2s_send_packet(Packet) ->
     #jid{lserver = LServer} = xmpp:get_from(Packet),
-    push(LServer, s2s_send_packet).
+    push(LServer, s2s_send_packet),
+    Packet.
 
 -spec s2s_receive_packet({stanza(), ejabberd_s2s_in:state()}) ->
 				{stanza(), ejabberd_s2s_in:state()}.


### PR DESCRIPTION
Let `s2s_send_packet` hook callbacks filter/drop stanzas, analogous to [the `s2s_receive_packet` hook][1].

[1]: https://github.com/processone/ejabberd/blob/20.07/src/ejabberd_s2s_in.erl#L221-L226