### PR TITLE
Add 'gitonly_deps' list to rebar config/script

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -61,6 +61,8 @@
         {yconf, ".*", {git, "https://github.com/processone/yconf", {tag, "1.0.7"}}}
        ]}.
 
+{gitonly_deps, [elixir, luerl]}.
+
 {if_var_true, latest_deps,
  {floating_deps, [cache_tab,
                   eimp,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -196,9 +196,14 @@ AppendList2 = fun(Append) ->
 	      end,
 
 Rebar3DepsFilter =
-fun(DepsList) ->
-	lists:map(fun({DepName, _, {git, _, {tag, Version}}}) ->
-			  {DepName, Version};
+fun(DepsList, GitOnlyDeps) ->
+	lists:map(fun({DepName, _, {git, _, {tag, Version}}} = Dep) ->
+			  case lists:member(DepName, GitOnlyDeps) of
+			      true ->
+				  Dep;
+			      _ ->
+				  {DepName, Version}
+                          end;
 		     (Dep) ->
 			  Dep
 		  end, DepsList)
@@ -367,8 +372,8 @@ Rules = [
 	  AppendList2(ProcssXrefExclusions), [], []},
 	 {[deps], [floating_deps], true,
 	  ProcessFloatingDeps, [], []},
-	 {[deps], IsRebar3,
-	  Rebar3DepsFilter, []},
+	 {[deps], [gitonly_deps], IsRebar3,
+	  Rebar3DepsFilter, [], []},
 	 {[deps], SystemDeps /= false,
 	  GlobalDepsFilter, []}
 	],


### PR DESCRIPTION
Add list of dependencies that should only be built from git, to support building with rebar3 where deps do not have hex packages (or where the package versions do not directly map to git tags).

This is required for elixir and luerl deps.