### PR TITLE
rebar3 plugin to support configure-deps command

### DIFF
--- a/_checkouts/configure_deps/rebar.config
+++ b/_checkouts/configure_deps/rebar.config
@@ -1,0 +1,2 @@
+{erl_opts, [debug_info]}.
+{deps, []}.

--- a/_checkouts/configure_deps/src/configure_deps.app.src
+++ b/_checkouts/configure_deps/src/configure_deps.app.src
@@ -1,0 +1,9 @@
+{application, configure_deps,
+ [{description, "A rebar3 plugin to explicitly run configure on dependencies"},
+  {vsn, "0.0.1"},
+  {registered, []},
+  {applications, [kernel, stdlib]},
+  {env,[]},
+  {modules, []},
+  {links, []}
+ ]}.

--- a/_checkouts/configure_deps/src/configure_deps.erl
+++ b/_checkouts/configure_deps/src/configure_deps.erl
@@ -1,0 +1,8 @@
+-module(configure_deps).
+
+-export([init/1]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    {ok, State1} = configure_deps_prv:init(State),
+    {ok, State1}.

--- a/_checkouts/configure_deps/src/configure_deps_prv.erl
+++ b/_checkouts/configure_deps/src/configure_deps_prv.erl
@@ -48,7 +48,7 @@ do_app(App) ->
     Dir = rebar_app_info:dir(App),
 	Opts = rebar_app_info:opts(App),
 	Overrides = rebar_opts:get(Opts, overrides),
-    lists:foldl(fun parse_additions/2, {binary_to_atom(rebar_app_info:name(App)), Dir}, Overrides).
+    lists:foldl(fun parse_additions/2, {binary_to_atom(rebar_app_info:name(App), utf8), Dir}, Overrides).
 
 -spec format_error(any()) ->  iolist().
 format_error(Reason) ->

--- a/_checkouts/configure_deps/src/configure_deps_prv.erl
+++ b/_checkouts/configure_deps/src/configure_deps_prv.erl
@@ -1,0 +1,55 @@
+-module(configure_deps_prv).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, 'configure-deps').
+-define(DEPS, [install_deps]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+	        {namespace, default},
+            {name, ?PROVIDER},            % The 'user friendly' name of the task
+            {module, ?MODULE},            % The module implementation of the task
+            {bare, true},                 % The task can be run by the user, always true
+            {deps, ?DEPS},                % The list of dependencies
+            {example, "rebar3 configure-deps"}, % How to use the plugin
+            {opts, []},                   % list of options understood by the plugin
+            {short_desc, "Explicitly run ./configure for dependencies"},
+            {desc, "A rebar plugin to allow explicitly running ./configure on depdendencies. Useful if dependencies might change prior to compilation when configure is run."}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    Apps = rebar_state:project_apps(State) ++ lists:usort(rebar_state:all_deps(State)),
+    lists:foreach(fun do_app/1, Apps),
+    {ok, State}.
+
+exec_configure({'configure-deps', Cmd}, Dir) ->
+	c:cd(Dir),
+	os:cmd(Cmd);
+exec_configure(_, Acc) -> Acc.
+
+parse_pre_hooks({pre_hooks, PreHooks}, Acc) ->
+    lists:foldl(fun exec_configure/2, Acc, PreHooks);
+parse_pre_hooks(_, Acc) -> Acc.
+
+parse_additions({add, App, Additions}, {MyApp, Dir}) when App == MyApp ->
+    lists:foldl(fun parse_pre_hooks/2, Dir, Additions),
+	{MyApp, Dir};
+parse_additions(_, Acc) -> Acc.
+
+do_app(App) ->
+    Dir = rebar_app_info:dir(App),
+	Opts = rebar_app_info:opts(App),
+	Overrides = rebar_opts:get(Opts, overrides),
+    lists:foldl(fun parse_additions/2, {binary_to_atom(rebar_app_info:name(App)), Dir}, Overrides).
+
+-spec format_error(any()) ->  iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).

--- a/rebar.config
+++ b/rebar.config
@@ -111,6 +111,7 @@
 {deps_erl_opts, [{if_var_true, hipe, native}]}.
 
 {if_rebar3, {plugins, [rebar3_hex, {provider_asn1, "0.2.0"}]}}.
+{if_rebar3, {project_plugins, [configure_deps]}}.
 {if_not_rebar3, {plugins, [
                            deps_erl_opts, override_deps_versions2, override_opts, configure_deps,
                            {if_var_true, elixir, rebar_elixir_compiler},


### PR DESCRIPTION
To allow running configure on dependencies prior to compilation, add a rebar3 plugin to support the 'configure-deps' command introduced for rebar2 in a7639fd4