### PR TITLE
Add outbound s2s out interface (ipv4/ipv6)

### DIFF
--- a/src/ejabberd_option.erl
+++ b/src/ejabberd_option.erl
@@ -90,6 +90,8 @@
 -export([oom_killer/0]).
 -export([oom_queue/0]).
 -export([oom_watermark/0]).
+-export([outgoing_s2s_ipv4_address/0,outgoing_s2s_ipv4_address/1]).
+-export([outgoing_s2s_ipv6_address/0,outgoing_s2s_ipv6_address/1]).
 -export([outgoing_s2s_families/0, outgoing_s2s_families/1]).
 -export([outgoing_s2s_port/0, outgoing_s2s_port/1]).
 -export([outgoing_s2s_timeout/0, outgoing_s2s_timeout/1]).
@@ -665,6 +667,20 @@ outgoing_s2s_families() ->
 -spec outgoing_s2s_families(global | binary()) -> ['inet' | 'inet6',...].
 outgoing_s2s_families(Host) ->
     ejabberd_config:get_option({outgoing_s2s_families, Host}).
+
+-spec outgoing_s2s_ipv4_address() -> inet:ip4_address().
+outgoing_s2s_ipv4_address() ->
+    outgoing_s2s_ipv4_address(global).
+-spec outgoing_s2s_ipv4_address(global | binary()) -> inet:ip4_address().
+outgoing_s2s_ipv4_address(Host) ->
+    ejabberd_config:get_option({outgoing_s2s_ipv4_address, Host}).
+
+-spec outgoing_s2s_ipv6_address() -> inet:ip6_address().
+outgoing_s2s_ipv6_address() ->
+    outgoing_s2s_ipv6_address(global).
+-spec outgoing_s2s_ipv6_address(global | binary()) -> inet:ip6_address().
+outgoing_s2s_ipv6_address(Host) ->
+    ejabberd_config:get_option({outgoing_s2s_ipv6_address, Host}).
 
 -spec outgoing_s2s_port() -> 1..1114111.
 outgoing_s2s_port() ->

--- a/src/ejabberd_options.erl
+++ b/src/ejabberd_options.erl
@@ -271,6 +271,10 @@ opt_type(outgoing_s2s_families) ->
 		   (ipv6) -> inet6
 		end, L)
       end);
+opt_type(outgoing_s2s_ipv4_address) ->
+    econf:ipv4();
+opt_type(outgoing_s2s_ipv6_address) ->
+    econf:ipv6();
 opt_type(outgoing_s2s_port) ->
     econf:port();
 opt_type(outgoing_s2s_timeout) ->
@@ -587,6 +591,8 @@ options() ->
      {oom_queue, 10000},
      {oom_watermark, 80},
      {outgoing_s2s_families, [inet, inet6]},
+     {outgoing_s2s_ipv4_address, undefined},
+     {outgoing_s2s_ipv6_address, undefined},
      {outgoing_s2s_port, 5269},
      {outgoing_s2s_timeout, timer:seconds(10)},
      {pam_service, <<"ejabberd">>},


### PR DESCRIPTION
Adding options taking IPs as string:
outgoing_s2s_ipv4_address: "1.2.3.4"
outgoing_s2s_ipv6_address: "2000:1:1:1::1"

We are open to contributions for ejabberd, as GitHub pull requests (PR).
Here are a few points to consider before submitting your PR. (You can
remove the whole text after reading.)

1. Does this PR address an issue? Please reference it in the PR
   description.

2. Have you properly described the proposed change?

3. Please make sure the change is atomic and does only touch the needed
   modules. If you have other changes/fixes to provide, please submit
   them as separate PRs.

4. If your change or new feature involves storage backends, did you make
   sure your change works with all backends?

5. Do you provide tests? How can we check the behavior of the code?

6. Did you consider documentation changes in the
   processone/docs.ejabberd.im repository?
