### PR TITLE
Improve rebar3 configure-deps plugin output

### DIFF
--- a/_checkouts/configure_deps/src/configure_deps_prv.erl
+++ b/_checkouts/configure_deps/src/configure_deps_prv.erl
@@ -31,8 +31,7 @@ do(State) ->
     {ok, State}.
 
 exec_configure({'configure-deps', Cmd}, Dir) ->
-	c:cd(Dir),
-	os:cmd(Cmd);
+	rebar_utils:sh(Cmd, [{cd, Dir}, {use_stdout, true}]);
 exec_configure(_, Acc) -> Acc.
 
 parse_pre_hooks({pre_hooks, PreHooks}, Acc) ->


### PR DESCRIPTION
Switch to using rebar_utils:sh/2 instead of os:cmd/1 to spawn ./configure so that output can be monitored and errors detected