### PR TITLE
web admin display garbled

### DIFF
--- a/src/str.erl
+++ b/src/str.erl
@@ -286,7 +286,7 @@ suffix(B1, B2) ->
 -spec format(io:format(), list()) -> binary().
 
 format(Format, Args) ->
-    unicode:characters_to_binary(io_lib:format(Format, Args)).
+    list_to_binary(io_lib:format(Format, Args)).
 
 
 -spec sha(iodata()) -> binary().


### PR DESCRIPTION
1. Does this PR address an issue? Please reference it in the PR
   description.

In the ejabberd web admin , other country language may dispaly garbled(eg. Japanese, Chinese ...), like the url `/admin/node/ejabberd@localhost/`, `/admin/node/ejabberd@localhost/db/`

2. Have you properly described the proposed change?

Yes.

3. Do you provide tests? How can we check the behavior of the code?

I test it in my environment. In the web admin just change the chrome language it will appear.

