### PR TITLE
Let systemd start ejabberd in foreground

### DIFF
--- a/ejabberd.service.template
+++ b/ejabberd.service.template
@@ -3,13 +3,12 @@ Description=XMPP Server
 After=network.target
 
 [Service]
-Type=forking
 User=ejabberd
 Group=ejabberd
 LimitNOFILE=65536
 Restart=on-failure
 RestartSec=5
-ExecStart=/bin/sh -c '@ctlscriptpath@/ejabberdctl start && @ctlscriptpath@/ejabberdctl started'
+ExecStart=@ctlscriptpath@/ejabberdctl foreground
 ExecStop=/bin/sh -c '@ctlscriptpath@/ejabberdctl stop && @ctlscriptpath@/ejabberdctl stopped'
 ExecReload=@ctlscriptpath@/ejabberdctl reload_config
 PrivateDevices=true


### PR DESCRIPTION
Daemons started by systemd shouldn't fork into the background if
possible, because if multiple forked processes exist, systemd has
a hard time determining the main process ID.

In a memory constrained environment, the OOM killer may cause
ejabberd to exit without any trace. Because epmd keeps running,
systemd wouldn't notice the error condition, and as a result it
won't restart the server.

With ejabberd running in foreground, systemd is able to obtain the
correct exit code (137 in this case, instead of 0) and schedules a
restart. The administrator can then see what happend by looking at
systemctl status ejabberd.