### PR TITLE
also convert embedded errors to binary

### DIFF
--- a/src/ejabberd_sql.erl
+++ b/src/ejabberd_sql.erl
@@ -1034,7 +1034,7 @@ mysql_to_odbc({error, MySQLRes})
   when is_list(MySQLRes) ->
     {error, list_to_binary(MySQLRes)};
 mysql_to_odbc({error, MySQLRes}) ->
-    {error, p1_mysql:get_result_reason(MySQLRes)};
+    mysql_to_odbc({error, p1_mysql:get_result_reason(MySQLRes)});
 mysql_to_odbc(ok) ->
     ok.
 


### PR DESCRIPTION
%% Convert MySQL query result to Erlang ODBC result formalism
It seems all error messages have to be converted to binaries.
This fix also converts embedded SQL results errors (that are currently lists) to binaries

This conversion to binary is essential for the error message to match in the code below

%% Generate the OTP callback return tuple depending on the driver result.
abort_on_driver_error({error, <<"query timed out">>} =
