### PR TITLE
Add multi-domain support (and flexibility) to LDAP shared roster (rev2).

### DIFF
--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -76,7 +76,8 @@
          ufilter = <<"">>                             :: binary(),
          rfilter = <<"">>                             :: binary(),
          gfilter = <<"">>                             :: binary(),
-	 auth_check = true                            :: boolean()}).
+         user_jid_attr = <<"">>                       :: binary(),
+         auth_check = true                            :: boolean()}).
 
 -record(group_info, {desc, members}).
 
@@ -387,6 +388,24 @@ search_group_info(State, Group) ->
 	  {ok, #group_info{desc = GroupDesc, members = lists:usort(lists:flatten(MembersLists))}}
     end.
 
+get_member_jid(#state{user_jid_attr = <<>>}, UID, Host) ->
+    {jid:nodeprep(UID), Host};
+get_member_jid(#state{user_jid_attr = UserJIDAttr, user_uid = UIDAttr} = State,
+               UID, Host) ->
+    Entries = eldap_search(State,
+                           [eldap_filter:do_sub(<<"(", UIDAttr/binary, "=%u)">>,
+                                                [{<<"%u">>, UID}])],
+                           [UserJIDAttr]),
+    case Entries of
+        [] ->
+            {error, error};
+        [#eldap_entry{attributes = [{UserJIDAttr, [MemberJID | _]}]} | _] ->
+            case jid:decode(MemberJID) of
+                error -> {error, Host};
+                #jid{luser = U, lserver = S} -> {U, S}
+            end
+    end.
+
 extract_members(State, Extractor, AuthChecker, #eldap_entry{attributes = Attrs}, {DescAcc, JIDsAcc}) ->
     Host = State#state.host,
     case {eldap_utils:get_ldap_attr(State#state.group_attr, Attrs),
@@ -394,23 +413,22 @@ extract_members(State, Extractor, AuthChecker, #eldap_entry{attributes = Attrs},
           lists:keysearch(State#state.uid, 1, Attrs)} of
         {ID, Desc, {value, {GroupMemberAttr, Members}}} when ID /= <<"">>,
                                                              GroupMemberAttr == State#state.uid ->
-            JIDs = lists:foldl(fun({ok, UID}, L) ->
-                                       PUID = jid:nodeprep(UID),
-                                       case PUID of
-                                           error ->
-                                               L;
-                                           _ ->
-                                               case AuthChecker(PUID, Host) of
-                                                   true ->
-                                                       [{PUID, Host} | L];
-                                                   _ ->
-                                                       L
-                                               end
-                                       end;
-                                  (_, L) -> L
-                               end,
-                               [],
-                               lists:map(Extractor, Members)),
+            JIDs = lists:foldl(
+                fun({ok, UID}, L) ->
+                    {MemberUID, MemberHost} = get_member_jid(State, UID, Host),
+                    case MemberUID of
+                        error ->
+                            L;
+                        _ ->
+                            case AuthChecker(MemberUID, MemberHost) of
+                                true ->
+                                    [{MemberUID, MemberHost} | L];
+                                _ ->
+                                    L
+                            end
+                    end;
+                   (_, L) -> L
+                end, [], lists:map(Extractor, Members)),
             {Desc, [JIDs | JIDsAcc]};
         _ ->
             {DescAcc, JIDsAcc}
@@ -456,6 +474,7 @@ parse_options(Host, Opts) ->
     UIDAttr = mod_shared_roster_ldap_opt:ldap_memberattr(Opts),
     UIDAttrFormat = mod_shared_roster_ldap_opt:ldap_memberattr_format(Opts),
     UIDAttrFormatRe = mod_shared_roster_ldap_opt:ldap_memberattr_format_re(Opts),
+    JIDAttr = mod_shared_roster_ldap_opt:ldap_userjidattr(Opts),
     AuthCheck = mod_shared_roster_ldap_opt:ldap_auth_check(Opts),
     ConfigFilter = mod_shared_roster_ldap_opt:ldap_filter(Opts),
     ConfigUserFilter = mod_shared_roster_ldap_opt:ldap_ufilter(Opts),
@@ -500,6 +519,7 @@ parse_options(Host, Opts) ->
            base = Cfg#eldap_config.base,
            deref_aliases = Cfg#eldap_config.deref_aliases,
 	   uid = UIDAttr,
+           user_jid_attr = JIDAttr,
 	   group_attr = GroupAttr, group_desc = GroupDesc,
 	   user_desc = UserDesc, user_uid = UserUID,
 	   uid_format = UIDAttrFormat,
@@ -550,6 +570,8 @@ mod_opt_type(ldap_ufilter) ->
 mod_opt_type(ldap_userdesc) ->
     econf:binary();
 mod_opt_type(ldap_useruid) ->
+    econf:binary();
+mod_opt_type(ldap_userjidattr) ->
     econf:binary();
 mod_opt_type(ldap_backups) ->
     econf:list(econf:domain(), [unique]);
@@ -607,6 +629,7 @@ mod_options(Host) ->
      {ldap_ufilter, <<"">>},
      {ldap_userdesc, <<"cn">>},
      {ldap_useruid, <<"cn">>},
+     {ldap_userjidattr, <<"">>},
      {ldap_backups, ejabberd_option:ldap_backups(Host)},
      {ldap_base, ejabberd_option:ldap_base(Host)},
      {ldap_uids, ejabberd_option:ldap_uids(Host)},

--- a/src/mod_shared_roster_ldap_opt.erl
+++ b/src/mod_shared_roster_ldap_opt.erl
@@ -30,6 +30,7 @@
 -export([ldap_ufilter/1]).
 -export([ldap_uids/1]).
 -export([ldap_userdesc/1]).
+-export([ldap_userjidattr/1]).
 -export([ldap_useruid/1]).
 -export([use_cache/1]).
 
@@ -194,6 +195,12 @@ ldap_userdesc(Opts) when is_map(Opts) ->
     gen_mod:get_opt(ldap_userdesc, Opts);
 ldap_userdesc(Host) ->
     gen_mod:get_module_opt(Host, mod_shared_roster_ldap, ldap_userdesc).
+
+-spec ldap_userjidattr(gen_mod:opts() | global | binary()) -> binary().
+ldap_userjidattr(Opts) when is_map(Opts) ->
+    gen_mod:get_opt(ldap_userjidattr, Opts);
+ldap_userjidattr(Host) ->
+    gen_mod:get_module_opt(Host, mod_shared_roster_ldap, ldap_userjidattr).
 
 -spec ldap_useruid(gen_mod:opts() | global | binary()) -> binary().
 ldap_useruid(Opts) when is_map(Opts) ->


### PR DESCRIPTION
**Revision 2 of an old outdated PR ( #2344):**

This patch adds multi-domain support to 'mod_shared_roster_ldap'. AFAIK, adding users from other domains (hosts), to a shared roster, is not possible in the current module variant. It also allows quite a bit more flexibilty by not assuming the JID is simply the compound of roster contact UID and the Host of the user owning the roster. Basically, it allows us to define a groupOfNames (e.g. xmppRosterGroup) and list any users, anywhere in the ldap directory by specifiying the attribute defining the JID of the members.

I've been using this patch/feature in production on an older ejabberd version for about 2 years now, it works great. I recently upgraded to 18.01 and re-ported the patch with some error handling improvements for when the ldap entries don't match (typos perhaps).

The best thing about this patch is that (AFAIK) it's completely backwards compatible. If you DO NOT set the new module variable 'ldap_userjidattr' to anything other than the default empty string, it works exactly as before. However, if you do set it to say "mail", then it uses that field to determine the JID of the contact (roster entry).  Instead of just forming it with the compounding of 'UID of member'@'Host of roster owner user'. On my server the ldap 'mail' attribute is the same as the XMPP JID, but if they are not the same, another attribute could be used.

I realise this is not a simple PR and must be scrutinized carefully. Do not hesitate to ask for further explanation etc. I am more than willing to add/modify documentation. I'd really like to get this feature upstream because currently I potentially need to keep redoing my patch everytime I upgrade to a new version of ejabberd. And one day it may not be possible to patch due to a conflict in design. LDAP Shared Rosters for multi-domains is crucial to me now. We have a complex group of companies that are on different domains, but must collaborate. Can't see how I'd run a xmpp server without it. 


Examples:
-------------

**Below are some sample and relevant LDAP entries:**

    cn=Example Org Roster,ou=groups,o=Example Organisation,dc=acme,dc=com
    objectClass: groupOfNames
    objectClass: xmppRosterGroup
    objectClass: top
    xmppRosterStatus: active
    member:
    description: Roster group for Example Org
    cn: Example Org Roster
    uniqueMember: uid=john,ou=people,o=Example Organisation,dc=acme,dc=com
    uniqueMember: uid=pierre,ou=people,o=Example Organisation,dc=acme,dc=com
    uniqueMember: uid=jane,ou=people,o=Example Organisation,dc=acme,dc=com

...

    uid=john,ou=people,o=Example Organisation,dc=acme,dc=com
    objectClass: top
    objectClass: person
    objectClass: organizationalPerson
    objectClass: inetOrgPerson
    objectClass: mailUser
    objectClass: sipRoutingObject
    uid: john
    givenName: John
    sn: Doe
    cn: John Doe
    displayName: John Doe
    accountStatus: active
    userPassword: secretpass
    IMAPURL: imap://imap.example.net:143
    mailHost: smtp.example.net
    mail: john@example.net
    sipLocalAddress: john@example.net


**Below is the sample ejabberd.yml module configuration to match:**

    mod_shared_roster_ldap:
      ldap_servers:
        - "ldap.acme.com"
      ldap_encrypt: tls
      ldap_port: 636
      ldap_rootdn: "cn=Manager,dc=acme,dc=com"
      ldap_password: "supersecretpass"
      ldap_base: "dc=acme,dc=com"
      ldap_filter: "(objectClass=*)"
      ldap_rfilter: "(&(objectClass=xmppRosterGroup)(xmppRosterStatus=active))"
      ldap_gfilter: "(&(objectClass=xmppRosterGroup)(xmppRosterStatus=active)(cn=%g))"
      ldap_groupattr: "cn"
      ldap_groupdesc: "cn"
      ldap_memberattr: "uniqueMember"
      ldap_memberattr_format_re: "uid=([a-z.]*),(ou=.*,)*(o=.*,)*dc=acme,dc=com"
      ldap_useruid: "uid"
      ldap_userdesc: "cn"
      ldap_userjidattr: "mail"
      ldap_auth_check: false
      ldap_user_cache_validity: 86400
      ldap_group_cache_validity: 86400