### PR TITLE
Fix websocket Pong responses (improve rfc6455 compliancy)

### DIFF
--- a/src/ejabberd_websocket.erl
+++ b/src/ejabberd_websocket.erl
@@ -358,7 +358,7 @@ process_frame(#frame_info{unprocessed = none,
                       | Recv],
                      Send};
                 9 -> % Ping
-                    Frame = encode_frame(Unprocessed, 10),
+                    Frame = encode_frame(Unmasked, 10),
                     {FrameInfo3#frame_info{unmasked_msg = UnmaskedMsg}, [ping | Recv],
                      [Frame | Send]};
                 10 -> % Pong


### PR DESCRIPTION
The proposed fix solves 2 RFC constraints about :

1. control frames length

https://tools.ietf.org/html/rfc6455#section-5.5

All control frames MUST have a payload length of 125 bytes or less
   and MUST NOT be fragmented.

2. ping "data" response

https://tools.ietf.org/html/rfc6455#section-5.5.3

A Pong frame sent in response to a Ping frame must have identical
   "Application data" as found in the message body of the Ping frame
   being replied to.


We had issues since the PONG reply (former "Unprocessed") may contain incoming data and may exceed the 125 size limit of a control frame causing our remote client to disconnect...


Below a simulated incoming PING (with data)

```erlang
PingFrame = ejabberd_websocket:encode_frame(<<"my ping data">>, PingOpcode = 9).
<<137,12,109,121,32,112,105,110,103,32,100,97,116,97>>

WS ! {tcp, {frame_info,none,0,undefined,true,undefined,<<>>,<<>>,<<>>}, PingFrame}.
```

and the associated trace to show how the fix improves the compliancy.

```redbug
% 18:23:51.844 <0.13322.0>({ejabberd_http,init,3})
% ejabberd_websocket:handle_data(tcp, {frame_info,none,0,undefined,true,undefined,<<>>,<<>>,<<>>}, <<137,12,109,121,32,112,105,110,103,32,100,97,116,97>>, #Port<0.656>, <0.13323.0>, gen_tcp, {state,500000,500000,500000,1612459410677267})

% 18:23:51.844 <0.13322.0>({ejabberd_http,init,3})
% ejabberd_websocket:process_frame({frame_info,none,0,undefined,true,undefined,<<>>,<<>>,<<>>}, <<137,12,109,121,32,112,105,110,103,32,100,97,116,97>>)
{tcp,{frame_info,none,0,undefined,true,undefined,<<>>,<<>>,<<>>}, <<137,12,109,121,32,112,105,110,103,32,100,97,116,97>>}

% 18:23:51.844 <0.13322.0>({ejabberd_http,init,3})
% ejabberd_websocket:process_frame({frame_info,none,0,12,true,9,none,<<>>,<<>>}, <<"my ping data">>)

% 18:23:51.844 <0.13322.0>({ejabberd_http,init,3})              
% ejabberd_websocket:process_frame({frame_info,none,0,undefined,true,undefined,<<>>,<<>>,<<>>}, <<>>)
{{frame_info,none,0,undefined,true,undefined,<<>>,<<>>,<<>>}, [], []}
                                                                
% 18:23:51.844 <0.13322.0>({ejabberd_http,init,3})
% ejabberd_websocket:process_frame/2 => ok

% 18:23:51.844 <0.13322.0>({ejabberd_http,init,3})              
% ejabberd_websocket:trace({reply_pong,{'Unmasked',<<"my ping data">>},{'Unprocessed',<<>>}})


I added this line to show the former value "Unprocessed" and the new correct value "Unmasked"
trace({reply_pong, {'Unmasked', Unmasked}, {'Unprocessed', Unprocessed}}),


% 18:23:51.844 <0.13322.0>({ejabberd_http,init,3})              
% ejabberd_websocket:encode_frame(<<"my ping data">>, 10)
{{frame_info,none,0,undefined,true,undefined,<<>>,<<>>,<<>>}, [ping], [<<138,12,109,121,32,112,105,110,103,32,100,97,116,97>>]}
                                                                
% 18:23:51.844 <0.13322.0>({ejabberd_http,init,3})
% ejabberd_websocket:process_frame/2 => ok
{{frame_info,none,0,undefined,true,undefined,<<>>,<<>>,<<>>}, [ping], [<<138,12,109,121,32,112,105,110,103,32,100,97,116,97>>]}
                                                                
% 18:23:51.844 <0.13322.0>({ejabberd_http,init,3})
% ejabberd_websocket:process_frame/2 => ok

```
