### PR TITLE
Move sql directory from extra_src_dirs to src_dirs

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -108,8 +108,8 @@
             {if_var_true, sip, {d, 'SIP'}},
             {if_var_true, stun, {d, 'STUN'}},
             {if_have_fun, {erl_error, format_exception, 6}, {d, 'HAVE_ERL_ERROR'}},
-            {if_rebar3, {extra_src_dirs, [sql]}},
             {src_dirs, [src,
+                        {if_rebar3, sql},
                         {if_var_true, tools, tools},
                         {if_var_true, elixir, include}]}]}.
 


### PR DESCRIPTION
rebar3 needs sql directory as a src dir so that tests can reference sql files, so sql dir was added to extra_src_dirs in d9c1befb. It turns out extra_src_dirs does unexpected unwanted extra things like copy all beam files there too, so move sql dir to regular src_dirs.
