### PR TITLE
fix eldap certificate verification

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -96,6 +96,7 @@
             {if_version_above, "20", {d, 'DEPRECATED_GET_STACKTRACE'}},
             {if_version_below, "21", {d, 'USE_OLD_HTTP_URI'}},
             {if_version_below, "22", {d, 'LAGER'}},
+            {if_version_below, "21", {d, 'NO_CUSTOMIZE_HOSTNAME_CHECK'}},
             {if_version_below, "23", {d, 'USE_OLD_CRYPTO_HMAC'}},
             {if_version_below, "23", {d, 'USE_OLD_PG2'}},
             {if_var_match, db_type, mssql, {d, 'mssql'}},


### PR DESCRIPTION
Reported in #3527. Add hostname matching function, and specify SNI

Also, OTP 23 dropped backwards compatibility for 0, 1, 2 values for verify, so replace with combination of verify_none/verify_peer and fail_if_no_peer_cert as appropriate