### PR TITLE
fix gen_pubsub_node:get_state return value

### DIFF
--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -705,8 +705,7 @@ remove_user(User, Server) ->
 					case node_action(Host, PType,
 							 get_state,
 							 [Nidx, jid:tolower(Entity)]) of
-					    {result, State} ->
-						ItemIds = State#pubsub_state.items,
+					    {result, #pubsub_state{items = ItemIds}} ->
 						node_action(Host, PType,
 							    remove_extra_items,
 							    [Nidx, 0, ItemIds]),
@@ -3821,6 +3820,8 @@ node_call(Host, Type, Function, Args) ->
 	true ->
 	    case apply(Module, Function, Args) of
 		{result, Result} ->
+		    {result, Result};
+		#pubsub_state{} = Result ->
 		    {result, Result};
 		{error, #stanza_error{}} = Err ->
 		    Err;


### PR DESCRIPTION
"get_state" is still a "gen_pubsub_node" callback that does not return a "result" tuple.

-callback get_state(NodeIdx :: nodeIdx(),
	Key :: ljid()) ->
    pubsubState().

3 ways to fix this :

- modify the call back to return {result, pubsubState()}
- accept a #pubsub_state{} as return value              <===== My fix
- accept any return values since errors are matched by "error" and "{error, _}" 