### PR TITLE
unwrap mucsub and treat payload like a message

### DIFF
--- a/src/mod_push.erl
+++ b/src/mod_push.erl
@@ -538,7 +538,13 @@ notify(LUser, LServer, Clients, Pkt, Dir) ->
 	     fun((iq() | timeout) -> any())) -> ok.
 notify(LServer, PushLJID, Node, XData, Pkt, Dir, HandleResponse) ->
     From = jid:make(LServer),
-    Summary = make_summary(LServer, Pkt, Dir),
+    Pkt1 = case misc:is_mucsub_message(Pkt) of
+        true -> 
+            misc:unwrap_mucsub_message(Pkt);
+        _ ->
+            Pkt
+    end,
+    Summary = make_summary(LServer, Pkt1, Dir),
     Item = #ps_item{sub_els = [#push_notification{xdata = Summary}]},
     PubSub = #pubsub{publish = #ps_publish{node = Node, items = [Item]},
 		     publish_options = XData},


### PR DESCRIPTION
since mucsub messages are wrapped the summary does not detect the body properly. thus checking if its a mucsub message and in that case unwrapping it solves that issue. i assume this is the expected behaviour so this patch brings the behaviour in line with normal push notifications.

We are open to contributions for ejabberd, as GitHub pull requests (PR).
Here are a few points to consider before submitting your PR. (You can
remove the whole text after reading.)

1. Does this PR address an issue? Please reference it in the PR
   description.

2. Have you properly described the proposed change?

3. Please make sure the change is atomic and does only touch the needed
   modules. If you have other changes/fixes to provide, please submit
   them as separate PRs.

4. If your change or new feature involves storage backends, did you make
   sure your change works with all backends?

5. Do you provide tests? How can we check the behavior of the code?

6. Did you consider documentation changes in the
   processone/docs.ejabberd.im repository?
