### PR TITLE
allow shared roster group placeholder in mqtt topic

### DIFF
--- a/src/acl.erl
+++ b/src/acl.erl
@@ -25,6 +25,7 @@
 -export([match_rules/4, match_acls/3]).
 -export([access_rules_validator/0, access_validator/0]).
 -export([validator/1, validators/0]).
+-export([loaded_shared_roster_module/1]).
 %% gen_server callbacks
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 	 terminate/2, code_change/3]).

--- a/src/mod_mqtt.erl
+++ b/src/mod_mqtt.erl
@@ -600,6 +600,23 @@ match([H|T1], [<<"%c">>|T2], U, S, R) ->
         R -> match(T1, T2, U, S, R);
         _ -> false
     end;
+match([H|T1], [<<"%g">>|T2], U, S, R) ->
+    case jid:resourceprep(H) of
+        H -> 
+            case acl:loaded_shared_roster_module(S) of
+                undefined -> false;
+                Mod ->
+                    case Mod:get_group_opts(S, H) of
+                        error -> false;
+                        _ ->
+                            case Mod:is_user_in_group({U, S}, H, S) of
+                                true -> match(T1, T2, U, S, R);
+                                _ -> false
+                            end
+                    end
+            end;
+        _ -> false
+    end;
 match([H|T1], [H|T2], U, S, R) ->
     match(T1, T2, U, S, R);
 match([], [], _, _, _) ->


### PR DESCRIPTION
to allow for a more dynamic access control of topics, even at runtime and since shared roster groups are already part of the acl model i suggest a placeholder for shared roster groups in mqtt topics. the code resolves the respective roster group, checks its existence and the membership of the subscribing/publishing user.

We are open to contributions for ejabberd, as GitHub pull requests (PR).
Here are a few points to consider before submitting your PR. (You can
remove the whole text after reading.)