### PR TITLE
Use rebar3 in Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,31 +35,32 @@ before_script:
 
 cache:
   directories:
-  - deps/
+  - ~/.cache/rebar3/
 
 script:
   - ./autogen.sh
-  - ./configure --prefix=/tmp/ejabberd --enable-all --disable-odbc --disable-elixir
+  - ./configure --prefix=/tmp/ejabberd --enable-all --disable-odbc --disable-elixir --with-rebar=`which rebar3`
   - make update
   - make
   - make install -s
   - make xref
-  - ./tools/hook_deps.sh ebin
+  - make hooks
   - sed -i -e 's/ct:pal/ct:log/' test/suite.erl
   - ln -sf ../sql priv/
   - echo "" >> rebar.config
   - echo '{ct_extra_params, "-verbosity 20"}.' >> rebar.config
-  - escript ./rebar skip_deps=true ct -v
-  - grep -q 'TEST COMPLETE,.* 0 failed' logs/raw.log
-  - test $(find logs -empty -name error.log)
+  - rebar3 ct -v
+  - ln -s _build/test/logs/ logs
+  - grep -q 'TEST COMPLETE,.* 0 failed' `find logs/ -name suite.log`
+  - test $(find logs/ -empty -name error.log)
 
 after_script:
-  - find logs -name suite.log -exec cat '{}' ';'
+  - find logs/ -name suite.log -exec cat '{}' ';'
 
 after_failure:
-  - find logs -name exunit.log -exec cat '{}' ';'
-  - find logs -name ejabberd.log -exec cat '{}' ';'
-  - find logs -name suite.log -exec cat '{}' ';' | awk 'BEGIN{RS="\n=case";FS="\n"} /=result\s*failed/ {print "=case" $0}'
+  - find logs/ -name exunit.log -exec cat '{}' ';'
+  - find logs/ -name ejabberd.log -exec cat '{}' ';'
+  - find logs/ -name suite.log -exec cat '{}' ';' | awk 'BEGIN{RS="\n=case";FS="\n"} /=result\s*failed/ {print "=case" $0}'
 
 after_success:
   - coveralls-merge erlang.json

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -341,12 +341,13 @@ end,
 
 TravisPostHooks =
 fun(true) ->
-	[{ct, "echo '\n%%! -pa ebin/ deps/coveralls/ebin\n" ++
+	[{ct, "echo '\n%%! -pa _build/test/lib/ejabberd/ebin/ " ++
+	      "_build/test/lib/coveralls/ebin _build/test/lib/jsx/ebin\n" ++
 	      "main(_)->{ok,F}=file:open(\"erlang.json\",[write])," ++
 	      "io:fwrite(F,\"~s\",[coveralls:convert_file(" ++
-	      "\"logs/all.coverdata\", \"" ++
+	      "\"_build/test/cover/ct.coverdata\", #{service_job_id => \"" ++
 	      os:getenv("TRAVIS_JOB_ID") ++
-	      "\", \"travis-ci\",\"\")]).' > getcover.erl"},
+	      "\", service_name => \"travis-ci\"})]).' > getcover.erl"},
 	 {ct, "escript ./getcover.erl"}];
    (_) ->
 	[]
@@ -359,7 +360,7 @@ Rules = [
 			     {clean, {asn, clean}}
 			    ]}]), []},
 	 {[deps], os:getenv("TRAVIS") == "true",
-	  AppendList([{coveralls, ".*", {git, "https://github.com/markusn/coveralls-erl", {tag, "v2.0.1"}}}]), []},
+	  AppendList([{coveralls, "2.2.0"}, {jsx, "2.10.0"}]), []},
 	 {[post_hooks], [cover_enabled], os:getenv("TRAVIS") == "true",
 	  AppendList2(TravisPostHooks), [], false},
 	 {[overrides], [post_hook_configure], SystemDeps == false,


### PR DESCRIPTION
ejabberd can be compiled using rebar2, rebar3 or mix. I have been using rebar3 since some months ago, and it works perfectly for building ejabberd, at least in my experience.

Regarding Travis, I haven't seen any specific performance benefit in Travis using rebar3 instead of rebar2: the testing time just reduces between one to three minutes (15 -> 14 minutes, 18 -> 15 minutes)

But by upgrading Travis from rebar2 to rebar3, we move ejabberd one step forward, and leave rebar2 one step behind. This would make easier, in the future, to drop rebar2 support.

So, here is a proposal to use rebar3 in Travis. Any feedback and opinion is welcome.