### PR TITLE
Fixed srg_create params and shared roster groups cache issues

### DIFF
--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -664,7 +664,8 @@ get_commands_spec() ->
 			"name desc \\\"group1\\\\ngroup2\\\"",
 			module = ?MODULE, function = srg_create,
 			args = [{group, binary}, {host, binary},
-				{name, binary}, {description, binary}, {display, binary}],
+				{label, binary}, {description, binary}, {display, binary}],
+			args_rename = [{name, label}],
 			args_example = [<<"group3">>, <<"myserver.com">>, <<"Group3">>,
 				<<"Third group">>, <<"group1\\\\ngroup2">>],
 			args_desc = ["Group identifier", "Group server name", "Group name",
@@ -1456,12 +1457,12 @@ private_set2(Username, Host, Xml) ->
 %%% Shared Roster Groups
 %%%
 
-srg_create(Group, Host, Name, Description, Display) ->
+srg_create(Group, Host, Label, Description, Display) ->
     DisplayList = case Display of
 	<<>> -> [];
 	_ -> ejabberd_regexp:split(Display, <<"\\\\n">>)
     end,
-    Opts = [{name, Name},
+    Opts = [{label, Label},
 	    {displayed_groups, DisplayList},
 	    {description, Description}],
     {atomic, _} = mod_shared_roster:create_group(Host, Group, Opts),

--- a/src/mod_shared_roster.erl
+++ b/src/mod_shared_roster.erl
@@ -713,14 +713,14 @@ add_user_to_group2(Host, US, Group) ->
 	  push_user_to_displayed(LUser, LServer, Group, Host, both, DisplayedToGroups),
 	  push_displayed_to_user(LUser, LServer, Host, both, DisplayedGroups),
 	  Mod = gen_mod:db_mod(Host, ?MODULE),
+	  Mod:add_user_to_group(Host, US, Group),
 	  case use_cache(Mod, Host) of
 	      true ->
 		  ets_cache:delete(?USER_GROUPS_CACHE, {Host, US}, cache_nodes(Mod, Host)),
 		  ets_cache:delete(?GROUP_EXPLICIT_USERS_CACHE, {Host, Group}, cache_nodes(Mod, Host));
 	      false ->
 		  ok
-	  end,
-	  Mod:add_user_to_group(Host, US, Group)
+	  end
     end.
 
 get_displayed_groups(Group, LServer) ->
@@ -749,6 +749,7 @@ remove_user_from_group(Host, US, Group) ->
 	  set_group_opts(Host, Group, NewGroupOpts);
       nomatch ->
 	  Mod = gen_mod:db_mod(Host, ?MODULE),
+	  Result = Mod:remove_user_from_group(Host, US, Group),
 	  case use_cache(Mod, Host) of
 	      true ->
 		  ets_cache:delete(?USER_GROUPS_CACHE, {Host, US}, cache_nodes(Mod, Host)),
@@ -756,7 +757,6 @@ remove_user_from_group(Host, US, Group) ->
 	      false ->
 		  ok
 	  end,
-	  Result = Mod:remove_user_from_group(Host, US, Group),
 	  DisplayedToGroups = displayed_to_groups(Group, Host),
 	  DisplayedGroups = get_displayed_groups(Group, LServer),
 	  push_user_to_displayed(LUser, LServer, Group, Host, remove, DisplayedToGroups),


### PR DESCRIPTION
This pull request fixes issues with shared roster groups:

1. fixed srg_create administrative api function - it accepted old name parameter and stores it as `name` into OPTS. The parameter should be now named and stored as `label`
2. it fixes cache issues. The cache was cleaned **before** item was added / removed from shared roster group. So that it can happen (and it happened to us), that user was added to shared roster group, but cache item was reloaded before item was updated in database - so there were old data in cache. I changed the order (first update in DB, then delete cache) and it fixed this inconsistency issue.

This pull request is fixing issue #3576.