### PR TITLE
MySQL Backend Patch for scram-sha512

### DIFF
--- a/sql/mysql.new.sql
+++ b/sql/mysql.new.sql
@@ -20,8 +20,8 @@ CREATE TABLE users (
     username varchar(191) NOT NULL,
     server_host varchar(191) NOT NULL,
     password text NOT NULL,
-    serverkey varchar(64) NOT NULL DEFAULT '',
-    salt varchar(64) NOT NULL DEFAULT '',
+    serverkey varchar(128) NOT NULL DEFAULT '',
+    salt varchar(128) NOT NULL DEFAULT '',
     iterationcount integer NOT NULL DEFAULT 0,
     created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (server_host(191), username)

--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -19,8 +19,8 @@
 CREATE TABLE users (
     username varchar(191) PRIMARY KEY,
     password text NOT NULL,
-    serverkey varchar(64) NOT NULL DEFAULT '',
-    salt varchar(64) NOT NULL DEFAULT '',
+    serverkey varchar(128) NOT NULL DEFAULT '',
+    salt varchar(128) NOT NULL DEFAULT '',
     iterationcount integer NOT NULL DEFAULT 0,
     created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
scram-sha512 did not work, because serverkey is longer then that array. All passwords was unhashed.