### PR TITLE
PubSub: Bump default value for 'max_items' limit

### DIFF
--- a/include/pubsub.hrl
+++ b/include/pubsub.hrl
@@ -23,7 +23,7 @@
 -define(ERR_EXTENDED(E, C), mod_pubsub:extended_error(E, C)).
 
 %% The actual limit can be configured with mod_pubsub's option max_items_node
--define(MAXITEMS, 10).
+-define(MAXITEMS, 1000).
 
 %% this is currently a hard limit.
 %% Would be nice to have it configurable.

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -4276,7 +4276,7 @@ mod_doc() ->
 	    #{value => "MaxItems",
 	      desc =>
 		  ?T("Define the maximum number of items that can be "
-		     "stored in a node. Default value is: '10'.")}},
+		     "stored in a node. Default value is: '1000'.")}},
 	   {max_nodes_discoitems,
 	    #{value => "pos_integer() | infinity",
 	      desc =>


### PR DESCRIPTION
Bump the default value for `mod_pubsub`'s `max_items_node` option, which hard-limits the `max_items` value requested by clients.

These days, use cases such as [microblogging][1] or [XEP-0402][2] may need a large number of items per node.  Bumping the limit makes sure such functionality is properly supported with the default configuration.

[1]: https://xmpp.org/extensions/xep-0277.html
[2]: https://xmpp.org/extensions/xep-0402.html