### PR TITLE
"sort -R" command in captcha-ng.sh is not POSIX - added "shuf" and "cat" as fallback

### DIFF
--- a/tools/captcha-ng.sh
+++ b/tools/captcha-ng.sh
@@ -42,7 +42,8 @@ INTRUDER()
 {
 NUMBERS=$(echo "$INPUT" | grep -o . | tr '\n' ' ')
 SORTED_UNIQ_NUM=$(echo "${NUMBERS[@]}" | sort -u | tr '\n' ' ')
-RANDOM_DIGITS=$(echo 123456789 | grep -o . | sort -R | tr '\n' ' ')
+SORT_RANDOM_CMD="$( ( echo x|sort -R >&/dev/null && echo "sort -R" ) || ( echo x|shuf >&/dev/null && echo shuf ) || echo cat)"
+RANDOM_DIGITS=$(echo 123456789 | grep -o . | eval "$SORT_RANDOM_CMD" | tr '\n' ' ')
 INTRUDER=-1
 
 for i in $RANDOM_DIGITS


### PR DESCRIPTION
Some busybox cannot do sort -R (=random). Shuf is an alternative but some systems do not even have that.

This is important for docker containers. 

I am running an 1:1 copy of the official ECS docker image, just build by myself against ARM. This is how I noticed the problem.

Tested and works on all sorts of systems.