### PR TITLE
PubSub: Support 'max_items=max' and improve performance

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -124,7 +124,7 @@ defmodule Ejabberd.MixProject do
      {:pkix, "~> 1.0"},
      {:stringprep, ">= 1.0.26"},
      {:stun, "~> 1.0"},
-     {:xmpp, "~> 1.5"},
+     {:xmpp, git: "https://github.com/processone/xmpp", ref: "e943c0285aa85e3cbd4bfb9259f6b7de32b00395", override: true},
      {:yconf, "~> 1.0"}]
     ++ cond_deps()
   end

--- a/rebar.config
+++ b/rebar.config
@@ -59,7 +59,7 @@
         {stringprep, ".*", {git, "https://github.com/processone/stringprep", {tag, "1.0.27"}}},
         {if_var_true, stun,
          {stun, ".*", {git, "https://github.com/processone/stun", {tag, "1.0.44"}}}},
-        {xmpp, ".*", {git, "https://github.com/processone/xmpp", {tag, "1.5.4"}}},
+        {xmpp, ".*", {git, "https://github.com/processone/xmpp", "e943c0285aa85e3cbd4bfb9259f6b7de32b00395"}},
         {yconf, ".*", {git, "https://github.com/processone/yconf", {tag, "1.0.12"}}}
        ]}.
 

--- a/src/gen_pubsub_node.erl
+++ b/src/gen_pubsub_node.erl
@@ -123,6 +123,11 @@
     {error, stanza_error()}.
 
 -callback remove_extra_items(NodeIdx :: nodeIdx(),
+	Max_Items :: unlimited | non_neg_integer()) ->
+    {result, {[itemId()], [itemId()]}
+	}.
+
+-callback remove_extra_items(NodeIdx :: nodeIdx(),
 	Max_Items :: unlimited | non_neg_integer(),
 	ItemIds :: [itemId()]) ->
     {result, {[itemId()], [itemId()]}

--- a/src/gen_pubsub_nodetree.erl
+++ b/src/gen_pubsub_nodetree.erl
@@ -67,6 +67,9 @@
 -callback get_nodes(Host :: host())->
     [pubsubNode()].
 
+-callback get_all_nodes(Host :: host()) ->
+    [pubsubNode()].
+
 -callback get_parentnodes(Host :: host(),
 	NodeId :: nodeId(),
 	From :: jid:jid()) ->

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -210,7 +210,7 @@
 	pep_mapping             :: [{binary(), binary()}],
 	ignore_pep_from_offline :: boolean(),
 	last_item_cache         :: boolean(),
-	max_items_node          :: non_neg_integer(),
+	max_items_node          :: non_neg_integer()|unlimited,
 	max_subscriptions_node  :: non_neg_integer()|undefined,
 	default_node_config     :: [{atom(), binary()|boolean()|integer()|atom()}],
 	nodetree                :: binary(),
@@ -3399,7 +3399,7 @@ node_config(_, _, []) ->
 %% @doc <p>Return the maximum number of items for a given node.</p>
 %% <p>Unlimited means that there is no limit in the number of items that can
 %% be stored.</p>
--spec max_items(host(), [{atom(), any()}]) -> non_neg_integer().
+-spec max_items(host(), [{atom(), any()}]) -> non_neg_integer() | unlimited.
 max_items(Host, Options) ->
     case get_option(Options, persist_items) of
 	true ->
@@ -3549,8 +3549,10 @@ decode_get_pending(#xdata{fields = Fs}, Lang) ->
     end.
 
 -spec check_opt_range(atom(), [proplists:property()],
-		      non_neg_integer() | undefined) -> boolean().
+		      non_neg_integer() | unlimited | undefined) -> boolean().
 check_opt_range(_Opt, _Opts, undefined) ->
+    true;
+check_opt_range(_Opt, _Opts, unlimited) ->
     true;
 check_opt_range(Opt, Opts, Max) ->
     case proplists:get_value(Opt, Opts, Max) of
@@ -3558,7 +3560,7 @@ check_opt_range(Opt, Opts, Max) ->
 	Val -> Val =< Max
     end.
 
--spec get_max_items_node(host()) -> undefined | non_neg_integer().
+-spec get_max_items_node(host()) -> undefined | unlimited | non_neg_integer().
 get_max_items_node(Host) ->
     config(Host, max_items_node, undefined).
 
@@ -4150,7 +4152,7 @@ mod_opt_type(ignore_pep_from_offline) ->
 mod_opt_type(last_item_cache) ->
     econf:bool();
 mod_opt_type(max_items_node) ->
-    econf:non_neg_int();
+    econf:non_neg_int(unlimited);
 mod_opt_type(max_nodes_discoitems) ->
     econf:non_neg_int(infinity);
 mod_opt_type(max_subscriptions_node) ->
@@ -4277,7 +4279,7 @@ mod_doc() ->
 		     "and allows to raise user connection rate. The cost "
 		     "is memory usage, as every item is stored in memory.")}},
 	   {max_items_node,
-	    #{value => "MaxItems",
+	    #{value => "non_neg_integer() | infinity",
 	      desc =>
 		  ?T("Define the maximum number of items that can be "
 		     "stored in a node. Default value is: '10'.")}},

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -3553,8 +3553,10 @@ decode_get_pending(#xdata{fields = Fs}, Lang) ->
 check_opt_range(_Opt, _Opts, undefined) ->
     true;
 check_opt_range(Opt, Opts, Max) ->
-    Val = proplists:get_value(Opt, Opts, Max),
-    Val =< Max.
+    case proplists:get_value(Opt, Opts, Max) of
+	max -> true;
+	Val -> Val =< Max
+    end.
 
 -spec get_max_items_node(host()) -> undefined | non_neg_integer().
 get_max_items_node(Host) ->
@@ -3708,6 +3710,7 @@ features() ->
      <<"access-whitelist">>,   % OPTIONAL
      <<"collections">>,   % RECOMMENDED
      <<"config-node">>,   % RECOMMENDED
+     <<"config-node-max">>,
      <<"create-and-configure">>,   % RECOMMENDED
      <<"item-ids">>,   % RECOMMENDED
      <<"last-published">>,   % RECOMMENDED

--- a/src/node_flat.erl
+++ b/src/node_flat.erl
@@ -375,7 +375,8 @@ publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload,
 		    or (Subscribed == true)) ->
 	    {error, xmpp:err_forbidden()};
 	true ->
-	    if MaxItems > 0 ->
+	    if MaxItems > 0;
+	       MaxItems == unlimited ->
 		    Now = erlang:timestamp(),
 		    case get_item(Nidx, ItemId) of
 			{result, #pubsub_item{creation = {_, GenKey}} = OldItem} ->

--- a/src/node_flat.erl
+++ b/src/node_flat.erl
@@ -39,7 +39,8 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/7, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4,
+    remove_extra_items/2, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -402,6 +403,16 @@ publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload,
 		    {result, {default, broadcast, []}}
 	    end
     end.
+
+remove_extra_items(Nidx, MaxItems) ->
+    {result, States} = get_states(Nidx),
+    Records = States ++ mnesia:read({pubsub_orphan, Nidx}),
+    ItemIds = lists:flatmap(fun(#pubsub_state{items = Is}) ->
+				    Is;
+			       (#pubsub_orphan{items = Is}) ->
+				    Is
+			    end, Records),
+    remove_extra_items(Nidx, MaxItems, ItemIds).
 
 %% @doc <p>This function is used to remove extra items, most notably when the
 %% maximum number of items has been reached.</p>

--- a/src/node_flat_sql.erl
+++ b/src/node_flat_sql.erl
@@ -247,7 +247,8 @@ publish_item(Nidx, Publisher, PublishModel, MaxItems, ItemId, Payload,
 		    or (Subscribed == true)) ->
 	    {error, xmpp:err_forbidden()};
 	true ->
-	    if MaxItems > 0 ->
+	    if MaxItems > 0;
+	       MaxItems == unlimited ->
 		    Now = erlang:timestamp(),
 		    case get_item(Nidx, ItemId) of
 			{result, #pubsub_item{creation = {_, GenKey}} = OldItem} ->

--- a/src/node_pep.erl
+++ b/src/node_pep.erl
@@ -35,7 +35,8 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/7, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4,
+    remove_extra_items/2, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -134,6 +135,9 @@ unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
 publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
     node_flat:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
 	Payload, PubOpts).
+
+remove_extra_items(Nidx, MaxItems) ->
+    node_flat:remove_extra_items(Nidx, MaxItems).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/node_pep_sql.erl
+++ b/src/node_pep_sql.erl
@@ -37,7 +37,8 @@
 -export([init/3, terminate/2, options/0, features/0,
     create_node_permission/6, create_node/2, delete_node/1,
     purge_node/2, subscribe_node/8, unsubscribe_node/4,
-    publish_item/7, delete_item/4, remove_extra_items/3,
+    publish_item/7, delete_item/4,
+    remove_extra_items/2, remove_extra_items/3,
     get_entity_affiliations/2, get_node_affiliations/1,
     get_affiliation/2, set_affiliation/3,
     get_entity_subscriptions/2, get_node_subscriptions/1,
@@ -91,6 +92,9 @@ unsubscribe_node(Nidx, Sender, Subscriber, SubId) ->
 publish_item(Nidx, Publisher, Model, MaxItems, ItemId, Payload, PubOpts) ->
     node_flat_sql:publish_item(Nidx, Publisher, Model, MaxItems, ItemId,
 	Payload, PubOpts).
+
+remove_extra_items(Nidx, MaxItems) ->
+    node_flat_sql:remove_extra_items(Nidx, MaxItems).
 
 remove_extra_items(Nidx, MaxItems, ItemIds) ->
     node_flat_sql:remove_extra_items(Nidx, MaxItems, ItemIds).

--- a/src/nodetree_tree.erl
+++ b/src/nodetree_tree.erl
@@ -46,7 +46,8 @@
 
 -export([init/3, terminate/2, options/0, set_node/1,
     get_node/3, get_node/2, get_node/1, get_nodes/2,
-    get_nodes/1, get_parentnodes/3, get_parentnodes_tree/3,
+    get_nodes/1, get_all_nodes/1,
+    get_parentnodes/3, get_parentnodes_tree/3,
     get_subnodes/3, get_subnodes_tree/3, create_node/6,
     delete_node/2]).
 
@@ -97,6 +98,14 @@ get_nodes(Host, Limit) ->
 	'$end_of_table' -> [];
 	{Nodes, _} -> Nodes
     end.
+
+get_all_nodes({_U, _S, _R} = Owner) ->
+    Host = jid:tolower(jid:remove_resource(Owner)),
+    mnesia:match_object(#pubsub_node{nodeid = {Host, '_'}, _ = '_'});
+get_all_nodes(Host) ->
+    mnesia:match_object(#pubsub_node{nodeid = {Host, '_'}, _ = '_'})
+	++ mnesia:match_object(#pubsub_node{nodeid = {{'_', Host, '_'}, '_'},
+					    _ = '_'}).
 
 get_parentnodes(Host, Node, _From) ->
     case catch mnesia:read({pubsub_node, {Host, Node}}) of

--- a/src/nodetree_virtual.erl
+++ b/src/nodetree_virtual.erl
@@ -38,7 +38,8 @@
 
 -export([init/3, terminate/2, options/0, set_node/1,
     get_node/3, get_node/2, get_node/1, get_nodes/2,
-    get_nodes/1, get_parentnodes/3, get_parentnodes_tree/3,
+    get_nodes/1, get_all_nodes/1,
+    get_parentnodes/3, get_parentnodes_tree/3,
     get_subnodes/3, get_subnodes_tree/3, create_node/6,
     delete_node/2]).
 
@@ -69,6 +70,9 @@ get_nodes(Host) ->
     get_nodes(Host, infinity).
 
 get_nodes(_Host, _Limit) ->
+    [].
+
+get_all_nodes(_Host) ->
     [].
 
 get_parentnodes(_Host, _Node, _From) ->


### PR DESCRIPTION
Let PubSub clients request the maximum limit for the node configuration option `max_items` by specifying the special value `max` instead of an integer. This was added to [XEP-0060][1], revision 1.17.0, and clarified in revision 1.20.0. The feature is highly useful for proper multi-item PubSub support, as required by modern extensions such as [PEP Native Bookmarks][2]. It depends on the [current `xmpp` code][3].

Based on that feature, support PubSub nodes without `max_items` limit. This allows for avoiding an SQL query which can be very expensive if the node has a large number of items.

Also, add a `delete_old_pubsub_items` command which can be especially useful for nodes without `max_items` limit.

Thanks to [Ammonit Measurement GmbH][4] for sponsoring this work.

[1]: https://xmpp.org/extensions/xep-0060.html
[2]: https://xmpp.org/extensions/xep-0402.html
[3]: https://github.com/processone/xmpp/commit/e943c0285aa85e3cbd4bfb9259f6b7de32b00395
[4]: https://www.ammonit.com