### PR TITLE
Changed default outgoing_s2s_families to IPv6 

### DIFF
--- a/man/ejabberd.yml.5
+++ b/man/ejabberd.yml.5
@@ -1208,6 +1208,8 @@ percents\&.
 Specify which address families to try, in what order\&. The default is
 \fI[ipv6, ipv4]\fR
 which means it first tries connecting with IPv6, if that fails it tries using IPv4\&.
+.PP
+NOTE: This option is obsolete and irrelevant when using ejabberd 23.xx and Erlang/OTP 22, or newer versions of them.
 .RE
 .sp
 \fINote\fR about the next option: added in 20\&.12:

--- a/man/ejabberd.yml.5
+++ b/man/ejabberd.yml.5
@@ -1203,11 +1203,11 @@ option)\&. Later, when memory drops below this
 percents\&.
 .RE
 .PP
-\fBoutgoing_s2s_families\fR: \fI[ipv4 | ipv6, \&.\&.\&.]\fR
+\fBoutgoing_s2s_families\fR: \fI[ipv6 | ipv4, \&.\&.\&.]\fR
 .RS 4
 Specify which address families to try, in what order\&. The default is
-\fI[ipv4, ipv6]\fR
-which means it first tries connecting with IPv4, if that fails it tries using IPv6\&.
+\fI[ipv6, ipv4]\fR
+which means it first tries connecting with IPv6, if that fails it tries using IPv4\&.
 .RE
 .sp
 \fINote\fR about the next option: added in 20\&.12:

--- a/src/ejabberd_options.erl
+++ b/src/ejabberd_options.erl
@@ -614,7 +614,7 @@ options() ->
      {oom_killer, true},
      {oom_queue, 10000},
      {oom_watermark, 80},
-     {outgoing_s2s_families, [inet, inet6]},
+     {outgoing_s2s_families, [inet6, inet]},
      {outgoing_s2s_ipv4_address, undefined},
      {outgoing_s2s_ipv6_address, undefined},
      {outgoing_s2s_port, 5269},

--- a/src/ejabberd_options_doc.erl
+++ b/src/ejabberd_options_doc.erl
@@ -969,7 +969,9 @@ doc() ->
         desc =>
             ?T("Specify which address families to try, in what order. "
                "The default is '[ipv4, ipv6]' which means it first tries "
-               "connecting with IPv4, if that fails it tries using IPv6.")}},
+               "connecting with IPv4, if that fails it tries using IPv6."
+               "This option is obsolete and irrelevant when using ejabberd 23.xx "
+               "and Erlang/OTP 22, or newer versions of them.")}},
      {outgoing_s2s_ipv4_address,
       #{value => "Address",
         note => "added in 20.12",


### PR DESCRIPTION
Servers are within datacenters where IPv6 is more commonly enabled (contrary to clients), and if it's not present - it'll just fall back to IPv4.