### PR TITLE
Remove CTLLOCKDIR (/var/lock/ejabberdctl) from Makefile.in

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -68,9 +68,6 @@ LUADIR = $(PRIVDIR)/lua
 # /var/lib/ejabberd/
 SPOOLDIR = $(DESTDIR)@localstatedir@/lib/ejabberd
 
-# /var/lock/ejabberdctl
-CTLLOCKDIR = $(DESTDIR)@localstatedir@/lock/ejabberdctl
-
 # /var/log/ejabberd/
 LOGDIR = $(DESTDIR)@localstatedir@/log/ejabberd
 
@@ -313,11 +310,6 @@ install: copy-files
 	$(CHOWN_COMMAND) -R @INSTALLUSER@ $(SPOOLDIR) >$(CHOWN_OUTPUT)
 	chmod -R 750 $(SPOOLDIR)
 	#
-	# ejabberdctl lock directory
-	$(INSTALL) -d -m 750 $(O_USER) $(CTLLOCKDIR)
-	$(CHOWN_COMMAND) -R @INSTALLUSER@ $(CTLLOCKDIR) >$(CHOWN_OUTPUT)
-	chmod -R 750 $(CTLLOCKDIR)
-	#
 	# Log directory
 	$(INSTALL) -d -m 750 $(O_USER) $(LOGDIR)
 	$(CHOWN_COMMAND) -R @INSTALLUSER@ $(LOGDIR) >$(CHOWN_OUTPUT)
@@ -366,7 +358,6 @@ uninstall-all: uninstall-binary
 	rm -rf $(ETCDIR)
 	rm -rf $(EJABBERDDIR)
 	rm -rf $(SPOOLDIR)
-	rm -rf $(CTLLOCKDIR)
 	rm -rf $(LOGDIR)
 
 clean:

--- a/rebar.config
+++ b/rebar.config
@@ -180,7 +180,6 @@
         {overlay_vars, "vars.config"},
         {extended_start_script, true},
         {overlay, [{mkdir, "var/log/ejabberd"},
-                   {mkdir, "var/lock"},
                    {mkdir, "var/lib/ejabberd"},
                    {mkdir, "etc/ejabberd"},
                    {copy, "rel/files/erl", "\{\{erts_vsn\}\}/bin/erl"}, % in rebar2 this prepends erts-

--- a/rel/reltool.config.script
+++ b/rel/reltool.config.script
@@ -89,7 +89,6 @@ Sys = [{lib_dirs, []},
 
 Overlay = [
            {mkdir, "var/log/ejabberd"},
-           {mkdir, "var/lock"},
            {mkdir, "var/lib/ejabberd"},
            {mkdir, "etc/ejabberd"},
            {mkdir, "doc"},


### PR DESCRIPTION
Flock'ing /var/lock/ejabberdctl by ejabberdctl was removed with
f7d4aae64db8 ("Use UUID for ctl node name (#1021)"), however the
according recipies in the Makefile where never removed. This commit
does that.