### PR TITLE
Update rebar3 command for `make update`

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -115,7 +115,7 @@ else
 ifeq "$(REBAR_VER)" "3"
   SKIPDEPS=
   LISTDEPS=tree
-  UPDATEDEPS=upgrade
+  UPDATEDEPS=upgrade --all
   DEPSPATTERN="s/ (.*//; /^ / s/.* \([a-z0-9_]*\).*/\1/p;"
   DEPSBASE=_build
   DEPSDIR=$(DEPSBASE)/default/lib


### PR DESCRIPTION
Since https://github.com/erlang/rebar3/commit/8426b2e9d5335265bbad6426ae8399f4a59bb581 rebar3 needs `--all` for `upgrade`

Else it errors out with: `===> Specify a list of dependencies to upgrade, or --all to upgrade them all`

/LE: fix commit link