### PR TITLE
Sync old-to-new schema script with reality

### DIFF
--- a/sql/pg.new.sql
+++ b/sql/pg.new.sql
@@ -161,6 +161,24 @@
 -- DROP INDEX i_push_ut;
 -- ALTER TABLE push_session ADD PRIMARY KEY (server_host, username, timestamp);
 -- CREATE UNIQUE INDEX i_push_session_susn ON push_session USING btree (server_host, username, service, node);
+-- ALTER TABLE push_session ALTER COLUMN server_host DROP DEFAULT;
+
+-- ALTER TABLE mix_pam ADD COLUMN server_host text NOT NULL DEFAULT '<HOST>';
+-- DROP INDEX i_mix_pam;
+-- DROP INDEX i_mix_pam_us;
+-- CREATE UNIQUE INDEX i_mix_pam ON mix_pam (username, server_host, channel, service);
+-- CREATE INDEX i_mix_pam_us ON mix_pam (username, server_host);
+-- ALTER TABLE mix_pam ALTER COLUMN server_host DROP DEFAULT;
+
+-- ALTER TABLE route ADD COLUMN server_host text NOT NULL DEFAULT '<HOST>';
+-- DROP INDEX i_route;
+-- CREATE UNIQUE INDEX i_route ON route USING btree (domain, server_host, node, pid);
+-- ALTER TABLE i_route ALTER COLUMN server_host DROP DEFAULT;
+
+-- ALTER TABLE mqtt_pub ADD COLUMN server_host text NOT NULL DEFAULT '<HOST>';
+-- DROP INDEX i_mqtt_topic;
+-- CREATE UNIQUE INDEX i_mqtt_topic_server ON mqtt_pub (topic, server_host);
+-- ALTER TABLE mqtt_pub ALTER COLUMN server_host DROP DEFAULT;
 
 
 CREATE TABLE users (

--- a/src/mod_admin_update_sql.erl
+++ b/src/mod_admin_update_sql.erl
@@ -164,10 +164,12 @@ update_tables(State) ->
     drop_index(State, "i_timestamp"),
     drop_index(State, "i_peer"),
     drop_index(State, "i_bare_peer"),
+    drop_index(State, "i_username_peer"),
+    drop_index(State, "i_username_bare_peer"),
     create_index(State, "archive", "i_archive_sh_username_timestamp", ["server_host", "username", "timestamp"]),
     create_index(State, "archive", "i_archive_sh_timestamp", ["server_host", "timestamp"]),
-    create_index(State, "archive", "i_archive_sh_peer", ["server_host", "peer"]),
-    create_index(State, "archive", "i_archive_sh_bare_peer", ["server_host", "bare_peer"]),
+    create_index(State, "archive", "i_archive_sh_username_peer", ["server_host", "username", "peer"]),
+    create_index(State, "archive", "i_archive_sh_username_bare_peer", ["server_host", "username", "bare_peer"]),
     drop_sh_default(State, "archive"),
 
     add_sh_column(State, "archive_prefs"),
@@ -255,19 +257,29 @@ update_tables(State) ->
     create_index(State, "sm", "i_sm_sh_username", ["server_host", "username"]),
     drop_sh_default(State, "sm"),
 
-    add_sh_column(State, "carboncopy"),
-    drop_index(State, "i_carboncopy_ur"),
-    drop_index(State, "i_carboncopy_user"),
-    add_pkey(State, "carboncopy", ["server_host", "username", "resource"]),
-    create_index(State, "carboncopy", "i_carboncopy_sh_user", ["server_host", "username"]),
-    drop_sh_default(State, "carboncopy"),
-
     add_sh_column(State, "push_session"),
     drop_index(State, "i_push_usn"),
     drop_index(State, "i_push_ut"),
     add_pkey(State, "push_session", ["server_host", "username", "timestamp"]),
-    create_index(State, "push_session", "i_push_session_susn", ["server_host", "username", "service", "node"]),
+    create_unique_index(State, "push_session", "i_push_session_susn", ["server_host", "username", "service", "node"]),
     drop_sh_default(State, "push_session"),
+
+    add_sh_column(State, "mix_pam"),
+    drop_index(State, "i_mix_pam"),
+    drop_index(State, "i_mix_pam_us"),
+    create_unique_index(State, "mix_pam", "i_mix_pam", ["username", "server_host", "channel", "service"]),
+    create_index(State, "mix_pam", "i_mix_pam_us", ["username", "server_host"]),
+    drop_sh_default(State, "mix_pam"),
+
+    add_sh_column(State, "route"),
+    drop_index(State, "i_route"),
+    create_unique_index(State, "route", "i_route", ["domain", "server_host", "node", "pid"]),
+    drop_sh_default(State, "route"),
+
+    add_sh_column(State, "mqtt_pub"),
+    drop_index(State, "i_mqtt_topic"),
+    create_unique_index(State, "mqtt_pub", "i_mqtt_topic_server", ["topic", "server_host"]),
+    drop_sh_default(State, "mqtt_pub"),
 
     ok.
 


### PR DESCRIPTION
Update the update_sql function to match current "new" sql schema

"XRevan86" pointed out in [ejabberd@conference.process-one.net](xmpp:ejabberd@conference.process-one.net) that i_push_session_susn should have been created as a unique index, and on closer inspection there are a number of other discrepancies between the update function and the actual schema

Users who have previously updated from old to new schema using this function would need to manually perform the following to correct their schema:

```
ALTER TABLE archive DROP CONSTRAINT i_archive_sh_peer;
ALTER TABLE archive DROP CONSTRAINT i_archive_sh_bare_peer;
CREATE INDEX i_archive_sh_username_peer ON archive USING btree (server_host, username, peer);
CREATE INDEX i_archive_sh_username_bare_peer ON archive USING btree (server_host, username, bare_peer);

DROP TABLE carboncopy;

ALTER TABLE push_session DROP CONSTRAINT i_push_session_susn;
CREATE UNIQUE INDEX i_push_session_susn ON push_session USING btree (server_host, username, service, node);

ALTER TABLE mix_pam DROP CONSTRAINT i_mix_pam;
ALTER TABLE mix_pam DROP CONSTRAINT i_mix_pam_us;
CREATE UNIQUE INDEX i_mix_pam ON mix_pam (username, server_host, channel, service);
CREATE INDEX i_mix_pam_us ON mix_pam (username, server_host);

ALTER TABLE route DROP CONSTRAINT i_route;
CREATE UNIQUE INDEX i_route ON route USING btree (domain, server_host, node, pid);

ALTER TABLE mqtt_pub DROP CONSTRAINT i_mqtt_topic;
CREATE UNIQUE INDEX i_mqtt_topic_server ON mqtt_pub (topic, server_host);
```