### PR TITLE
Checking users is active in SM for JWT authenticated user

### DIFF
--- a/src/ejabberd_auth_jwt.erl
+++ b/src/ejabberd_auth_jwt.erl
@@ -85,7 +85,14 @@ check_password(User, AuthzId, Server, Token) ->
             end
     end.
 
-user_exists(_User, _Host) -> {nocache, false}.
+user_exists(User, Host) ->
+  %% Checking that the user has an active session
+  %% If the session was negociated by the JWT auth method then we define that the user exists
+  %% Any other cases will return that the user doesn't exist
+  {nocache, case ejabberd_sm:get_user_info(User, Host) of
+              [{_, Info}] -> proplists:get_value(auth_module, Info) == ejabberd_auth_jwt;
+              _ -> false
+            end}.
 
 use_cache(_) ->
     false.


### PR DESCRIPTION
This PR aims to fix #3537 by checking if the requested user has an active session.

To define if the user is active I call the `ejabberd_sm` module to `get_user_info` and then I check if the `auth_module` was the `jwt` one. If it is it means that the user is authenticated and virtually exists.

Another option was to create a persisted point to store every users that are connecting with JWT.

The down side of this update is that a user which is connected at a time with JWT can be define as existing but when he disconnects he can't be targetted for any offline features, which for me is fine but it needs to be discuss or define in documentation.

I would like to have inputs on potential performance issue or anything else related to it.

Thanks for reading !

Signed-off-by: Freyskeyd <simon.paitrault@gmail.com>