### PR TITLE
Improve binary installers

### DIFF
--- a/tools/make-installers
+++ b/tools/make-installers
@@ -68,10 +68,12 @@ code_path="/opt/$rel_name-$rel_vsn"
 data_path="/opt/$rel_name"
 conf_path="$data_path/conf"
 pem_file="$conf_path/server.pem"
-url='https://docs.ejabberd.im/admin/upgrade/#specific-version-upgrade-notes'
-url_doc_admin='https://docs.ejabberd.im/admin/installation/#administration-account'
+uninstall_file="$code_path/uninstall.txt"
+home_url='https://www.ejabberd.im'
+doc_url='https://docs.ejabberd.im'
+upgrade_url="$doc_url/admin/upgrade/#specific-version-upgrade-notes"
+admin_url="$doc_url/admin/installation/#administration-account"
 tmp_dir=$(mktemp -d "/tmp/.$rel_name.XXXXXX")
-path_uninstall="$code_path/uninstall.txt"
 
 trap 'rm -rf "$tmp_dir"' INT TERM EXIT
 umask 022
@@ -82,13 +84,13 @@ create_help_file()
 
 	cat >"$file" <<-EOF
 	This is the $rel_name $rel_vsn-$iteration installer for linux-$arch
-
-	Visit
-	  https://www.ejabberd.im/
-
-	ejabberd Documentation site:
-	  https://docs.ejabberd.im/
-        
+	
+	Visit:
+	  $home_url
+	
+	ejabberd documentation site:
+	  $doc_url
+	
 	EOF
 }
 
@@ -210,22 +212,23 @@ create_setup_script()
 	echo '$rel_name $rel_vsn has been installed successfully.'
 	echo
 
-	echo >$path_uninstall
-	echo '# To uninstall ejabberd, first remove the service:' >>$path_uninstall
-	echo 'systemctl --now disable ejabberd' >>$path_uninstall
-	echo 'rm -rf /etc/systemd/system/ejabberd.service' >>$path_uninstall
-	echo >>$path_uninstall
-	echo '# Remove the binary files' >>$path_uninstall
-	echo 'rm -rf /opt/ejabberd-*' >>$path_uninstall
-	echo >>$path_uninstall
-	echo '# If you want to remove your config, database and logs:' >>$path_uninstall
-	echo 'rm -rf /opt/ejabberd' >>$path_uninstall
+	cat >'$uninstall_file' <<_EOF
+	# To uninstall ejabberd, first remove the service. If you're using systemd:
+	systemctl --now disable ejabberd
+	rm -f /etc/systemd/system/ejabberd.service
+	
+	# Remove the binary files:
+	rm -rf /opt/ejabberd-*
+	
+	# If you want to remove your configuration, database and logs:
+	rm -rf /opt/ejabberd
+	_EOF
 
 	if [ \$is_upgrade = true ]
 	then
 		echo 'Please check the following web site for upgrade notes:'
 		echo
-		echo '$url'
+		echo '$upgrade_url'
 		echo
 		echo 'If everything looks fine, restart the $rel_name service:'
 		echo '  systemctl restart ejabberd'
@@ -233,9 +236,10 @@ create_setup_script()
 		echo 'Now you can check ejabberd is running correctly:'
 		echo '  systemctl status ejabberd'
 		echo
-		echo 'Next you may want to edit ejabberd.yml to setup hosts,'
+		echo 'Next you may want to edit ejabberd.yml to set up hosts,'
 		echo 'register an account and grant it admin rigts, see:'
-		echo '$url_doc_admin'
+		echo
+		echo '$admin_url'
 	fi
 	EOF
 	chmod +x "$dir/setup"
@@ -252,7 +256,8 @@ do
 	gzip -c -d <"$tgz_name" >"$tmp_dir/$tar_name"
         create_help_file "$tmp_dir/help.txt"
 	create_setup_script "$tmp_dir" "$tar_name"
-	"$makeself" --help-header "$tmp_dir/help.txt" "$tmp_dir" "$installer_name" "$rel_name $rel_vsn" './setup'
+	"$makeself" --help-header "$tmp_dir/help.txt" \
+	    "$tmp_dir" "$installer_name" "$rel_name $rel_vsn" './setup'
 	find "$tmp_dir" -mindepth 1 -delete
 done
 echo "$myself: Created installers successfully."

--- a/tools/make-installers
+++ b/tools/make-installers
@@ -97,7 +97,6 @@ create_help_file()
 create_setup_script()
 {
 	local dir="$1"
-	local tarball="$2"
 
 	cat >"$dir/setup" <<-EOF
 	#!/bin/sh
@@ -176,7 +175,9 @@ create_setup_script()
 	then host='localhost'
 	fi
 
-	tar --skip-old-files -C "\$(dirname '$code_path')" -xf '$tarball'
+	(tar -cf - '$rel_name' | tar --skip-old-files -C "\$(dirname '$code_path')" -xpf -)
+	(tar -cf - '$rel_name-$rel_vsn' | tar -C "\$(dirname '$code_path')" -xpf -)
+
 	chown -R -h 'root:root' '$code_path'
 	chown 'root:$rel_name' '$code_path/lib/epam-'*'/priv/bin/epam'
 	chmod '4750' '$code_path/lib/epam-'*'/priv/bin/epam'
@@ -247,15 +248,14 @@ create_setup_script()
 
 for arch in $architectures
 do
-	tar_name="$rel_name-$rel_vsn-linux-$arch.tar"
-	tgz_name="$tar_name.gz"
+	tar_name="$rel_name-$rel_vsn-linux-$arch.tar.gz"
 	installer_name="$rel_name-$rel_vsn-$iteration-linux-$arch.run"
 
-	test -e "$tgz_name" || tools/make-binaries
+	test -e "$tar_name" || tools/make-binaries
 	echo "$myself: Putting together installer for $arch ..."
-	gzip -c -d <"$tgz_name" >"$tmp_dir/$tar_name"
+	tar -xzpf "$tar_name"
         create_help_file "$tmp_dir/help.txt"
-	create_setup_script "$tmp_dir" "$tar_name"
+	create_setup_script "$tmp_dir"
 	"$makeself" --help-header "$tmp_dir/help.txt" \
 	    "$tmp_dir" "$installer_name" "$rel_name $rel_vsn" './setup'
 	find "$tmp_dir" -mindepth 1 -delete

--- a/tools/make-installers
+++ b/tools/make-installers
@@ -64,15 +64,12 @@ fi
 
 rel_name='ejabberd'
 rel_vsn=$(git describe --tags | sed -e 's/-g.*//' -e 's/-/./' | tr -d '[:space:]')
-code_path="/opt/$rel_name-$rel_vsn"
-data_path="/opt/$rel_name"
-conf_path="$data_path/conf"
-pem_file="$conf_path/server.pem"
-uninstall_file="$code_path/uninstall.txt"
 home_url='https://www.ejabberd.im'
 doc_url='https://docs.ejabberd.im'
 upgrade_url="$doc_url/admin/upgrade/#specific-version-upgrade-notes"
 admin_url="$doc_url/admin/installation/#administration-account"
+default_code_dir="/opt/$rel_name-$rel_vsn"
+default_data_dir="/opt/$rel_name"
 tmp_dir=$(mktemp -d "/tmp/.$rel_name.XXXXXX")
 
 trap 'rm -rf "$tmp_dir"' INT TERM EXIT
@@ -113,51 +110,101 @@ create_setup_script()
 		if [ -t 0 ]
 		then
 			read -p "\$question (y/n) [n] " response
-			response="\$(printf '%s' "\$response" |
-			             tr '[:upper:]' '[:lower:]')"
-			if [ "\$response" = 'y' ] || [ "\$response" = 'yes' ]
-			then return 0
-			else return 1
-			fi
+			case "\$response" in
+			[Yy]|[Yy][Ee][Ss])
+				return 0
+				;;
+			[Nn]|[Nn][Oo]|'')
+				return 1
+				;;
+			*)
+				echo 'Please respond with "yes" or "no".'
+				user_agrees "\$question"
+				;;
+			esac
 		else # Assume 'yes' if not running interactively.
 			return 0
 		fi
 	}
 
-	if [ \$(id -u) != 0 ]
+	if [ \$(id -u) = 0 ]
 	then
-		echo >&2 'The installer must be run with superuser privileges.'
-		exit 1
+		is_superuser=true
+	else
+		is_superuser=false
+		echo "Running without superuser privileges (installer wasn't invoked"
+		echo 'with "sudo"), cannot perform system-wide installation this way.'
+		if ! user_agrees 'Continue anyway?'
+		then
+			echo 'Aborting installation.'
+			exit 1
+		fi
 	fi
+
+	if [ \$is_superuser = true ]
+	then
+		code_dir='$default_code_dir'
+		data_dir='$default_data_dir'
+		user_name='$rel_name'
+		group_name='$rel_name'
+	elif user_agrees "Install $rel_name below \$HOME/opt?"
+	then
+		code_dir="\$HOME/opt/$rel_name-$rel_vsn"
+		data_dir="\$HOME/opt/$rel_name"
+		user_name="\$(id -u -n)"
+		group_name="\$(id -g -n)"
+	else
+		read -p 'Installation prefix: ' prefix
+		if printf '%s' "\$prefix" | grep -q '^/'
+		then
+			code_dir="\$prefix/$rel_name-$rel_vsn"
+			data_dir="\$prefix/$rel_name"
+			user_name="\$(id -u -n)"
+			group_name="\$(id -g -n)"
+		else
+			echo >&2 'Prefix must be specified as an absolute path.'
+			echo >&2 'Aborting installation.'
+			exit 1
+		fi
+	fi
+
+	prefix="\$(dirname "\$code_dir")"
+	conf_dir="\$data_dir/conf"
+	pem_file="\$conf_dir/server.pem"
+	uninstall_file="\$code_dir/uninstall.txt"
 
 	if [ -e '/run/systemd/system' ]
 	then is_systemd=true
 	else is_systemd=false
 	fi
-	if [ -e '$data_path' ]
+	if [ -e "\$data_dir" ]
 	then is_upgrade=true
 	else is_upgrade=false
 	fi
-	if id -u '$rel_name' >'/dev/null' 2>&1
+	if id -u "\$user_name" >'/dev/null' 2>&1
 	then user_exists=true
 	else user_exists=false
 	fi
 
 	echo
 	echo 'The following installation paths will be used:'
-	echo '- $code_path'
+	echo "- \$code_dir"
 	if [ \$is_upgrade = true ]
-	then echo "- $data_path (existing files won't be modified)"
-	else echo '- $data_path'
+	then echo "- \$data_dir (existing files won't be modified)"
+	else echo "- \$data_dir (for configuration, database, and log files)"
 	fi
-	if [ \$is_systemd = true ]
-	then echo '- /etc/systemd/system/$rel_name.service'
-	fi
-	if [ \$user_exists = false ]
-	then echo 'The $rel_name user is going to be created.'
-	fi
-	if [ \$is_systemd = true ] && [ \$is_upgrade = false ]
-	then echo 'The $rel_name service is going to be enabled and started.'
+	if [ \$is_superuser = true ]
+	then
+		if [ \$is_systemd = true ]
+		then
+			echo '- /etc/systemd/system/$rel_name.service'
+			if [ \$is_upgrade = false ]
+			then echo 'The $rel_name service is going to be enabled and started.'
+			fi
+		fi
+		if [ \$user_exists = false ]
+		then echo 'The $rel_name user is going to be created.'
+		fi
 	fi
 	if ! user_agrees 'Install $rel_name $rel_vsn now?'
 	then
@@ -166,8 +213,8 @@ create_setup_script()
 	fi
 	echo
 
-	if [ \$user_exists = false ]
-	then useradd -r -d '$data_path' '$rel_name'
+	if [ \$user_exists = false ] && [ \$is_superuser = true ]
+	then useradd -r -d "\$data_dir" "\$user_name"
 	fi
 
 	host=\$(hostname --fqdn 2>'/dev/null' || :)
@@ -175,72 +222,131 @@ create_setup_script()
 	then host='localhost'
 	fi
 
-	(tar -cf - '$rel_name' | tar --skip-old-files -C "\$(dirname '$code_path')" -xpf -)
-	(tar -cf - '$rel_name-$rel_vsn' | tar -C "\$(dirname '$code_path')" -xpf -)
+	mkdir -p "\$prefix"
+	tar -cf - '$rel_name' | tar --skip-old-files -C "\$prefix" -xf -
+	tar -cf - '$rel_name-$rel_vsn' | tar -C "\$prefix" -xf -
 
-	chown -R -h 'root:root' '$code_path'
-	chown 'root:$rel_name' '$code_path/lib/epam-'*'/priv/bin/epam'
-	chmod '4750' '$code_path/lib/epam-'*'/priv/bin/epam'
+	if [ \$is_superuser = true ]
+	then
+		if [ \$is_upgrade = false ]
+		then chown -R -h "\$user_name:\$group_name" "\$data_dir"
+		fi
+		chown -R -h "\$(id -u -n):\$group_name" "\$code_dir"
+		chmod -R g+rX "\$code_dir"
+		chmod '4750' "\$code_dir/lib/epam-"*'/priv/bin/epam'
+	else
+		sed -i "s/^INSTALLUSER=.*/INSTALLUSER=\"\$user_name\"/" \
+		    "\$code_dir/bin/${rel_name}ctl"
+		sed -i "s/^USER=.*/USER=\$user_name/" \
+		    "\$code_dir/bin/$rel_name.init"
+		sed -i \
+		    -e "s/^User=.*/User=\$user_name/" \
+		    -e "s/^Group=.*/Group=\$group_name/" \
+		    "\$code_dir/bin/$rel_name.service"
+	fi
+	if [ "\$code_dir" != '$default_code_dir' ]
+	then
+		sed -i "s|$default_code_dir|\$code_dir|g" \
+		    "\$code_dir/bin/${rel_name}ctl" \
+		    "\$code_dir/bin/$rel_name.init" \
+		    "\$code_dir/bin/$rel_name.service"
+	fi
+	if [ "\$data_dir" != '$default_data_dir' ]
+	then
+		sed -i "s|$default_data_dir|\$data_dir|g" \
+		    "\$code_dir/bin/${rel_name}ctl" \
+		    "\$code_dir/bin/$rel_name.init" \
+		    "\$code_dir/bin/$rel_name.service" \
+		    "\$data_dir/conf/$rel_name.yml" \
+		    "\$data_dir/conf/${rel_name}ctl.cfg"
+	fi
+
 	if [ \$is_upgrade = false ]
 	then
-		sed -i "s/ - localhost$/ - \$host/" '$conf_path/$rel_name.yml'
+		sed -i "s/ - localhost$/ - \$host/" "\$conf_dir/$rel_name.yml"
 		openssl req -x509 \
 		            -batch \
 		            -nodes \
 		            -newkey rsa:4096 \
-		            -keyout '$pem_file' \
-		            -out '$pem_file' \
+		            -keyout "\$pem_file" \
+		            -out "\$pem_file" \
 		            -days 3650 \
 		            -subj "/CN=\$host" >'/dev/null' 2>&1 || :
-		if [ -e '$pem_file' ]
-		then chown '$rel_name:$rel_name' '$pem_file'
-		else echo 'Failed to create a TLS certificate for ejabberd.' >&2
+		if ! [ -e "\$pem_file" ]
+		then
+			echo 'Failed to create a TLS certificate for $rel_name.' >&2
+		elif [ \$is_superuser = true ]
+		then
+			chown "\$user_name:\$group_name" "\$pem_file"
 		fi
 	fi
 
-	if [ \$is_systemd = true ]
-	then
-		cp '$code_path/bin/$rel_name.service' '/etc/systemd/system/'
+	case \$is_systemd,\$is_superuser in
+	true,true)
+		cp "\$code_dir/bin/$rel_name.service" '/etc/systemd/system/'
 		systemctl -q daemon-reload
 		if [ \$is_upgrade = false ]
 		then systemctl -q --now enable '$rel_name'
 		fi
-	elif [ \$is_upgrade = false ]
-	then
+		;;
+	true,false)
+		echo 'You might want to install a systemd unit (see the'
+		echo "\$code_dir/bin directory for an example)."
+		;;
+	false,*)
 		echo 'You might want to install an init script (see the'
-		echo '$code_path/bin directory for an example).'
-	fi
+		echo "\$code_dir/bin directory for an example)."
+		;;
+	esac
+
+	echo
 	echo '$rel_name $rel_vsn has been installed successfully.'
 	echo
 
-	cat >'$uninstall_file' <<_EOF
-	# To uninstall ejabberd, first remove the service. If you're using systemd:
-	systemctl --now disable ejabberd
-	rm -f /etc/systemd/system/ejabberd.service
+	cat >"\$uninstall_file" <<-_EOF
+	# To uninstall $rel_name, first remove the service. If you're using systemd:
+	systemctl --now disable $rel_name
+	rm -f /etc/systemd/system/$rel_name.service
 	
 	# Remove the binary files:
-	rm -rf /opt/ejabberd-*
+	rm -rf \$code_dir
 	
 	# If you want to remove your configuration, database and logs:
-	rm -rf /opt/ejabberd
+	rm -rf \$data_dir
 	_EOF
-
-	if [ \$is_upgrade = true ]
+	if [ \$is_superuser = true ]
 	then
+		cat >>"\$uninstall_file" <<-_EOF
+		
+		# To remove the user running $rel_name:
+		userdel \$user_name
+		_EOF
+	fi
+
+	if [ \$is_upgrade = false ]
+	then
+		if [ \$is_systemd = true ] && [ \$is_superuser = true ]
+		then
+			echo 'Now you can check $rel_name is running correctly:'
+			echo '  systemctl status $rel_name'
+			echo
+		fi
+		echo 'Next you may want to edit $rel_name.yml to set up hosts,'
+		echo 'register an account and grant it admin rigts, see:'
+		echo
+		echo '$admin_url'
+	else
 		echo 'Please check the following web site for upgrade notes:'
 		echo
 		echo '$upgrade_url'
 		echo
-		echo 'If everything looks fine, restart the $rel_name service:'
-		echo '  systemctl restart ejabberd'
-	else
-		echo 'Now you can check ejabberd is running correctly:'
-		echo '  systemctl status ejabberd'
-		echo
-		echo 'Next you may want to edit ejabberd.yml to set up hosts,'
-		echo 'register an account and grant it admin rigts, see:'
-		echo
-		echo '$admin_url'
+		if [ \$is_systemd = true ] && [ \$is_superuser = true ]
+		then
+			echo 'If everything looks fine, restart the $rel_name service:'
+			echo '  systemctl restart $rel_name'
+		else
+			echo 'If everything looks fine, restart the $rel_name service.'
+		fi
 	fi
 	EOF
 	chmod +x "$dir/setup"
@@ -253,8 +359,8 @@ do
 
 	test -e "$tar_name" || tools/make-binaries
 	echo "$myself: Putting together installer for $arch ..."
-	tar -xzpf "$tar_name"
-        create_help_file "$tmp_dir/help.txt"
+	tar -C "$tmp_dir" -xzpf "$tar_name"
+	create_help_file "$tmp_dir/help.txt"
 	create_setup_script "$tmp_dir"
 	"$makeself" --help-header "$tmp_dir/help.txt" \
 	    "$tmp_dir" "$installer_name" "$rel_name $rel_vsn" './setup'


### PR DESCRIPTION
- Let the binary installers support non-superuser installations.
- Make sure the binary installers override old files in `/opt/ejabberd-$version` on upgrade.
- While at it, also apply various cosmetic changes.