### PR TITLE
Support ERL_DIST_PORT option to work without epmd

### DIFF
--- a/.github/container/Dockerfile
+++ b/.github/container/Dockerfile
@@ -61,6 +61,9 @@ RUN export PEM=/opt/ejabberd/conf/server.pem \
         \ncertfiles: \
         \n  - /opt/ejabberd/conf/server.pem' "/opt/ejabberd/conf/ejabberd.yml"
 
+RUN sed -i '/^#ERL_DIST_PORT:/a \ \
+        \nERL_DIST_PORT: 5210' "/opt/ejabberd/conf/ejabberdctl.cfg"
+
 FROM alpine:3.15.4
 ENV HOME=/opt/ejabberd
 ARG VERSION=master
@@ -111,7 +114,7 @@ HEALTHCHECK \
 WORKDIR $HOME
 USER ejabberd
 VOLUME ["$HOME/conf", "$HOME/database", "$HOME/logs", "$HOME/upload"]
-EXPOSE 1883 4369-4399 5222 5269 5280 5443
+EXPOSE 1883 5210 5222 5269 5280 5443
 
 ENTRYPOINT ["/usr/local/bin/ejabberdctl"]
 CMD ["foreground"]

--- a/.github/container/ejabberdctl.template
+++ b/.github/container/ejabberdctl.template
@@ -82,6 +82,7 @@ if [ -n "$INET_DIST_INTERFACE" ] ; then
         ERLANG_OPTS="$ERLANG_OPTS -kernel inet_dist_use_interface $INET_DIST_INTERFACE2"
     fi
 fi
+[ -n "$ERL_DIST_PORT" ] && ERLANG_OPTS="$ERLANG_OPTS -erl_epmd_port $ERL_DIST_PORT -start_epmd false"
 # if vm.args file exists in config directory, pass it to Erlang VM
 [ -f "$VMARGS" ] && ERLANG_OPTS="$ERLANG_OPTS -args_file $VMARGS"
 ERL_LIBS='{{libdir}}'
@@ -103,6 +104,7 @@ export EJABBERD_LOG_PATH
 export EJABBERD_PID_PATH
 export ERL_CRASH_DUMP
 export ERL_EPMD_ADDRESS
+export ERL_DIST_PORT
 export ERL_INETRC
 export ERL_MAX_PORTS
 export ERL_MAX_ETS_TABLES
@@ -110,6 +112,11 @@ export CONTRIB_MODULES_PATH
 export CONTRIB_MODULES_CONF_DIR
 export ERL_LIBS
 export SCRIPT_DIR
+
+set_dist_client()
+{
+    [ -n "$ERL_DIST_PORT" ] && ERLANG_OPTS="$ERLANG_OPTS -dist_listen false"
+}
 
 # run command either directly or via su $INSTALLUSER
 run_cmd()
@@ -233,6 +240,7 @@ uid()
 # stop epmd if there is no other running node
 stop_epmd()
 {
+    [ -n "$ERL_DIST_PORT" ] && return
     "$EPMD" -names 2>/dev/null | grep -q name || "$EPMD" -kill >/dev/null
 }
 
@@ -240,6 +248,7 @@ stop_epmd()
 # if all ok, ensure runtime directory exists and make it current directory
 check_start()
 {
+    [ -n "$ERL_DIST_PORT" ] && return
     "$EPMD" -names 2>/dev/null | grep -q " ${ERLANG_NODE%@*} " && {
         pgrep -f "$ERLANG_NODE" >/dev/null && {
             echo "ERROR: The ejabberd node '$ERLANG_NODE' is already running."
@@ -328,14 +337,17 @@ case $1 in
         ;;
     debug)
         debugwarning
+        set_dist_client
         exec_erl "$(uid debug)" -hidden -remsh "$ERLANG_NODE"
         ;;
     etop)
+        set_dist_client
         exec_erl "$(uid top)" -hidden -node "$ERLANG_NODE" -s etop \
                  -s erlang halt -output text
         ;;
     iexdebug)
         debugwarning
+        set_dist_client
         exec_iex "$(uid debug)" --remsh "$ERLANG_NODE"
         ;;
     iexlive)
@@ -345,20 +357,24 @@ case $1 in
     ping)
         PEER=${2:-$ERLANG_NODE}
         [ "$PEER" = "${PEER%.*}" ] && PS="-s"
+        set_dist_client
         exec_cmd "$ERL" ${PS:--}name "$(uid ping "$(hostname $PS)")" $ERLANG_OPTS \
                  -noinput -hidden -eval 'io:format("~p~n",[net_adm:ping('"'$PEER'"')])' \
                  -s erlang halt -output text
         ;;
     started)
+        set_dist_client
         wait_status 0 30 2 # wait 30x2s before timeout
         ;;
     stopped)
+        set_dist_client
         wait_status 3 30 2 && stop_epmd # wait 30x2s before timeout
         ;;
     post_waiter)
         post_waiter_waiting
         ;;
     *)
+        set_dist_client
         run_erl "$(uid ctl)" -hidden -noinput -s ejabberd_ctl \
                  -extra "$ERLANG_NODE" $NO_TIMEOUT "$@"
         result=$?

--- a/CONTAINER.md
+++ b/CONTAINER.md
@@ -178,7 +178,7 @@ This container image exposes the ports:
 - `5280`: For admin interface.
 - `5443`: With encryption, used for admin interface, API, CAPTCHA, OAuth, Websockets and XMPP BOSH.
 - `1883`: Used for MQTT
-- `4369-4399`: EPMD and Erlang connectivity, used for `ejabberdctl` and clustering
+- `5210`: Erlang connectivity, used for `ejabberdctl` and clustering
 
 
 ### Volumes
@@ -276,7 +276,6 @@ docker buildx build \
 ```
 
 It's also possible to use podman instead of docker, just notice:
-- `EXPOSE 4369-4399` port range is not supported, remove that in Dockerfile
 - It mentions that `healthcheck` is not supported by the Open Container Initiative image format
 - If you want to start with command `live`, add environment variable `EJABBERD_BYPASS_WARNINGS=true`
 ```bash

--- a/ejabberdctl.cfg.example
+++ b/ejabberdctl.cfg.example
@@ -47,10 +47,28 @@
 #INET_DIST_INTERFACE=127.0.0.1
 
 #.
-#' ERL_EPMD_ADDRESS: IP addresses where epmd listens for connections
+#' ERL_DIST_PORT: Port number for Erlang distribution
+#
+# For Erlang distribution, clustering and ejabberdctl usage, the
+# Erlang VM listens in a random TCP port number, and the Erlang Port
+# Mapper Daemon (EPMD) is spawned and used to determine this port
+# number.
+#
+# ERL_DIST_PORT can define this port number.  In that case, EPMD is
+# not spawned during ejabberd startup, and ERL_EPMD_ADDRESS is
+# ignored. ERL_DIST_PORT must be set to the same port number during
+# ejabberd startup and when calling ejabberdctl.  This feature
+# requires at least Erlang/OTP 23.1.
+#
+# Default: not defined
+#
+#ERL_DIST_PORT=5210
+
+#.
+#' ERL_EPMD_ADDRESS: IP addresses where EPMD listens for connections
 #
 # This environment variable may be set to a comma-separated
-# list of IP addresses, in which case the epmd daemon
+# list of IP addresses, in which case the EPMD daemon
 # will listen only on the specified address(es) and on the
 # loopback address (which is implicitly added to the list if it
 # has not been specified). The default behaviour is to listen on

--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -81,6 +81,7 @@ if [ -n "$INET_DIST_INTERFACE" ] ; then
         ERLANG_OPTS="$ERLANG_OPTS -kernel inet_dist_use_interface $INET_DIST_INTERFACE2"
     fi
 fi
+[ -n "$ERL_DIST_PORT" ] && ERLANG_OPTS="$ERLANG_OPTS -erl_epmd_port $ERL_DIST_PORT -start_epmd false"
 # if vm.args file exists in config directory, pass it to Erlang VM
 [ -f "$VMARGS" ] && ERLANG_OPTS="$ERLANG_OPTS -args_file $VMARGS"
 ERL_LIBS='{{libdir}}'
@@ -102,6 +103,7 @@ export EJABBERD_LOG_PATH
 export EJABBERD_PID_PATH
 export ERL_CRASH_DUMP
 export ERL_EPMD_ADDRESS
+export ERL_DIST_PORT
 export ERL_INETRC
 export ERL_MAX_PORTS
 export ERL_MAX_ETS_TABLES
@@ -109,6 +111,11 @@ export CONTRIB_MODULES_PATH
 export CONTRIB_MODULES_CONF_DIR
 export ERL_LIBS
 export SCRIPT_DIR
+
+set_dist_client()
+{
+    [ -n "$ERL_DIST_PORT" ] && ERLANG_OPTS="$ERLANG_OPTS -dist_listen false"
+}
 
 # run command either directly or via su $INSTALLUSER
 exec_cmd()
@@ -220,6 +227,7 @@ uid()
 # stop epmd if there is no other running node
 stop_epmd()
 {
+    [ -n "$ERL_DIST_PORT" ] && return
     "$EPMD" -names 2>/dev/null | grep -q name || "$EPMD" -kill >/dev/null
 }
 
@@ -227,6 +235,7 @@ stop_epmd()
 # if all ok, ensure runtime directory exists and make it current directory
 check_start()
 {
+    [ -n "$ERL_DIST_PORT" ] && return
     "$EPMD" -names 2>/dev/null | grep -q " ${ERLANG_NODE%@*} " && {
         pgrep -f "$ERLANG_NODE" >/dev/null && {
             echo "ERROR: The ejabberd node '$ERLANG_NODE' is already running."
@@ -291,14 +300,17 @@ case $1 in
         ;;
     debug)
         debugwarning
+        set_dist_client
         exec_erl "$(uid debug)" -hidden -remsh "$ERLANG_NODE"
         ;;
     etop)
+        set_dist_client
         exec_erl "$(uid top)" -hidden -node "$ERLANG_NODE" -s etop \
                  -s erlang halt -output text
         ;;
     iexdebug)
         debugwarning
+        set_dist_client
         exec_iex "$(uid debug)" --remsh "$ERLANG_NODE"
         ;;
     iexlive)
@@ -308,17 +320,21 @@ case $1 in
     ping)
         PEER=${2:-$ERLANG_NODE}
         [ "$PEER" = "${PEER%.*}" ] && PS="-s"
+        set_dist_client
         exec_cmd "$ERL" ${PS:--}name "$(uid ping "$(hostname $PS)")" $ERLANG_OPTS \
                  -noinput -hidden -eval 'io:format("~p~n",[net_adm:ping('"'$PEER'"')])' \
                  -s erlang halt -output text
         ;;
     started)
+        set_dist_client
         wait_status 0 30 2 # wait 30x2s before timeout
         ;;
     stopped)
+        set_dist_client
         wait_status 3 30 2 && stop_epmd # wait 30x2s before timeout
         ;;
     *)
+        set_dist_client
         exec_erl "$(uid ctl)" -hidden -noinput -s ejabberd_ctl \
                  -extra "$ERLANG_NODE" $NO_TIMEOUT "$@"
         result=$?


### PR DESCRIPTION
This PR implements an option to disable EPMD and use instead a fixed distribution port. This feature is optional, and disabled by default. The proposed port could be 5210, for example.

It would be great if that feature gets tested, and also the current implementation gets reviewed in case there's a simpler way to achieve the required changes in ejabberdctl.template.

Additionally, this PR includes a commit that enables this feature in the container published in the Github Package registry. It would be great if people with experience in containers mention if that feature is worth enabling, if it makes administration easier, or if it introduces more troubles for administering and clustering than benefits...

Notice:
- Erlang/OTP 23.1 or higher is required to use ERL_DIST_PORT
- `make relive` doesn't support ERL_DIST_PORT, neither rebar3 nor elixir
- To use "ejabberd" script: `ERL_DIST_PORT=5210 _build/dev/rel/ejabberd/bin/ejabberd ping`
- It seems `make install` doesn't work with Elixir's mix since at least ejabberd 21.07, maybe older
- To connect from local "ejabberdctl" to containerized ejabberd:
  export port 5210 from container, and share COOKIE file

Successfully tested with:
- Erlang/OTP 23.1 and 25.0
- rebar 2.6.4
- rebar3 3.14.3 and 3.18
- elixir 1.10.3 and 1.13

Reference:
https://www.erlang.org/blog/otp-23-highlights/
https://blog.erlware.org/epmdlessless/