### PR TITLE
Support @VERSION@ and @SEMVER@ in captcha_cmd option

### DIFF
--- a/src/ejabberd_options.erl
+++ b/src/ejabberd_options.erl
@@ -110,7 +110,14 @@ opt_type(cache_missed) ->
 opt_type(cache_size) ->
     econf:pos_int(infinity);
 opt_type(captcha_cmd) ->
-    econf:file();
+    econf:and_then(
+	econf:binary(),
+	fun(V) ->
+		V2 = misc:expand_keyword(<<"@SEMVER@">>, V,
+				    ejabberd_option:version()),
+		misc:expand_keyword(<<"@VERSION">>, V2,
+				    misc:semver_to_xxyy(ejabberd_option:version()))
+	end);
 opt_type(captcha_host) ->
     econf:binary();
 opt_type(captcha_limit) ->

--- a/src/ejabberd_options_doc.erl
+++ b/src/ejabberd_options_doc.erl
@@ -457,8 +457,14 @@ doc() ->
       #{value => ?T("Path"),
         desc =>
             ?T("Full path to a script that generates http://../basic/#captcha[CAPTCHA] images. "
+               "@VERSION@ is replaced with ejabberd version number in XX.YY format. "
+               "@SEMVER@ is replaced with ejabberd version number in semver format "
+               "when compiled with Elixir's mix, or XX.YY format otherwise. "
                "There is no default value: when this option is not "
-               "set, CAPTCHA functionality is completely disabled.")}},
+               "set, CAPTCHA functionality is completely disabled."),
+        example =>
+            [{?T("When using the ejabberd installers or container image, the example captcha scripts can be used like this:"),
+              ["captcha_cmd: /opt/ejabberd-@VERSION@/lib/ejabberd-@SEMVER@/priv/bin/captcha.sh"]}]}},
      {captcha_limit,
       #{value => "pos_integer() | infinity",
         desc =>

--- a/src/misc.erl
+++ b/src/misc.erl
@@ -43,7 +43,7 @@
 	 get_my_ipv4_address/0, get_my_ipv6_address/0, parse_ip_mask/1,
 	 crypto_hmac/3, crypto_hmac/4, uri_parse/1,
 	 match_ip_mask/3, format_hosts_list/1, format_cycle/1, delete_dir/1,
-	 logical_processors/0]).
+	 semver_to_xxyy/1, logical_processors/0]).
 
 %% Deprecated functions
 -export([decode_base64/1, encode_base64/1]).
@@ -620,6 +620,16 @@ delete_dir(Dir) ->
 	_:{badmatch, {error, Error}} ->
 	    {error, Error}
     end.
+
+-spec semver_to_xxyy(binary()) -> binary().
+semver_to_xxyy(<<Y1, Y2, $., M2, $., $0>>) ->
+    <<Y1, Y2, $., $0, M2>>;
+semver_to_xxyy(<<Y1, Y2, $., M2, $., Patch/binary>>) ->
+    <<Y1, Y2, $., $0, M2, $., Patch/binary>>;
+semver_to_xxyy(<<Y1, Y2, $., M1, M2, $., $0>>) ->
+    <<Y1, Y2, $., M1, M2>>;
+semver_to_xxyy(Version) when is_binary(Version) ->
+    Version.
 
 %%%===================================================================
 %%% Internal functions


### PR DESCRIPTION
Those macros are useful because the example captcha scripts are copied in a path `ejabberd-$VERSION/priv/bin` tha depends on the ejabberd version number, and changes for each release. Also, depending on the install method (one that uses rebar3, or Elixir's mix), that $VERSION may be in `XX.YY` or in `SEMVER` format (respectively).

Thanks to @weiss for the `semver_to_xxyy/1` function code.