### PR TITLE
mod_mix_pam: Provide MIX channels as roster entries via hook

### DIFF
--- a/include/mod_roster.hrl
+++ b/include/mod_roster.hrl
@@ -28,7 +28,8 @@
     ask = none                             :: ask() | '_',
     groups = []                            :: [binary()] | '_',
     askmessage = <<"">>                    :: binary() | '_',
-    xs = []                                :: [fxml:xmlel()] | '_'
+    xs = []                                :: [fxml:xmlel()] | '_',
+    mix_participant_id = <<>>              :: binary() | '_'
 }).
 
 -record(roster_version,

--- a/include/mod_roster.hrl
+++ b/include/mod_roster.hrl
@@ -28,8 +28,7 @@
     ask = none                             :: ask() | '_',
     groups = []                            :: [binary()] | '_',
     askmessage = <<"">>                    :: binary() | '_',
-    xs = []                                :: [fxml:xmlel()] | '_',
-    mix_participant_id = <<>>              :: binary() | '_'
+    xs = []                                :: [fxml:xmlel()] | '_'
 }).
 
 -record(roster_version,

--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -777,9 +777,9 @@ broadcast_presence_unavailable(#{jid := JID, pres_a := PresA} = State, Pres,
 		    Roster = ejabberd_hooks:run_fold(roster_get, LServer,
 						     [], [{LUser, LServer}]),
 		    lists:foldl(
-			fun(#roster{jid = LJID, subscription = Sub}, Acc)
+			fun(#roster_item{jid = ItemJID, subscription = Sub}, Acc)
 			       when Sub == both; Sub == from ->
-			    maps:put(LJID, 1, Acc);
+			    maps:put(jid:tolower(ItemJID), 1, Acc);
 			   (_, Acc) ->
 			       Acc
 			end, #{BareJID => 1}, Roster);
@@ -813,8 +813,7 @@ broadcast_presence_available(#{jid := JID} = State,
 				    [], [{LUser, LServer}]),
     {FJIDs, TJIDs} =
 	lists:foldl(
-	  fun(#roster{jid = LJID, subscription = Sub}, {F, T}) ->
-		  To = jid:make(LJID),
+	  fun(#roster_item{jid = To, subscription = Sub}, {F, T}) ->
 		  F1 = if Sub == both orelse Sub == from ->
 			       Pres1 = xmpp:set_to(Pres, To),
 			       case privacy_check_packet(State, Pres1, out) of
@@ -843,10 +842,9 @@ broadcast_presence_available(#{jid := JID} = State,
     Items = ejabberd_hooks:run_fold(
 	      roster_get, LServer, [], [{LUser, LServer}]),
     JIDs = lists:foldl(
-	     fun(#roster{jid = LJID, subscription = Sub}, Tos)
+	     fun(#roster_item{jid = To, subscription = Sub}, Tos)
 		   when Sub == both orelse Sub == from ->
-		     To = jid:make(LJID),
-		     P = xmpp:set_to(Pres, jid:make(LJID)),
+		     P = xmpp:set_to(Pres, To),
 		     case privacy_check_packet(State, P, out) of
 			 allow -> [To|Tos];
 			 deny -> Tos

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1333,16 +1333,15 @@ get_roster(User, Server) ->
 %% several times, each one in a different group.
 make_roster_xmlrpc(Roster) ->
     lists:foldl(
-      fun(Item, Res) ->
-	      JIDS = jid:encode(Item#roster.jid),
-	      Nick = Item#roster.name,
-	      Subs = atom_to_list(Item#roster.subscription),
-	      Ask = atom_to_list(Item#roster.ask),
-	      Groups = case Item#roster.groups of
+      fun(#roster_item{jid = JID, name = Nick, subscription = Sub, ask = Ask} = Item, Res) ->
+	      JIDS = jid:encode(JID),
+	      Subs = atom_to_list(Sub),
+	      Asks = atom_to_list(Ask),
+	      Groups = case Item#roster_item.groups of
 			   [] -> [<<>>];
 			   Gs -> Gs
 		       end,
-	      ItemsX = [{JIDS, Nick, Subs, Ask, Group} || Group <- Groups],
+	      ItemsX = [{JIDS, Nick, Subs, Asks, Group} || Group <- Groups],
 	      ItemsX ++ Res
       end,
       [],

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -426,7 +426,11 @@ encode_item(Item) ->
 			   both -> subscribe;
 			   _ -> undefined
 		       end,
-		 groups = Item#roster.groups}.
+		 groups = Item#roster.groups,
+		 mix_channel = case Item#roster.mix_participant_id of
+				   <<>> -> undefined;
+				   _ -> #mix_roster_channel{'participant-id' = Item#roster.mix_participant_id}
+			       end}.
 
 -spec decode_item(roster_item(), #roster{}, boolean()) -> #roster{}.
 decode_item(#roster_item{subscription = remove} = Item, R, _) ->

--- a/src/mod_shared_roster.erl
+++ b/src/mod_shared_roster.erl
@@ -185,8 +185,8 @@ cache_nodes(Mod, Host) ->
         false -> ejabberd_cluster:get_nodes()
     end.
 
--spec get_user_roster([#roster{}], {binary(), binary()}) -> [#roster{}].
-get_user_roster(Items, {U, S} = US) ->
+-spec get_user_roster([#roster_item{}], {binary(), binary()}) -> [#roster_item{}].
+get_user_roster(Items, {_, S} = US) ->
     {DisplayedGroups, Cache} = get_user_displayed_groups(US),
     SRUsers = lists:foldl(
 	fun(Group, Acc1) ->
@@ -216,10 +216,10 @@ get_user_roster(Items, {U, S} = US) ->
 	    end
 	end,
 	SRUsers, Items),
-    SRItems = [#roster{usj = {U, S, {U1, S1, <<"">>}},
-		       us = US, jid = {U1, S1, <<"">>},
-		       name = get_rosteritem_name(U1, S1),
-		       subscription = both, ask = none, groups = GroupLabels}
+    SRItems = [#roster_item{jid = jid:make(U1, S1),
+			    name = get_rosteritem_name(U1, S1),
+			    subscription = both, ask = undefined,
+			    groups = GroupLabels}
 	       || {{U1, S1}, GroupLabels} <- dict:to_list(SRUsersRest)],
     SRItems ++ NewItems1.
 
@@ -855,16 +855,14 @@ displayed_to_groups(GroupName, LServer) ->
 
 push_item(User, Server, Item) ->
     mod_roster:push_item(jid:make(User, Server),
-			 Item#roster{subscription = none},
+			 Item#roster_item{subscription = none},
 			 Item).
 
 push_roster_item(User, Server, ContactU, ContactS, ContactN,
 		 GroupLabel, Subscription) ->
-    Item = #roster{usj =
-		       {User, Server, {ContactU, ContactS, <<"">>}},
-		   us = {User, Server}, jid = {ContactU, ContactS, <<"">>},
-		   name = ContactN, subscription = Subscription, ask = none,
-		   groups = [GroupLabel]},
+    Item = #roster_item{jid = jid:make(ContactU, ContactS),
+			name = ContactN, subscription = Subscription, ask = undefined,
+			groups = [GroupLabel]},
     push_item(User, Server, Item).
 
 -spec c2s_self_presence({presence(), ejabberd_c2s:state()})

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -109,8 +109,8 @@ depends(_Host, _Opts) ->
 %%--------------------------------------------------------------------
 %% Hooks
 %%--------------------------------------------------------------------
--spec get_user_roster([#roster{}], {binary(), binary()}) -> [#roster{}].
-get_user_roster(Items, {U, S} = US) ->
+-spec get_user_roster([#roster_item{}], {binary(), binary()}) -> [#roster_item{}].
+get_user_roster(Items, US) ->
     SRUsers = get_user_to_groups_map(US, true),
     {NewItems1, SRUsersRest} = lists:mapfoldl(fun (Item,
 						   SRUsers1) ->
@@ -135,10 +135,9 @@ get_user_roster(Items, {U, S} = US) ->
 						      end
 					      end,
 					      SRUsers, Items),
-    SRItems = [#roster{usj = {U, S, {U1, S1, <<"">>}},
-		       us = US, jid = {U1, S1, <<"">>},
-		       name = get_user_name(U1, S1), subscription = both,
-		       ask = none, groups = GroupNames}
+    SRItems = [#roster_item{jid = jid:make(U1, S1),
+			    name = get_user_name(U1, S1), subscription = both,
+			    ask = undefined, groups = GroupNames}
 	       || {{U1, S1}, GroupNames} <- dict:to_list(SRUsersRest)],
     SRItems ++ NewItems1.
 


### PR DESCRIPTION
Currently the joined MIX channels of a user are stored in the database of mod_mix_pam, but are not provided to the user in any way. This change subscribes to the hook of mod_roster and provides the joined channels.

TODO:
- [x] Add roster pushes
- [x] Only provide MIX subelements when `<mix-annotate/>` is set
  - [x] in roster get
  - [x] in roster pushes: Requires to store annotate setting for the session (Need to find out how)
- [x] Change roster hook to use `#roster_item{}` instead of `#roster{}` so the roster record can stay how it is (without mix participant ID). This way no empty field for the mix participant id is saved in the roster mnesia db.