### PR TITLE
Fix joining a MIX channel on a remote server

### DIFF
--- a/src/mod_mix.erl
+++ b/src/mod_mix.erl
@@ -593,10 +593,8 @@ known_nodes() ->
 
 -spec filter_nodes([binary()]) -> [binary()].
 filter_nodes(Nodes) ->
-    lists:filter(
-      fun(Node) ->
-	      lists:member(Node, Nodes)
-      end, known_nodes()).
+    KnownNodes = known_nodes(),
+    [Node || KnownNode <- KnownNodes, Node <- Nodes, KnownNode == Node].
 
 -spec multicast(module(), binary(), binary(),
 		binary(), binary(), fun((jid()) -> message())) -> ok.

--- a/src/mod_mix.erl
+++ b/src/mod_mix.erl
@@ -424,6 +424,7 @@ process_mix_join(#iq{to = To, from = From,
 		notify_participant_joined(Mod, ServerHost, To, From, ID, Nick),
 		xmpp:make_iq_result(IQ, #mix_join{id = ID,
 						  subscribe = Nodes,
+						  jid = make_channel_id(To, ID),
 						  nick = Nick,
 						  xmlns = XmlNs})
 	    catch _:{badmatch, {error, db_failure}} ->
@@ -645,6 +646,11 @@ notify_participant_left(Mod, LServer, To, ID) ->
 make_id(JID, Key) ->
     Data = jid:encode(jid:tolower(jid:remove_resource(JID))),
     xmpp_util:hex(misc:crypto_hmac(sha256, Data, Key, 10)).
+
+-spec make_channel_id(jid(), binary()) -> jid().
+make_channel_id(JID, ID) ->
+	{U, S, R} = jid:split(JID),
+	jid:make(<<ID/binary, $#, U/binary>>, S, R).
 
 %%%===================================================================
 %%% Error generators


### PR DESCRIPTION
- send the participant jid on join
- parse sub xml elements that were previously not parsed
- Fix subscribing to nodes when joining
