### PR TITLE
Adapt to mix improvements from p1-xmpp

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -114,7 +114,7 @@ defmodule Ejabberd.MixProject do
      {:p1_utils, "~> 1.0"},
      {:pkix, "~> 1.0"},
      {:stringprep, ">= 1.0.26"},
-     {:xmpp, git: "https://github.com/processone/xmpp.git", ref: "cdda2bea2df0b4ed40fbd854f6f1bf21c6b7a8c5", override: true},
+     {:xmpp, git: "https://github.com/processone/xmpp.git", ref: "62325549cced01b12878d79286311ae62fe0fc4f", override: true},
      {:yconf, "~> 1.0"}]
     ++ cond_deps()
   end

--- a/rebar.config
+++ b/rebar.config
@@ -70,7 +70,7 @@
         {stringprep, ".*", {git, "https://github.com/processone/stringprep", {tag, "1.0.28"}}},
         {if_var_true, stun,
          {stun, ".*", {git, "https://github.com/processone/stun", {tag, "1.2.2"}}}},
-        {xmpp, ".*", {git, "https://github.com/processone/xmpp", "cdda2bea2df0b4ed40fbd854f6f1bf21c6b7a8c5"}},
+        {xmpp, ".*", {git, "https://github.com/processone/xmpp", "62325549cced01b12878d79286311ae62fe0fc4f"}},
         {yconf, ".*", {git, "https://github.com/processone/yconf", {tag, "1.0.13"}}}
        ]}.
 

--- a/src/mod_mix_pam.erl
+++ b/src/mod_mix_pam.erl
@@ -226,7 +226,7 @@ get_mix_roster_items(Acc, {LUser, LServer}) ->
                         subscription = both,
                         ask = undefined,
                         groups = [<<"Channels">>],
-                        mix_channel = #mix_roster_channel{'participant-id' = Id}
+                        mix_channel = #mix_roster_channel{participant_id = Id}
                     }
                 end, Channels);
         _ ->
@@ -311,7 +311,7 @@ process_join_result(#iq{from = #jid{} = Channel,
 		subscription = none,
 		ask = undefined,
 		groups = [],
-		mix_channel = #mix_roster_channel{'participant-id' = ID}
+		mix_channel = #mix_roster_channel{participant_id = ID}
 	    }),
 	    % send IQ result
 	    ChanID = make_channel_id(Channel, ID),

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -273,10 +273,9 @@ write_roster_version(LUser, LServer, InTransaction) ->
 %%     - the roster version from client don't match current version.
 -spec process_iq_get(iq()) -> iq().
 process_iq_get(#iq{to = To, from = From,
-		   sub_els = [#roster_query{ver = RequestedVersion, mix_annotate = MixAnnotate}]} = IQ) ->
+		   sub_els = [#roster_query{ver = RequestedVersion, mix_annotate = MixEnabled}]} = IQ) ->
     LUser = To#jid.luser,
     LServer = To#jid.lserver,
-    MixEnabled = MixAnnotate == #mix_roster_annotate{},
     {ItemsToSend, VersionToSend} =
 	case {mod_roster_opt:versioning(LServer),
 	      mod_roster_opt:store_current_id(LServer)} of


### PR DESCRIPTION
- Adapt to renaming of 'participant-id' from mix_roster_channel record
- Adapt to change of mix_annotate type to boolean in roster_query
- [x] waits on https://github.com/processone/xmpp/pull/70
