### PR TITLE
fix table creation on a running cluster

### DIFF
--- a/src/ejabberd_mnesia.erl
+++ b/src/ejabberd_mnesia.erl
@@ -172,7 +172,10 @@ change_table_copy_type(Name, TabDef) ->
     if NewType /= CurrType ->
 	    ?INFO_MSG("Changing Mnesia table '~ts' from ~ts to ~ts",
 		      [Name, CurrType, NewType]),
-	    mnesia_op(change_table_copy_type, [Name, node(), NewType]);
+	    if CurrType == unknown -> mnesia_op(add_table_copy, [Name, node(), NewType]);
+		true ->
+		    mnesia_op(change_table_copy_type, [Name, node(), NewType])
+	    end;
        true ->
 	    {atomic, ok}
     end.


### PR DESCRIPTION
On a 2 nodes A & B running cluster, the "ejabberd_mnesia:create" on node A will create the mnesia table, but the same "ejabberd_mnesia:create" call on node B will trigger a table update since the table is "known".

This second call fails on the following call :

ejabberd_mnesia:mnesia_op(change_table_copy_type, [mytable,'ejabberd-cluster@my_xmpp.com',ram_copies]) => {aborted, {badarg,mytable,unknown}}

The function "ejabberd_mnesia:change_table_copy_type" manages configuration changes but requires an existing local copy, if the storage type is "unknown", create this copy with "mnesia_op(add_table_copy, [Name, node(), NewType])" instead fixes the issue.