### PR TITLE
Jid format when `multicastc` was cached

### DIFF
--- a/src/mod_multicast.erl
+++ b/src/mod_multicast.erl
@@ -407,7 +407,7 @@ route_grouped(LServer, LService, From, Groups, RestOfAddresses, Packet) ->
 		route_single ->
 		    route_individual(From, CC, BCC, OtherCC ++ RestOfAddresses, Packet);
 		{route_multicast, Service, Limits} ->
-		    route_multicast(From, Service, CC, BCC, OtherCC ++ RestOfAddresses, Packet, Limits)
+		    route_multicast(From, jid:make(Service), CC, BCC, OtherCC ++ RestOfAddresses, Packet, Limits)
 	    end
 	end, ok, Groups).
 


### PR DESCRIPTION
The error log:

```2022-11-22 04:10:25.436648+00:00 [error] <0.515.0>@ejabberd_router:route/1:95 Failed to route packet:
#message{
    id = <<>>,type = normal,lang = <<>>,
    from =
        #jid{
            user = <<"a123">>,server = <<"conference.example.com">>,
            resource = <<>>,luser = <<"a123">>,
            lserver = <<"conference.example.com">>,lresource = <<>>},
    to = <<"multicast.app.example.com">>,subject = [],body = [],
    thread = undefined,
    sub_els =
        [#ps_event{
             items =
                 #ps_items{
                     xmlns = <<>>,
                     node = <<"urn:xmpp:mucsub:nodes:subscribers">>,
                     items =
                         [#ps_item{
                              xmlns = <<>>,id = <<"5803948964051348597">>,
                              sub_els =
                                  [#muc_subscribe{
                                       nick = <<"bb">>,password = <<>>,
                                       jid = undefined,events = []}],
                              node = <<>>,publisher = <<>>}],
                     max_items = undefined,subid = <<>>,retract = undefined},
             purge = undefined,subscription = undefined,delete = undefined,
             create = undefined,configuration = undefined},
         #addresses{
             list =
                 [#address{
                      type = bcc,
                      jid =
                          #jid{
                              user = <<"aaa">>,server = <<"app.example.com">>,
                              resource = <<>>,luser = <<"aaa">>,
                              lserver = <<"app.example.com">>,lresource = <<>>},
                      desc = <<>>,node = <<>>,delivered = undefined,
                      sub_els = []},
                  #address{
                      type = bcc,
                      jid =
                          #jid{
                              user = <<"bb">>,server = <<"app.example.com">>,
                              resource = <<>>,luser = <<"bb">>,
                              lserver = <<"app.example.com">>,lresource = <<>>},
                      desc = <<>>,node = <<>>,delivered = undefined,
                      sub_els = []}]}],
    meta = #{}}
** exception error: {badrecord,jid}
   in function  ejabberd_router:do_route/1 (src/ejabberd_router.erl, line 394)
   in call from ejabberd_router:route/1 (src/ejabberd_router.erl, line 92)
   in call from maps:fold_1/3 (maps.erl, line 232)
   in call from mod_multicast:handle_info/2 (src/mod_multicast.erl, line 206)
   in call from gen_server:try_dispatch/4 (gen_server.erl, line 637)
   in call from gen_server:handle_msg/6 (gen_server.erl, line 711)
   in call from proc_lib:init_p_do_apply/3 (proc_lib.erl, line 249)
```


Then command debug select the multicastc:
```
(ejabberd@localhost) 2> mnesia:dirty_read(multicastc, <<"app.example.com">>). 

[{multicastc,<<"app.example.com">>,
             {{multicast_supported,<<"multicast.app.example.com">>,
                                   {limits,{default,20},{default,20}}},
              cached},
             63836303692}]
```

The type of `Service` was binary.

