### PR TITLE
When subscriber store the presence offline

### DIFF
--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -453,11 +453,13 @@ need_to_store(_LServer, #message{type = error}) -> false;
 need_to_store(LServer, #message{type = Type} = Packet) ->
     case xmpp:has_subtag(Packet, #offline{}) of
 	false ->
-	    case misc:unwrap_mucsub_message(Packet) of
-		#message{type = groupchat} = Msg ->
+	    case {xmpp:has_subtag(Packet, #ps_event{}), misc:unwrap_mucsub_message(Packet)} of
+		{true, #message{type = groupchat} = Msg} ->
 		    need_to_store(LServer, Msg#message{type = chat});
-		#message{} = Msg ->
+		{true, #message{} = Msg} ->
 		    need_to_store(LServer, Msg);
+		{true, _} ->
+		    false;
 		_ ->
 		    case check_store_hint(Packet) of
 			store ->


### PR DESCRIPTION
Someone presence one muc room, the subscriber may received this message:
```
#message{
 id = <<"14535871043214929496">>,type = normal,lang = <<>>,
 from =
  #jid{
   user = <<"aaaaaaaaa">>,server = <<"conference.example.com">>,
   resource = <<>>,luser = <<"aaaaaaaaa">>,
   lserver = <<"conference.example.com">>,lresource = <<>>},
 to =
  #jid{
   user = <<"suber_1">>,server = <<"example.com">>,resource = <<>>,
   luser = <<"suber_1">>,lserver = <<"example.com">>,lresource = <<>>},
 subject = [],body = [],thread = undefined,
 sub_els =
  [#ps_event{
    items =
     #ps_items{
      xmlns = <<>>,node = <<"urn:xmpp:mucsub:nodes:presence">>,
      items =
       [#ps_item{
         xmlns = <<>>,id = <<"14535871043214929496">>,
         sub_els =
          [#presence{
            id = <<>>,type = available,lang = <<"en">>,
            from =
             #jid{
              user = <<"aaaaaaaaa">>,server = <<"conference.example.com">>,
              resource = <<"bbb">>,luser = <<"aaaaaaaaa">>,
              lserver = <<"conference.example.com">>,lresource = <<"bbb">>},
            to =
             #jid{
              user = <<"suber_1">>,server = <<"example.com">>,resource = <<>>,
              luser = <<"suber_1">>,lserver = <<"example.com">>,
              lresource = <<>>},
            show = undefined,status = [],priority = undefined,
            sub_els =
             [#muc_user{
               decline = undefined,destroy = undefined,invites = [],
               items =
                [#muc_item{
                  actor = undefined,continue = undefined,reason = <<>>,
                  affiliation = owner,role = moderator,jid = undefined,
                  nick = <<>>}],
               status_codes = [],password = undefined}],
            meta = #{ip => {0,0,0,0,0,65535,49320,8449}}}],
         node = <<>>,publisher = <<>>}],
      max_items = undefined,subid = <<>>,retract = undefined},
    purge = undefined,subscription = undefined,delete = undefined,
    create = undefined,configuration = undefined}],
 meta = #{in_muc_mam => true}}
```

When the message need to store offline while the option `store_empty_body`  was `false`, it must throw exception.
