### PR TITLE
Fix portability issue with some shells

### DIFF
--- a/m4/erlang-extra.m4
+++ b/m4/erlang-extra.m4
@@ -75,7 +75,7 @@ EOF
 	if test "x`cat conftest.out`" != "xok"; then
 	   AC_MSG_RESULT([failed])
 	   X="`cat conftest.out`"
-	   if test "[$3]" == "warn"; then
+	   if test "[$3]" = "warn"; then
 	      AC_MSG_WARN([$X])
 	   else
 	      AC_MSG_FAILURE([$X])


### PR DESCRIPTION
Some shells do not implement a test command which supports the '==' operator. For the sake of compatibility with the greatest number of environments, it is preferable to use the '=' operator.
