### PR TITLE
Fix ejabberdctl output formatting

### DIFF
--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -498,7 +498,7 @@ is_supported_args(Args) ->
 
 %% Commands are Bold
 -define(B1, "\e[1m").
--define(B2, "\e[21m").
+-define(B2, "\e[22m").
 -define(C(S), case ShCode of true -> [?B1, S, ?B2]; false -> S end).
 
 %% Arguments are Dim


### PR DESCRIPTION
ECMA-48 SGR sequence ESC [21m is actually 'set double underline' but was incorrectly implemented as 'set normal intensity' in Linux prior to 4.17.

The correct sequence for 'set normal intensity' is ESC [22m, which fixes output formatting of 'ejabberdctl' and 'ejabberdctl help' on macos.