### PR TITLE
ejabberd_listener.erl: Increase default listen queue backlog value

### DIFF
--- a/src/ejabberd_listener.erl
+++ b/src/ejabberd_listener.erl
@@ -708,6 +708,6 @@ listen_options() ->
      {ip, {0,0,0,0}},
      {accept_interval, 0},
      {send_timeout, 15000},
-     {backlog, 5},
+     {backlog, 128},
      {use_proxy_protocol, false},
      {supervisor, true}].


### PR DESCRIPTION
Set this to 128, this the default value on both Linux and FreeBSD:

- https://www.getpagespeed.com/server-setup/nginx/maximizing-nginx-performance-a-comprehensive-guide-to-tuning-the-backlog-and-net-core-somaxconn-parameters
- https://docs.freebsd.org/en/books/handbook/config/#_kern_ipc_soacceptqueue