### PR TITLE
Fix SIGINT of ejabberdctl foreground by exec(1) on privilege drop

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -121,7 +121,7 @@ set_dist_client()
 exec_cmd()
 {
     case $EXEC_CMD in
-        as_install_user) su -s /bin/sh -c '"$0" "$@"' "$INSTALLUSER" -- "$@" ;;
+        as_install_user) su -s /bin/sh -c 'exec "$0" "$@"' "$INSTALLUSER" -- "$@" ;;
         as_current_user) "$@" ;;
     esac
 }


### PR DESCRIPTION
When `ejabberdctl foreground` is executed as root, it will su to the ejabberd user before starting Erlang.
If a user then hits ^C, su(1) kills the login shell it started and the Erlang process is interited by PID 1 instead of being stopped.

Prepending the command sent to the ejabberd user's shell with "exec" fixes this behaviour for me, because su(1) then kills the Erlang process instead of the login shell.

