### PR TITLE
Dockerfile: Include an entrypoint script for ejabberdctl

### DIFF
--- a/.github/container/Dockerfile
+++ b/.github/container/Dockerfile
@@ -126,6 +126,10 @@ RUN home_root_dir=$(echo $HOME | sed 's|\(.*\)/.*|\1 |') \
         \nexport SPOOL_DIR=/$HOME/database \
         \nexec /$(find $home_root_dir -name ejabberdctl) \"\$@\"" \
             > usr/local/bin/ejabberdctl \
+    && echo -e \
+        "#!/bin/sh \
+        \n \
+        \nexec ejabberdctl \"\$@\"" > usr/local/bin/run.sh \
     && chmod +x usr/local/bin/* \
     && scanelf --needed --nobanner --format '%n#p' --recursive $home_root_dir \
         | tr ',' '\n' \
@@ -186,5 +190,5 @@ USER $USER
 VOLUME ["/$HOME"]
 EXPOSE 1883 4369-4399 5210 5222 5269 5280 5443
 
-ENTRYPOINT ["/sbin/tini","--","ejabberdctl"]
+ENTRYPOINT ["/sbin/tini","--","run.sh"]
 CMD ["foreground"]


### PR DESCRIPTION
Hi @badlop 

The entrypoint script serves as a placeholder, so that admins can replace it with an actual entrypoint script, e.g. for initiating ejabberd clusters, through mounting it to the path `/usr/local/bin/run.sh`.

This PR does not change anything of the existing functions of the image.

Motivation:
I would like to use the image as basis for the [helm-chart](https://github.com/sando38/helm-ejabberd) with these [scripts](https://github.com/sando38/helm-ejabberd/tree/main/image/78f81de252dc932cd47b91d1a84ca8e8f0647498/scripts) and not rely on a custom image in the end. 