### PR TITLE
Dockerfile: add missing dependency for mssql databases

### DIFF
--- a/.github/container/Dockerfile
+++ b/.github/container/Dockerfile
@@ -157,7 +157,9 @@ RUN apk -U upgrade --available --no-cache \
     && apk add --no-cache \
         $(cat /tmp/runDeps) \
         so:libcap.so.2 \
-        tini
+        so:libtdsodbc.so.0 \
+        tini \
+    && ln -fs /usr/lib/libtdsodbc.so.0 /usr/lib/libtdsodbc.so
 
 ARG USER
 ARG UID


### PR DESCRIPTION
Error log without the change:
```
2023-08-12 08:54:13.295609+00:00 [warning] mssql connection failed:
** Reason: {"01000",0,
            "[unixODBC][Driver Manager]Can't open lib 'libtdsodbc.so' : file not found Connection to database failed."}
** Retry after: 5 seconds
2023-08-12 08:54:13.296471+00:00 [warning] mssql connection failed:
** Reason: {"01000",0,
            "[unixODBC][Driver Manager]Can't open lib 'libtdsodbc.so' : file not found Connection to database failed."}
** Retry after: 5 seconds
```

Binaries/installers are also "affected", meaning, `METHOD=package` needs the additional dependency as well. 

Update:
Currently, it is advised for users, who want to use the installer and rely on a MS SQL backend, to additionally install `libtdsodbc` libraries on their machine due to the nature of the odbc drivers being dynamic depending on the respective odbc backend in use. The installer cannot ship a hard linked driver.
