### PR TITLE
Improve get_roster command result: show groups as a list

### DIFF
--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -335,7 +335,7 @@ call_command([CmdString | Args], Auth, _AccessCommands, Version) ->
 							ArgsFormatted,
 							CI2,
 							Version),
-	    format_result(Result, ResultFormat);
+	    format_result_preliminary(Result, ResultFormat);
 	{'EXIT', {function_clause,[{lists,zip,[A1,A2|_], _} | _]}} ->
 	    {NumCompa, TextCompa} =
 		case {length(A1), length(A2)} of
@@ -385,6 +385,11 @@ format_arg2(Arg, Parse)->
 %% Format result
 %%-----------------------------
 
+format_result_preliminary(Result, {A, {list, B}}) ->
+    format_result(Result, {A, {top_result_list, B}});
+format_result_preliminary(Result, ResultFormat) ->
+    format_result(Result, ResultFormat).
+
 format_result({error, ErrorAtom}, _) ->
     {io_lib:format("Error: ~p", [ErrorAtom]), make_status(error)};
 
@@ -421,6 +426,16 @@ format_result(Code, {_Name, rescode}) ->
 format_result({Code, Text}, {_Name, restuple}) ->
     {io_lib:format("~ts", [Text]), make_status(Code)};
 
+format_result([], {_Name, {top_result_list, _ElementsDef}}) ->
+    "";
+format_result([FirstElement | Elements], {_Name, {top_result_list, ElementsDef}}) ->
+    [format_result(FirstElement, ElementsDef) |
+     lists:map(
+       fun(Element) ->
+	       ["\n" | format_result(Element, ElementsDef)]
+       end,
+       Elements)];
+
 %% The result is a list of something: [something()]
 format_result([], {_Name, {list, _ElementsDef}}) ->
     "";
@@ -430,7 +445,7 @@ format_result([FirstElement | Elements], {_Name, {list, ElementsDef}}) ->
      %% If there are more elements, put always first a newline character
      lists:map(
        fun(Element) ->
-	       ["\n" | format_result(Element, ElementsDef)]
+	       [";" | format_result(Element, ElementsDef)]
        end,
        Elements)];
 
@@ -755,7 +770,10 @@ print_usage_help(MaxC, ShCode) ->
 	 "\n",
 	 "Please note that 'ejabberdctl' shows all ejabberd commands,\n",
 	 "even those that cannot be used in the shell with ejabberdctl.\n",
-	 "Those commands can be identified because their description starts with: *"],
+	 "Those commands can be identified because their description starts with: *\n",
+	 "\n",
+	 "Some commands return lists, like get_roster and get_user_subscriptions.\n",
+	 "In those commands, the elements in the list are separated with: ;\n"],
     ArgsDef = [],
     C = #ejabberd_commands{
 	   name = help,

--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -835,6 +835,11 @@ filter_commands_regexp(All, Glob) ->
       end,
       All).
 
+maybe_add_policy_arguments(Args, user) ->
+    [{user, binary}, {host, binary} | Args];
+maybe_add_policy_arguments(Args, _) ->
+    Args.
+
 -spec print_usage_command(Cmd::string(), MaxC::integer(),
                           ShCode::boolean(), Version::integer()) -> ok.
 print_usage_command(Cmd, MaxC, ShCode, Version) ->
@@ -847,13 +852,15 @@ print_usage_command2(Cmd, C, MaxC, ShCode) ->
 		     tags = TagsAtoms,
 		     definer = Definer,
 		     desc = Desc,
-		     args = ArgsDef,
+		     args = ArgsDefPreliminary,
+		     policy = Policy,
 		     longdesc = LongDesc,
 		     result = ResultDef} = C,
 
     NameFmt = ["  ", ?B("Command Name"), ": ", ?C(Cmd), "\n"],
 
     %% Initial indentation of result is 13 = length("  Arguments: ")
+    ArgsDef = maybe_add_policy_arguments(ArgsDefPreliminary, Policy),
     Args = [format_usage_ctype(ArgDef, 13) || ArgDef <- ArgsDef],
     ArgsMargin = lists:duplicate(13, $\s),
     ArgsListFmt = case Args of


### PR DESCRIPTION
This PR improves the `get_roster` command, and fixes ejabberdctl to fully support that command and other ones like that.

This changes the API, so the release notes should describe it. For example:

---

### Changes in `get_roster` command

There are some changes in the result output of the `get_roster` command defined in `mod_admin_extra`:
- `ask` is renamed to `pending`
- `group` is renamed to `groups`
- the new `groups` is a list with all the group names
- a contact that is in several groups is now listed only once, and the groups are properly listed.

For example, let's say that `admin@localhost` has two contacts: a contact is present in two groups (`group1` and `group2`), the other contact is only present in a group (`group3`).

The [old get_roster command in ejabberd 23.04](https://docs.ejabberd.im/archive/23_04/admin-api/#get-roster) and previous versions was like:

```
$ ejabberdctl get_roster admin localhost
jan@localhost jan   none    subscribe       group1
jan@localhost jan   none    subscribe       group2
tom@localhost tom   none    subscribe       group3
```

The new [get_roster command](https://docs.ejabberd.im/developer/ejabberd-api/admin-api/#get-roster) in ejabberd 23.XX and newer versions returns as result:

```
$ ejabberdctl get_roster admin localhost
jan@localhost jan   none    subscribe       group1;group2
tom@localhost tom   none    subscribe       group3
```

Notice that the `ejabberdctl` command-line tool since now will represent list elements in results separated with `;`
