### PR TITLE
fix: invalid CTL_ON_CREATE usage in docker-compose example

### DIFF
--- a/CONTAINER.md
+++ b/CONTAINER.md
@@ -227,7 +227,7 @@ abort start, this can be disabled by prefixing commands with `!`
 Example usage (or check the [full example](#customized-example)):
 ```yaml
     environment:
-      - CTL_ON_CREATE=\! register admin localhost asd
+      - CTL_ON_CREATE=! register admin localhost asd
       - CTL_ON_START=stats registeredusers ;
                      check_password admin localhost asd ;
                      status
@@ -435,7 +435,7 @@ services:
     environment:
       - ERLANG_NODE_ARG=ejabberd@main
       - ERLANG_COOKIE=dummycookie123
-      - CTL_ON_CREATE=\! register admin localhost asd
+      - CTL_ON_CREATE=! register admin localhost asd
 
   replica:
     image: ghcr.io/processone/ejabberd


### PR DESCRIPTION
Hey guys,

I have been checking out the new feature introduced in https://github.com/processone/docker-ejabberd/issues/110 which is great but noticed that the example provided in the repo does not work.

As stated by @prefiks in https://github.com/processone/docker-ejabberd/issues/110#issuecomment-1941127153 the CTL_ON_CREATE variable value should look like `CTL_ON_CREATE=! register admin localhost asd`. There is no need to escape the `!` which actually breaks the script. Just a small typo that probably got in a way when adjusting the docs. Please see the below logs:

**Faulty example (based on docs in repo)**

```yaml
services:
  ejabberd:
    image: ghcr.io/processone/ejabberd:24.02
    container_name: ejabberd
    environment:
      - CTL_ON_CREATE=! register admin localhost asd
      - CTL_ON_START=\! check_password admin localhost notworking
    ports:
      - "5222:5222"
      - "5269:5269"
      - "5280:5280"
      - "5443:5443"
    volumes:
      - ./database:/opt/ejabberd/database
```

**Logs of the faulty example**

```shell
❯ docker compose up                                    
[+] Running 1/2
 ✔ Network ejabberd_default  Created                                                                                                            0.0s 
 ⠋ Container ejabberd        Created                                                                                                            0.1s 
Attaching to ejabberd
ejabberd  | 2024-04-19 14:21:04.793575+00:00 [info] Loading configuration from /opt/ejabberd/conf/ejabberd.yml
ejabberd  | 2024-04-19 14:21:04.994776+00:00 [info] Configuration loaded successfully
ejabberd  | 2024-04-19 14:21:05.085855+00:00 [info] Got no NOTIFY_SOCKET, notifications disabled
ejabberd  | 2024-04-19 14:21:05.093108+00:00 [info] Building language translation cache
ejabberd  | 2024-04-19 14:21:05.149478+00:00 [info] Creating Mnesia ram table 'ejabberd_commands'
ejabberd  | 2024-04-19 14:21:05.181508+00:00 [info] Creating Mnesia ram table 'route'
ejabberd  | 2024-04-19 14:21:05.185786+00:00 [info] Creating Mnesia ram table 'route_multicast'
ejabberd  | 2024-04-19 14:21:05.193557+00:00 [info] Creating Mnesia ram table 'session'
ejabberd  | 2024-04-19 14:21:05.196680+00:00 [info] Creating Mnesia ram table 'session_counter'
ejabberd  | 2024-04-19 14:21:05.202276+00:00 [info] Creating Mnesia ram table 's2s'
ejabberd  | 2024-04-19 14:21:05.205129+00:00 [info] Creating Mnesia ram table 'temporarily_blocked'
ejabberd  | 2024-04-19 14:21:05.211633+00:00 [info] Loading modules for localhost
ejabberd  | 2024-04-19 14:21:05.213157+00:00 [warning] Mnesia backend for mod_mam is not recommended: it's limited to 2GB and often gets corrupted when reaching this limit. SQL backend is recommended. Namely, for small servers SQLite is a preferred choice because it's very easy to configure.
ejabberd  | 2024-04-19 14:21:05.213257+00:00 [info] Creating Mnesia disc_only table 'archive_msg'
ejabberd  | 2024-04-19 14:21:05.219886+00:00 [info] Creating Mnesia disc_only table 'archive_prefs'
ejabberd  | 2024-04-19 14:21:05.228363+00:00 [info] Creating Mnesia disc_only table 'motd'
ejabberd  | 2024-04-19 14:21:05.233929+00:00 [info] Creating Mnesia disc_only table 'motd_users'
ejabberd  | 2024-04-19 14:21:05.242453+00:00 [info] Creating Mnesia disc_only table 'offline_msg'
ejabberd  | 2024-04-19 14:21:05.259857+00:00 [info] Creating Mnesia disc_only table 'caps_features'
ejabberd  | 2024-04-19 14:21:05.265456+00:00 [info] Creating Mnesia ram table 'pubsub_last_item'
ejabberd  | 2024-04-19 14:21:05.269755+00:00 [info] Creating Mnesia disc table 'pubsub_index'
ejabberd  | 2024-04-19 14:21:05.275856+00:00 [info] Creating Mnesia disc table 'pubsub_node'
ejabberd  | 2024-04-19 14:21:05.279978+00:00 [info] Creating Mnesia disc table 'pubsub_state'
ejabberd  | 2024-04-19 14:21:05.286089+00:00 [info] Creating Mnesia disc_only table 'pubsub_item'
ejabberd  | 2024-04-19 14:21:05.297889+00:00 [info] Creating Mnesia disc table 'pubsub_orphan'
ejabberd  | 2024-04-19 14:21:05.305073+00:00 [info] Creating Mnesia ram table 'mod_register_ip'
ejabberd  | 2024-04-19 14:21:05.309219+00:00 [info] Creating Mnesia disc_only table 'roster'
ejabberd  | 2024-04-19 14:21:05.320362+00:00 [info] Creating Mnesia disc_only table 'roster_version'
ejabberd  | 2024-04-19 14:21:05.339341+00:00 [info] Going to offer STUN/TURN service: 172.21.0.2:3478 (udp)
ejabberd  | 2024-04-19 14:21:05.344151+00:00 [info] Creating Mnesia disc table 'sr_group'
ejabberd  | 2024-04-19 14:21:05.350324+00:00 [info] Creating Mnesia disc table 'sr_user'
ejabberd  | 2024-04-19 14:21:05.368093+00:00 [info] Creating Mnesia disc table 'muc_room'
ejabberd  | 2024-04-19 14:21:05.373263+00:00 [info] Creating Mnesia disc table 'muc_registered'
ejabberd  | 2024-04-19 14:21:05.377566+00:00 [info] Creating Mnesia ram table 'muc_online_room'
ejabberd  | 2024-04-19 14:21:05.381142+00:00 [info] Creating Mnesia disc_only table 'private_storage'
ejabberd  | 2024-04-19 14:21:05.390617+00:00 [info] Creating Mnesia disc_only table 'privacy'
ejabberd  | 2024-04-19 14:21:05.405981+00:00 [info] Creating Mnesia disc_only table 'vcard'
ejabberd  | 2024-04-19 14:21:05.409997+00:00 [info] Creating Mnesia disc table 'vcard_search'
ejabberd  | 2024-04-19 14:21:05.425277+00:00 [info] Creating Mnesia ram table 'bosh'
ejabberd  | 2024-04-19 14:21:05.427594+00:00 [info] Creating Mnesia disc_only table 'push_session'
ejabberd  | 2024-04-19 14:21:05.437227+00:00 [info] Creating Mnesia disc_only table 'last_activity'
ejabberd  | 2024-04-19 14:21:05.447252+00:00 [info] Creating Mnesia disc_only table 'mqtt_pub'
ejabberd  | 2024-04-19 14:21:05.454173+00:00 [info] Creating Mnesia ram table 'mqtt_session'
ejabberd  | 2024-04-19 14:21:05.457219+00:00 [info] Creating Mnesia ram table 'mqtt_sub'
ejabberd  | 2024-04-19 14:21:05.465927+00:00 [info] Building MQTT cache for localhost, this may take a while
ejabberd  | 2024-04-19 14:21:05.469723+00:00 [info] Creating Mnesia ram table 'bytestream'
ejabberd  | 2024-04-19 14:21:05.472150+00:00 [warning] The option captcha_cmd is not configured, but some module wants to use the CAPTCHA feature.
ejabberd  | 2024-04-19 14:21:05.474510+00:00 [info] Creating Mnesia disc_only table 'passwd'
ejabberd  | 2024-04-19 14:21:05.478692+00:00 [info] Creating Mnesia ram table 'reg_users_counter'
ejabberd  | 2024-04-19 14:21:05.488504+00:00 [info] Creating Mnesia disc_only table 'oauth_token'
ejabberd  | 2024-04-19 14:21:05.492667+00:00 [info] Creating Mnesia disc table 'oauth_client'
ejabberd  | 2024-04-19 14:21:05.510616+00:00 [info] Waiting for Mnesia synchronization to complete
ejabberd  | 2024-04-19 14:21:05.526635+00:00 [warning] Invalid certificate in /opt/ejabberd/conf/server.pem: at line 53: self-signed certificate
ejabberd  | 2024-04-19 14:21:05.543796+00:00 [warning] No certificate found matching pubsub.localhost
ejabberd  | 2024-04-19 14:21:05.543882+00:00 [warning] No certificate found matching proxy.localhost
ejabberd  | 2024-04-19 14:21:05.543914+00:00 [warning] No certificate found matching conference.localhost
ejabberd  | 2024-04-19 14:21:05.543971+00:00 [warning] No certificate found matching upload.localhost
ejabberd  | 2024-04-19 14:21:05.545013+00:00 [info] ejabberd 24.2.0 is started in the node ejabberd@localhost in 0.80s
ejabberd  | 2024-04-19 14:21:05.545128+00:00 [info] Start accepting UDP connections at [::]:3478 for ejabberd_stun
ejabberd  | 2024-04-19 14:21:05.545199+00:00 [info] Start accepting TCP connections at [::]:1883 for mod_mqtt
ejabberd  | 2024-04-19 14:21:05.545159+00:00 [info] Start accepting TCP connections at 172.21.0.2:7777 for mod_proxy65_stream
ejabberd  | 2024-04-19 14:21:05.545155+00:00 [info] Start accepting TCP connections at [::]:5222 for ejabberd_c2s
ejabberd  | 2024-04-19 14:21:05.545192+00:00 [info] Start accepting TLS connections at [::]:5443 for ejabberd_http
ejabberd  | 2024-04-19 14:21:05.545181+00:00 [info] Start accepting TLS connections at [::]:5223 for ejabberd_c2s
ejabberd  | 2024-04-19 14:21:05.545187+00:00 [info] Start accepting TCP connections at [::]:5269 for ejabberd_s2s_in
ejabberd  | 2024-04-19 14:21:05.545193+00:00 [info] Start accepting TCP connections at [::]:5280 for ejabberd_http
ejabberd  | :> ejabberdctl register admin localhost asd
ejabberd  | User admin@localhost successfully registered
ejabberd  | :> ejabberdctl \! check_password admin localhost notworking
ejabberd  | Error: unknown command '\!'. Did you mean 'gc'?
ejabberd  | :> FAILURE in command '\! check_password admin localhost notworking' !!! Stopping ejabberd...
ejabberd  | [os_mon] memory supervisor port (memsup): Erlang has closed
ejabberd exited with code 1
```

**Working example**

```yaml
services:
  ejabberd:
    image: ghcr.io/processone/ejabberd:24.02
    container_name: ejabberd
    environment:
      - CTL_ON_CREATE=! register admin localhost asd
      - CTL_ON_START=! check_password admin localhost notworking
    ports:
      - "5222:5222"
      - "5269:5269"
      - "5280:5280"
      - "5443:5443"
    volumes:
      - ./database:/opt/ejabberd/database
```

**Working example logs**

```shell
❯ docker compose up                                   
[+] Running 1/2
 ✔ Network ejabberd_default  Created                                                                                                            0.0s 
 ⠋ Container ejabberd        Created                                                                                                            0.1s 
Attaching to ejabberd
ejabberd  | 2024-04-19 14:22:21.039783+00:00 [info] Loading configuration from /opt/ejabberd/conf/ejabberd.yml
ejabberd  | 2024-04-19 14:22:21.241100+00:00 [info] Configuration loaded successfully
ejabberd  | 2024-04-19 14:22:21.331984+00:00 [info] Got no NOTIFY_SOCKET, notifications disabled
ejabberd  | 2024-04-19 14:22:21.338093+00:00 [info] Building language translation cache
ejabberd  | 2024-04-19 14:22:21.396485+00:00 [info] Creating Mnesia ram table 'ejabberd_commands'
ejabberd  | 2024-04-19 14:22:21.421980+00:00 [info] Creating Mnesia ram table 'route'
ejabberd  | 2024-04-19 14:22:21.425709+00:00 [info] Creating Mnesia ram table 'route_multicast'
ejabberd  | 2024-04-19 14:22:21.433612+00:00 [info] Creating Mnesia ram table 'session'
ejabberd  | 2024-04-19 14:22:21.436688+00:00 [info] Creating Mnesia ram table 'session_counter'
ejabberd  | 2024-04-19 14:22:21.443244+00:00 [info] Creating Mnesia ram table 's2s'
ejabberd  | 2024-04-19 14:22:21.447040+00:00 [info] Creating Mnesia ram table 'temporarily_blocked'
ejabberd  | 2024-04-19 14:22:21.453472+00:00 [info] Loading modules for localhost
ejabberd  | 2024-04-19 14:22:21.455405+00:00 [warning] Mnesia backend for mod_mam is not recommended: it's limited to 2GB and often gets corrupted when reaching this limit. SQL backend is recommended. Namely, for small servers SQLite is a preferred choice because it's very easy to configure.
ejabberd  | 2024-04-19 14:22:21.455501+00:00 [info] Creating Mnesia disc_only table 'archive_msg'
ejabberd  | 2024-04-19 14:22:21.460663+00:00 [info] Creating Mnesia disc_only table 'archive_prefs'
ejabberd  | 2024-04-19 14:22:21.469575+00:00 [info] Creating Mnesia disc_only table 'motd'
ejabberd  | 2024-04-19 14:22:21.474892+00:00 [info] Creating Mnesia disc_only table 'motd_users'
ejabberd  | 2024-04-19 14:22:21.486187+00:00 [info] Creating Mnesia disc_only table 'offline_msg'
ejabberd  | 2024-04-19 14:22:21.503168+00:00 [info] Creating Mnesia disc_only table 'caps_features'
ejabberd  | 2024-04-19 14:22:21.508162+00:00 [info] Creating Mnesia ram table 'pubsub_last_item'
ejabberd  | 2024-04-19 14:22:21.512802+00:00 [info] Creating Mnesia disc table 'pubsub_index'
ejabberd  | 2024-04-19 14:22:21.519504+00:00 [info] Creating Mnesia disc table 'pubsub_node'
ejabberd  | 2024-04-19 14:22:21.523502+00:00 [info] Creating Mnesia disc table 'pubsub_state'
ejabberd  | 2024-04-19 14:22:21.529310+00:00 [info] Creating Mnesia disc_only table 'pubsub_item'
ejabberd  | 2024-04-19 14:22:21.544568+00:00 [info] Creating Mnesia disc table 'pubsub_orphan'
ejabberd  | 2024-04-19 14:22:21.549845+00:00 [info] Creating Mnesia ram table 'mod_register_ip'
ejabberd  | 2024-04-19 14:22:21.553475+00:00 [info] Creating Mnesia disc_only table 'roster'
ejabberd  | 2024-04-19 14:22:21.563587+00:00 [info] Creating Mnesia disc_only table 'roster_version'
ejabberd  | 2024-04-19 14:22:21.584157+00:00 [info] Going to offer STUN/TURN service: 172.22.0.2:3478 (udp)
ejabberd  | 2024-04-19 14:22:21.589282+00:00 [info] Creating Mnesia disc table 'sr_group'
ejabberd  | 2024-04-19 14:22:21.595819+00:00 [info] Creating Mnesia disc table 'sr_user'
ejabberd  | 2024-04-19 14:22:21.616649+00:00 [info] Creating Mnesia disc table 'muc_room'
ejabberd  | 2024-04-19 14:22:21.622071+00:00 [info] Creating Mnesia disc table 'muc_registered'
ejabberd  | 2024-04-19 14:22:21.627947+00:00 [info] Creating Mnesia ram table 'muc_online_room'
ejabberd  | 2024-04-19 14:22:21.632168+00:00 [info] Creating Mnesia disc_only table 'private_storage'
ejabberd  | 2024-04-19 14:22:21.641620+00:00 [info] Creating Mnesia disc_only table 'privacy'
ejabberd  | 2024-04-19 14:22:21.657314+00:00 [info] Creating Mnesia disc_only table 'vcard'
ejabberd  | 2024-04-19 14:22:21.661695+00:00 [info] Creating Mnesia disc table 'vcard_search'
ejabberd  | 2024-04-19 14:22:21.678254+00:00 [info] Creating Mnesia ram table 'bosh'
ejabberd  | 2024-04-19 14:22:21.681025+00:00 [info] Creating Mnesia disc_only table 'push_session'
ejabberd  | 2024-04-19 14:22:21.690262+00:00 [info] Creating Mnesia disc_only table 'last_activity'
ejabberd  | 2024-04-19 14:22:21.700235+00:00 [info] Creating Mnesia disc_only table 'mqtt_pub'
ejabberd  | 2024-04-19 14:22:21.706705+00:00 [info] Creating Mnesia ram table 'mqtt_session'
ejabberd  | 2024-04-19 14:22:21.710204+00:00 [info] Creating Mnesia ram table 'mqtt_sub'
ejabberd  | 2024-04-19 14:22:21.719757+00:00 [info] Building MQTT cache for localhost, this may take a while
ejabberd  | 2024-04-19 14:22:21.722984+00:00 [info] Creating Mnesia ram table 'bytestream'
ejabberd  | 2024-04-19 14:22:21.725236+00:00 [warning] The option captcha_cmd is not configured, but some module wants to use the CAPTCHA feature.
ejabberd  | 2024-04-19 14:22:21.727682+00:00 [info] Creating Mnesia disc_only table 'passwd'
ejabberd  | 2024-04-19 14:22:21.732888+00:00 [info] Creating Mnesia ram table 'reg_users_counter'
ejabberd  | 2024-04-19 14:22:21.742382+00:00 [info] Creating Mnesia disc_only table 'oauth_token'
ejabberd  | 2024-04-19 14:22:21.746760+00:00 [info] Creating Mnesia disc table 'oauth_client'
ejabberd  | 2024-04-19 14:22:21.764329+00:00 [info] Waiting for Mnesia synchronization to complete
ejabberd  | 2024-04-19 14:22:21.780234+00:00 [warning] Invalid certificate in /opt/ejabberd/conf/server.pem: at line 53: self-signed certificate
ejabberd  | 2024-04-19 14:22:21.797895+00:00 [warning] No certificate found matching pubsub.localhost
ejabberd  | 2024-04-19 14:22:21.798006+00:00 [warning] No certificate found matching proxy.localhost
ejabberd  | 2024-04-19 14:22:21.798051+00:00 [warning] No certificate found matching conference.localhost
ejabberd  | 2024-04-19 14:22:21.798082+00:00 [warning] No certificate found matching upload.localhost
ejabberd  | 2024-04-19 14:22:21.798979+00:00 [info] ejabberd 24.2.0 is started in the node ejabberd@localhost in 0.81s
ejabberd  | 2024-04-19 14:22:21.799591+00:00 [info] Start accepting TLS connections at [::]:5223 for ejabberd_c2s
ejabberd  | 2024-04-19 14:22:21.799595+00:00 [info] Start accepting TCP connections at [::]:5280 for ejabberd_http
ejabberd  | 2024-04-19 14:22:21.799603+00:00 [info] Start accepting TCP connections at 172.22.0.2:7777 for mod_proxy65_stream
ejabberd  | 2024-04-19 14:22:21.799647+00:00 [info] Start accepting UDP connections at [::]:3478 for ejabberd_stun
ejabberd  | 2024-04-19 14:22:21.799689+00:00 [info] Start accepting TCP connections at [::]:5222 for ejabberd_c2s
ejabberd  | 2024-04-19 14:22:21.799685+00:00 [info] Start accepting TLS connections at [::]:5443 for ejabberd_http
ejabberd  | 2024-04-19 14:22:21.799609+00:00 [info] Start accepting TCP connections at [::]:1883 for mod_mqtt
ejabberd  | 2024-04-19 14:22:21.799662+00:00 [info] Start accepting TCP connections at [::]:5269 for ejabberd_s2s_in
ejabberd  | :> ejabberdctl register admin localhost asd
ejabberd  | User admin@localhost successfully registered
ejabberd  | :> ejabberdctl check_password admin localhost notworking
ejabberd  | Error: false
ejabberd  | :> FAILURE in command 'check_password admin localhost notworking' !!! Ignoring result
```


Let me know if you need me to provide more details or something does not look right. Thanks for the great docker image!