### PR TITLE
Fix template error for elixir-enabled applications.

### DIFF
--- a/src/ejabberd_logger.erl
+++ b/src/ejabberd_logger.erl
@@ -370,7 +370,7 @@ console_template() ->
         andalso
         'Elixir.System':version() >= <<"1.15">> of
         true ->
-            [date, " ", time, " [", level, "] ", message, "\n"];
+            [date, " ", time, " [", level, "] ", msg, "\n"];
         false ->
             [time, " [", level, "] " | msg()]
     end.


### PR DESCRIPTION
Hello, I have an Elixir-based app that is pulling ejabberd as a dependency and noticed when I run the app as a release, the console logs are missing the messages:

```
 2024-07-12 14:17:24.108891-06:00 [info]
 2024-07-12 14:17:24.142699-06:00 [info]
 2024-07-12 14:17:24.170040-06:00 [info]
 2024-07-12 14:17:24.172795-06:00 [info]
 2024-07-12 14:17:24.225542-06:00 [info]
 2024-07-12 14:17:24.225665-06:00 [warning]
```
I realized that there is a bug in the template that uses `message` when it needs to be `msg` (as seen in the Erlang documentation https://www.erlang.org/doc/apps/kernel/logger_formatter#t:template/0)

After making this change, I get the following, correct logs:
```
 2024-07-12 14:45:59.809550-06:00 [info] Loading configuration from ejabberd.yml
 2024-07-12 14:45:59.842689-06:00 [info] Configuration loaded successfully
 2024-07-12 14:45:59.867775-06:00 [info] Got no NOTIFY_SOCKET, notifications disabled
 2024-07-12 14:45:59.870429-06:00 [info] Building language translation cache
 2024-07-12 14:45:59.920871-06:00 [info] Loading modules for localhost
 2024-07-12 14:45:59.920980-06:00 [warning] Mnesia backend for mod_mam is not recommended: it's limited to 2GB and often gets corrupted when reaching this limit. SQL backend is recommended. Namely, for small servers SQLite is a preferred choice because it's very easy to configure.
```