### PR TITLE
Mix release fails with logger application error

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,11 +43,11 @@ defmodule Ejabberd.MixProject do
 
   def application do
     [mod: {:ejabberd_app, []},
-     applications: [:idna, :inets, :kernel, :sasl, :ssl, :stdlib, :mix,
-                    :fast_tls, :fast_xml, :fast_yaml, :jose,
+     extra_applications: [:idna, :inets, :kernel, :sasl, :ssl, :stdlib, :mix,
+                    :fast_tls, :fast_xml, :fast_yaml, :jose, :logger,
                     :p1_utils, :stringprep, :syntax_tools, :yconf, :xmpp]
      ++ cond_apps(),
-     included_applications: [:mnesia, :os_mon, :logger,
+     included_applications: [:mnesia, :os_mon,
                              :cache_tab, :eimp, :mqtree, :p1_acme,
                              :p1_oauth2, :pkix]
      ++ cond_included_apps()]


### PR DESCRIPTION
When attempting a `mix release` on a new mix project, I get the following error:
```bash
** (Mix) :logger is listed both as a regular application and as an included application
```
Repro steps:
1. `mix new ejabberd_mix_release_issue`
2. Within `mix.exs`, add `{:ejabberd, "~> 24.7"}` in the list of deps.
3. `mix deps.get`
4. `mix compile`
5. `mix release`

Updating the `mix.exs` within ejabberd seems to fix the issue as I'm able to generate a release and the application is able to start up (provided there's an `ejabberd.cfg` file 🙂)
