### PR TITLE
CI: Add XMPP Interop tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,7 @@ jobs:
         grep -q "is started in" $RE/logs/ejabberd.log
 
     - name: Run XMPP Interoperability Tests against CI server.
+      if: matrix.otp == '26'
       continue-on-error: true
       uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.4.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,28 @@ jobs:
         cat $RE/logs/ejabberd.log
         grep -q "is stopped in" $RE/logs/ejabberd.log
 
-    - name: Check Development Release
+    - name: Start Development Release
       run: |
         make dev
         RE=_build/dev/rel/ejabberd
+        sed -i 's/starttls_required: true/starttls_required: false/g'  $RE/conf/ejabberd.yml
         $RE/bin/ejabberdctl start
         $RE/bin/ejabberdctl started
+        $RE/bin/ejabberdctl register admin localhost admin
+        grep -q "is started in" $RE/logs/ejabberd.log
+
+    - name: Run XMPP Interoperability Tests against CI server.
+      continue-on-error: true
+      uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.4.0
+      with:
+        domain: 'localhost'
+        adminAccountUsername: 'admin'
+        adminAccountPassword: 'admin'
+
+    - name: Stop Development Release
+      if: always()
+      run: |
+        RE=_build/dev/rel/ejabberd
         $RE/bin/ejabberdctl stop
         $RE/bin/ejabberdctl stopped
         cat $RE/logs/ejabberd.log


### PR DESCRIPTION
Modifies the CI build to integrate the GitHub Action-based test runner from the [XMPP Interop Testing project](https://xmpp-interop-testing.github.io). This executes additional integration tests that help verify ejabberd's compliance with XMPP specifications. To date, approximately 400 tests are included.

In this commit, none of the tests are excluded, which likely results in false positives. Therefor, the 'continue-on-error' flag is set, which intends to prevent the 'build from failing' even when one or more of the interop tests fail. This should ideally be removed in a later commit, after the configuration has been fine-tuned toward. If you choose to accept this PR, I would advise to iteratively evaluate the test responses, and for failing tests either adjust ejabberd's functionality (in case an actual bug was identifier), or to add a failing test to the configurable list of test exclusions.

I'm far from an expert in the ejabberd continuous integration setup. There might be more appropriate ways to integrate these tests.

I've rather arbitrarily picked the server that is build and started in the 'Development Release' step as the server that is targeted by these tests. Perhaps the 'Production Release' server is more appropriate?

I'm unsure if the splitting up of the "Check Development Release" step, in distinct 'start' and 'stop' steps (in between the new tests are executed) is appropriate. Does it affect the original purpose of this step?
