### PR TITLE
mix_pam: Remove 'Channels' roster group of mix channels

### DIFF
--- a/src/mod_mix_pam.erl
+++ b/src/mod_mix_pam.erl
@@ -227,7 +227,7 @@ get_mix_roster_items(Acc, {LUser, LServer}) ->
                         name = <<>>,
                         subscription = both,
                         ask = undefined,
-                        groups = [<<"Channels">>],
+                        groups = [],
                         mix_channel = #mix_roster_channel{participant_id = Id}
                     }
                 end, Channels);


### PR DESCRIPTION
This isn't specified and was probably only meant for debugging. In real
clients having this (forced) 'Channels' group is undesireable in most
cases.
