### PR TITLE
Makefile.in: introduce INSTALL_NOT_VERSIONED_DEP

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -277,7 +277,11 @@ indent:
 
 JOIN_PATHS=$(if $(wordlist 2,1000,$(1)),$(firstword $(1))/$(call JOIN_PATHS,$(wordlist 2,1000,$(1))),$(1))
 
+ifdef INSTALL_NOT_VERSIONED_DEP
+VERSIONED_DEP=$(1)
+else
 VERSIONED_DEP=$(if $(DEP_$(1)_VERSION),$(DEP_$(1)_VERSION),$(1))
+endif
 
 DEPIX:=$(words $(subst /, ,$(DEPSDIR)))
 LIBIX:=$(shell expr "$(DEPIX)" + 2)


### PR DESCRIPTION
Some distributives installs all dependencies as `/usr/local/lib/ejabberd/xxx` and adding `-1.2.3` to each of them just make things more noisy.

Here, I suggested a trivial changes with undocumented variable which maintaner may discover and enjoy, when he need it.

We are open to contributions for ejabberd, as GitHub pull requests (PR).
Here are a few points to consider before submitting your PR. (You can
remove the whole text after reading.)

1. Does this PR address an issue? Please reference it in the PR
   description.

2. Have you properly described the proposed change?

3. Please make sure the change is atomic and does only touch the needed
   modules. If you have other changes/fixes to provide, please submit
   them as separate PRs.

4. If your change or new feature involves storage backends, did you make
   sure your change works with all backends?

5. Do you provide tests? How can we check the behavior of the code?

6. Did you consider documentation changes in the
   processone/docs.ejabberd.im repository?
