### PR TITLE
feat: support loading Elixir modules for auth

### DIFF
--- a/lib/ejabberd_auth_example.ex
+++ b/lib/ejabberd_auth_example.ex
@@ -1,0 +1,39 @@
+defmodule ModAuthExample do
+  @moduledoc """
+
+  This is a dummy auth module to demonstrate the usage of Elixir to
+  create Ejabberd Auth modules.
+
+  """
+  import Ejabberd.Logger
+  @behaviour :ejabberd_auth
+
+  @impl true
+  def start(host) do
+    info("Using mod_auth_example to authenticate #{host} users")
+    nil
+  end
+
+  @impl true
+  def stop(host) do
+    info("Stop using mod_auth_example to authenticate #{host} users")
+    nil
+  end
+
+  @impl true
+  def check_password("alice", _authz_id, _host, "secret"), do: {:nocache, true}
+  def check_password(_username, _authz_id, _host, _secret), do: {:nocache, false}
+
+  @impl true
+  def user_exists("alice", _host), do: {:nocache, true}
+  def user_exists(_username, _host), do: {:nocache, false}
+
+  @impl true
+  def plain_password_required(_binary), do: true
+
+  @impl true
+  def store_type(_host), do: :external
+
+  @impl true
+  def use_cache(_host), do: false
+end

--- a/src/econf.erl
+++ b/src/econf.erl
@@ -505,10 +505,15 @@ db_type(M) ->
     and_then(
       atom(),
       fun(T) ->
-	      case code:ensure_loaded(db_module(M, T)) of
-		  {module, _} -> T;
-		  {error, _} -> fail({bad_db_type, M, T})
-	      end
+        case code:ensure_loaded(db_module(M, T)) of
+          {module, _} -> T;
+          {error, _} ->
+            ElixirModule = "Elixir." ++ atom_to_list(T),
+            case code:ensure_loaded(list_to_atom(ElixirModule)) of
+              {module, _} -> list_to_atom(ElixirModule);
+              {error, _} -> fail({bad_db_type, M, T})
+            end
+          end
       end).
 
 -spec queue_type() -> yconf:validator(ram | file).

--- a/src/ejabberd.erl
+++ b/src/ejabberd.erl
@@ -177,6 +177,15 @@ module_name([Dir, _, <<H,_/binary>> | _] = Mod) when H >= 65, H =< 90 ->
 	Lib -> <<"Elixir.Ejabberd.", Lib/binary, ".">>
     end,
     misc:binary_to_atom(<<Prefix/binary, Module/binary>>);
+
+module_name([<<"auth">> | T] = Mod) ->
+    case hd(T) of
+        %% T already starts with "Elixir" if an Elixir module is
+        %% loaded with that name, as per `econf:db_type/1`
+        <<"Elixir", _/binary>> ->  misc:binary_to_atom(hd(T));
+        _ -> module_name([<<"ejabberd">>] ++ Mod)
+    end;
+
 module_name([<<"ejabberd">> | _] = Mod) ->
     Module = str:join([erlang_name(M) || M<-Mod], $_),
     misc:binary_to_atom(Module);

--- a/src/ejabberd_auth.erl
+++ b/src/ejabberd_auth.erl
@@ -893,7 +893,7 @@ auth_modules() ->
 auth_modules(Server) ->
     LServer = jid:nameprep(Server),
     Methods = ejabberd_option:auth_method(LServer),
-    [ejabberd:module_name([<<"ejabberd">>, <<"auth">>,
+    [ejabberd:module_name([<<"auth">>,
 			   misc:atom_to_binary(M)])
      || M <- Methods].
 


### PR DESCRIPTION
Allow to specify an Elixir module name in `auth_method`. This would allow to create custom auth modules using Elixir.

If the referenced module, `M`,  cannot be loaded as `ejabberd_auth_M`, try to load it as `Elixir.M`.

This is my first contribution to this repo (and my first in Erlang at all), so please excuse me any basic mistake I could have done. Tell me and I'll fix them :)