### PR TITLE
ejabberdctl: support OpenBSD su

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -133,6 +133,9 @@ exec_cmd()
         as_install_user,OpenBSD)
             su -s /bin/sh "$INSTALLUSER" -c 'exec "$0" "$@"' "$@"
             ;;
+        as_install_user,NetBSD)
+            su "$INSTALLUSER" -c 'exec "$0" "$@"' -- "$@"
+            ;;
         as_install_user,*)
             su -s /bin/sh -c 'exec "$0" "$@"' "$INSTALLUSER" -- "$@"
             ;;


### PR DESCRIPTION
OpenBSD has a different than Linux su:
 1. `-c` before username is treated as login class;
 2. it doesn't require `--` as arguments separator.

Without (1) it complains as:

    su: no such login class: exec "$0" "$@"

and without (2):

    -: --: not found

Here, I've added detection of OS via `uname -s` which routes to the right `su`. I really think that other BSD may need it as well.
