### PR TITLE
Enable allow_unencrypted_sasl2 on websockets

### DIFF
--- a/src/ejabberd_http.erl
+++ b/src/ejabberd_http.erl
@@ -69,6 +69,7 @@
 		default_host,
 		custom_headers,
 		trail = <<>>,
+		allow_unencrypted_sasl2,
 		addr_re,
 		sock_peer_name = none
 	       }).
@@ -133,10 +134,12 @@ init(SockMod, Socket, Opts) ->
 
     CustomHeaders = proplists:get_value(custom_headers, Opts, []),
 
+    AllowUnencryptedSasl2 = proplists:get_bool(allow_unencrypted_sasl2, Opts),
     State = #state{sockmod = SockMod1,
                    socket = Socket1,
 		   custom_headers = CustomHeaders,
 		   options = Opts,
+		   allow_unencrypted_sasl2 = AllowUnencryptedSasl2,
 		   request_handlers = RequestHandlers,
 		   sock_peer_name = SockPeer,
 		   addr_re = RE},
@@ -916,6 +919,8 @@ normalize_path([Part | Path], Norm) ->
 
 listen_opt_type(tag) ->
     econf:binary();
+listen_opt_type(allow_unencrypted_sasl2) ->
+    econf:bool();
 listen_opt_type(request_handlers) ->
     econf:map(
       econf:and_then(
@@ -941,6 +946,7 @@ listen_options() ->
      {protocol_options, undefined},
      {tls, false},
      {tls_compression, false},
+     {allow_unencrypted_sasl2, false},
      {request_handlers, []},
      {tag, <<>>},
      {default_host, undefined},

--- a/src/ejabberd_http_ws.erl
+++ b/src/ejabberd_http_ws.erl
@@ -122,6 +122,7 @@ init([{#ws{ip = IP, http_opts = HOpts}, _} = WS]) ->
                                ({max_ack_queue, _}) -> true;
                                ({ack_timeout, _}) -> true;
                                ({resume_timeout, _}) -> true;
+                               ({allow_unencrypted_sasl2, _}) -> true;
                                ({max_resume_timeout, _}) -> true;
                                ({resend_on_timeout, _}) -> true;
                                ({access, _}) -> true;


### PR DESCRIPTION
https://github.com/processone/ejabberd/commit/47232838 added the allow_unencrypted_sasl2 option, but this was not added to websockets.