### PR TITLE
Kill orphan `epmd` after `ejabberdctl ping`

### DIFF
--- a/ejabberdctl.template
+++ b/ejabberdctl.template
@@ -389,6 +389,7 @@ case $1 in
                  -eval 'net_kernel:connect_node('"'$PEER'"')' \
                  -eval 'io:format("~p~n",[net_adm:ping('"'$PEER'"')])' \
                  -s erlang halt -output text
+        stop_epmd
         ;;
     started)
         set_dist_client


### PR DESCRIPTION
Here a trivial changes that cleanup an orphan `epmd` after `ejabberdctl ping` which migth be used inside some scripts to confirm that ejabberd is stop.