### PR TITLE
Fix misc:json_encode_With_kv_lists

### DIFF
--- a/src/misc.erl
+++ b/src/misc.erl
@@ -141,8 +141,9 @@ json_decode(Bin) ->
 -else.
 json_encode_with_kv_lists(Term) ->
     iolist_to_binary(json:encode(Term,
-		     fun([{_, _} | _] = Val, Encoder) ->
-			 json:encode_key_value_list(Val, Encoder);
+		     fun({[{_, _} | _]} = Val, Encoder) ->
+			 json:encode_key_value_list(element(1, Val), Encoder);
+			({[]}, _Encoder) -> <<"{}">>;
 			(Val, Encoder) ->
 			    json:encode_value(Val, Encoder)
 		     end)).


### PR DESCRIPTION
Jiffy translates `{[{<<"key">>, <<"value">>}]}` to `{"key": "value"}`. To do that with R27 json module we need to match `{[{_, _} | _]}` instead of `[{_, _} | _]`.

Tested `curl https://matrix.@HOST@:8448/_matrix/key/v2/server`

Fix #4338 #4244