### PR TITLE
Don't rewrite "self-addressed" privileged IQs as results.

### DIFF
--- a/src/ejabberd_router.erl
+++ b/src/ejabberd_router.erl
@@ -408,9 +408,9 @@ do_route(OrigPacket1) ->
 
 %% @format-begin
 process_privilege_iq(Packet) ->
-    To = xmpp:get_to(Packet),
+    Type = xmpp:get_type(Packet),
     case xmpp:get_meta(Packet, privilege_iq, none) of
-        {OriginalId, OriginalHost, ReplacedJid} when ReplacedJid == To ->
+        {OriginalId, OriginalHost, ReplacedJid} when (Type == result) or (Type == error) ->
             Privilege = #privilege{forwarded = #forwarded{sub_els = [Packet]}},
             #iq{type = xmpp:get_type(Packet),
                 id = OriginalId,


### PR DESCRIPTION
As described in #4347:

process_privilege_iq is meant to rewrite the result of a privileged IQ into the forwarded form required by XEP-0356 so it can be routed back to the original privileged requester. It checks whether the impersonated JID (`ReplacedJid`) of the original request matches the recipient of the IQ being processed to determine if this is a response to a a privileged IQ (assuming it has privileged-IQ metadata attached).

Unfortunately, it doesn't check the packet type, and this check will also match a privileged-IQ _request_ that is being sent to the same user that's being impersonated. This results in the request itself being rewritten and forwarded back to the sending component, instead of being processed and having the result send back.

Instead, just check for IQ results (either a regular result or an error), and as long as it is marked as being a response to a privileged-IQ, always rewrite it and forward it to the sending component. There's no circumstance under which we _shouldn't_ forward a privileged-IQ response, so we don't need to be tricky about checking whether impersonated-user and recipient match.
