### PR TITLE
New define_keyword option

### DIFF
--- a/src/econf.erl
+++ b/src/econf.erl
@@ -546,14 +546,10 @@ sip_uri() ->
 -spec host() -> yconf:validator(binary()).
 host() ->
     fun(Domain) ->
-	    Host = ejabberd_config:get_myname(),
 	    Hosts = ejabberd_config:get_option(hosts),
-	    Domain1 = (binary())(Domain),
-	    Domain2 = misc:expand_keyword(<<"@HOST@">>, Domain1, Host),
-	    Domain3 = (domain())(Domain2),
-	    case lists:member(Domain3, Hosts) of
-		true -> fail({route_conflict, Domain3});
-		false -> Domain3
+	    case lists:member(Domain, Hosts) of
+		true -> fail({route_conflict, Domain});
+		false -> Domain
 	    end
     end.
 

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -566,7 +566,15 @@ callback_modules(external) ->
 	      end
       end, beams(external));
 callback_modules(all) ->
-    callback_modules(local) ++ callback_modules(external).
+    lists_uniq(callback_modules(local) ++ callback_modules(external)).
+
+-ifdef(OTP_BELOW_25).
+lists_uniq(List) ->
+    lists:usort(List).
+-else.
+lists_uniq(List) ->
+    lists:uniq(List).
+-endif.
 
 -spec validators(module(), [atom()], [any()]) -> econf:validators().
 validators(Mod, Disallowed, DK) ->

--- a/src/ejabberd_config.erl
+++ b/src/ejabberd_config.erl
@@ -38,6 +38,7 @@
 -export([dump/0, dump/1, convert_to_yaml/1, convert_to_yaml/2]).
 -export([callback_modules/1]).
 -export([set_option/2]).
+-export([get_defined_keywords/1, get_predefined_keywords/1, replace_keywords/2, replace_keywords/3]).
 
 %% Deprecated functions
 -export([get_option/2]).
@@ -403,6 +404,93 @@ format_error({error, {exception, Class, Reason, St}}) ->
 	"code, please report the bug with ejabberd configuration "
 	"file attached and the following stacktrace included:~n** ~ts",
 	[misc:format_exception(2, Class, Reason, St)])).
+
+%% @format-begin
+
+replace_keywords(Host, Value) ->
+    Keywords = get_defined_keywords(Host) ++ get_predefined_keywords(Host),
+    replace_keywords(Host, Value, Keywords).
+
+replace_keywords(Host, List, Keywords) when is_list(List) ->
+    [replace_keywords(Host, Element, Keywords) || Element <- List];
+replace_keywords(_Host, Atom, Keywords) when is_atom(Atom) ->
+    Str = atom_to_list(Atom),
+    case Str == string:uppercase(Str) of
+        false ->
+            Atom;
+        true ->
+            MacroName = iolist_to_binary(Str),
+            case proplists:get_value(MacroName, Keywords) of
+                undefined ->
+                    Atom;
+                Replacement ->
+                    Replacement
+            end
+    end;
+replace_keywords(_Host, Binary, Keywords) when is_binary(Binary) ->
+    lists:foldl(fun ({Key, Replacement}, V) when is_binary(Replacement) ->
+                        misc:expand_keyword(<<"@", Key/binary, "@">>, V, Replacement);
+                    ({_, _}, V) ->
+                        V
+                end,
+                Binary,
+                Keywords);
+replace_keywords(Host, {Element1, Element2}, Keywords) ->
+    {Element1, replace_keywords(Host, Element2, Keywords)};
+replace_keywords(_Host, Value, _DK) ->
+    Value.
+
+get_defined_keywords(Host) ->
+    Tab = case get_tmp_config() of
+              undefined ->
+                  ejabberd_options;
+              T ->
+                  T
+          end,
+    get_defined_keywords(Tab, Host).
+
+get_defined_keywords(Tab, Host) ->
+    KeysHost =
+        case ets:lookup(Tab, {define_keyword, Host}) of
+            [{_, List}] ->
+                List;
+            _ ->
+                []
+        end,
+    KeysGlobal =
+        case Host /= global andalso ets:lookup(Tab, {define_keyword, global}) of
+            [{_, ListG}] ->
+                ListG;
+            _ ->
+                []
+        end,
+    %% Trying to get defined keywords in host_config when starting ejabberd,
+    %% the options are not yet stored in ets
+    KeysTemp = case not is_atom(Tab) andalso KeysHost == [] andalso KeysGlobal == [] of
+                   true ->
+		       get_defined_keywords_yaml_config(ets:lookup_element(Tab, {yaml_config, global}, 2));
+                   false ->
+                       []
+               end,
+    lists:reverse(KeysTemp ++ KeysGlobal ++ KeysHost).
+
+get_defined_keywords_yaml_config(Y) ->
+    [{erlang:atom_to_binary(KwAtom, latin1), KwValue}
+     || {KwAtom, KwValue} <- proplists:get_value(define_keyword, Y, [])].
+
+get_predefined_keywords(Host) ->
+    HostList = case Host of
+        global -> [];
+        _ -> [{<<"HOST">>, Host}]
+    end,
+    {ok, [[Home]]} = init:get_argument(home),
+    HostList ++
+    [{<<"HOME">>, list_to_binary(Home)},
+     {<<"SEMVER">>, ejabberd_option:version()},
+     {<<"VERSION">>,
+      misc:semver_to_xxyy(
+          ejabberd_option:version())}].
+%% @format-end
 
 %%%===================================================================
 %%% Internal functions

--- a/src/ejabberd_config_transformer.erl
+++ b/src/ejabberd_config_transformer.erl
@@ -128,6 +128,11 @@ transform(Host, s2s_use_starttls, required_trusted, Acc) ->
     Hosts = maps:get(remove_s2s_dialback, Acc, []),
     Acc1 = maps:put(remove_s2s_dialback, [Host|Hosts], Acc),
     {{true, {s2s_use_starttls, required}}, Acc1};
+transform(Host, define_macro, Macro, Acc) when is_binary(Host) ->
+    ?WARNING_MSG("The option 'define_macro' is not supported inside 'host_config'. "
+		 "Consequently those macro definitions for host '~ts' are unused: ~ts",
+		 [Host, io_lib:format("~p", [Macro])]),
+    {true, Acc};
 transform(_Host, _Opt, _Val, Acc) ->
     {true, Acc}.
 

--- a/src/ejabberd_http.erl
+++ b/src/ejabberd_http.erl
@@ -932,12 +932,7 @@ listen_opt_type(default_host) ->
 listen_opt_type(custom_headers) ->
     econf:map(
       econf:binary(),
-      econf:and_then(
-	econf:binary(),
-	fun(V) ->
-		misc:expand_keyword(<<"@VERSION@">>, V,
-				    ejabberd_option:version())
-	end)).
+      econf:binary()).
 
 listen_options() ->
     [{ciphers, undefined},

--- a/src/ejabberd_option.erl
+++ b/src/ejabberd_option.erl
@@ -38,6 +38,7 @@
 -export([cluster_nodes/0]).
 -export([default_db/0, default_db/1]).
 -export([default_ram_db/0, default_ram_db/1]).
+-export([define_keyword/0, define_keyword/1]).
 -export([define_macro/0]).
 -export([disable_sasl_mechanisms/0, disable_sasl_mechanisms/1]).
 -export([disable_sasl_scram_downgrade_protection/0, disable_sasl_scram_downgrade_protection/1]).
@@ -371,6 +372,13 @@ default_ram_db() ->
 -spec default_ram_db(global | binary()) -> 'mnesia' | 'redis' | 'sql'.
 default_ram_db(Host) ->
     ejabberd_config:get_option({default_ram_db, Host}).
+
+-spec define_keyword() -> any().
+define_keyword() ->
+    define_keyword(global).
+-spec define_keyword(global | binary()) -> any().
+define_keyword(Host) ->
+    ejabberd_config:get_option({define_keyword, Host}).
 
 -spec define_macro() -> any().
 define_macro() ->

--- a/src/ejabberd_options.erl
+++ b/src/ejabberd_options.erl
@@ -138,6 +138,8 @@ opt_type(default_db) ->
     econf:enum([mnesia, sql]);
 opt_type(default_ram_db) ->
     econf:enum([mnesia, sql, redis]);
+opt_type(define_keyword) ->
+    econf:map(econf:binary(), econf:any(), [unique]);
 opt_type(define_macro) ->
     econf:map(econf:binary(), econf:any(), [unique]);
 opt_type(disable_sasl_scram_downgrade_protection) ->
@@ -510,6 +512,7 @@ opt_type(jwt_auth_only_rule) ->
 		    {jwt_key, jose_jwk:key() | undefined} |
 		    {append_host_config, [{binary(), any()}]} |
 		    {host_config, [{binary(), any()}]} |
+		    {define_keyword, any()} |
 		    {define_macro, any()} |
 		    {include_config_file, any()} |
 		    {atom(), any()}].
@@ -567,6 +570,7 @@ options() ->
      {certfiles, undefined},
      {cluster_backend, mnesia},
      {cluster_nodes, []},
+     {define_keyword, []},
      {define_macro, []},
      {disable_sasl_scram_downgrade_protection, false},
      {disable_sasl_mechanisms, []},

--- a/src/ejabberd_options.erl
+++ b/src/ejabberd_options.erl
@@ -112,14 +112,7 @@ opt_type(cache_missed) ->
 opt_type(cache_size) ->
     econf:pos_int(infinity);
 opt_type(captcha_cmd) ->
-    econf:and_then(
-	econf:binary(),
-	fun(V) ->
-		V2 = misc:expand_keyword(<<"@SEMVER@">>, V,
-				    ejabberd_option:version()),
-		misc:expand_keyword(<<"@VERSION@">>, V2,
-				    misc:semver_to_xxyy(ejabberd_option:version()))
-	end);
+    econf:binary();
 opt_type(captcha_host) ->
     econf:binary();
 opt_type(captcha_limit) ->
@@ -493,7 +486,6 @@ opt_type(jwt_auth_only_rule) ->
 		    {c2s_protocol_options, undefined | binary()} |
                     {s2s_ciphers, undefined | binary()} |
                     {c2s_ciphers, undefined | binary()} |
-		    {captcha_cmd, undefined | binary()} |
 		    {websocket_origin, [binary()]} |
 		    {disable_sasl_mechanisms, [binary()]} |
 		    {s2s_zlib, boolean()} |

--- a/src/ejabberd_options_doc.erl
+++ b/src/ejabberd_options_doc.erl
@@ -534,18 +534,26 @@ doc() ->
             ?T("A list of Erlang nodes to connect on ejabberd startup. "
                "This option is mostly intended for ejabberd customization "
                "and sophisticated setups. The default value is an empty list.")}},
-     {define_macro,
-      #{value => "{MacroName: MacroValue}",
+     {define_keyword,
+      #{value => "{NAME: Value}",
         desc =>
-            ?T("Defines a "
-               "_`../configuration/file-format.md#macros-in-configuration-file|macro`_. "
-               "The value can be any valid arbitrary "
-               "YAML value. For convenience, it's recommended to define "
-               "a 'MacroName' in capital letters. Duplicated macros are not allowed. "
-               "Macros are processed after additional configuration files have "
-               "been included, so it is possible to use macros that are defined "
-               "in configuration files included before the usage. "
-               "It is possible to use a 'MacroValue' in the definition of another macro."),
+            ?T("Allows to define configuration "
+                "_`../configuration/file-format.md#keywords|keywords`_. "),
+        example =>
+            ["define_keyword:",
+             "  SQL_USERNAME: \"eja.global\"",
+             "",
+             "host_config:",
+             "  localhost:",
+             "    define_keyword:",
+             "      SQL_USERNAME: \"eja.localhost\"",
+             "",
+             "sql_username: \"prefix.@SQL_USERNAME@\""]}},
+     {define_macro,
+      #{value => "{NAME: Value}",
+        desc =>
+            ?T("Allows to define configuration "
+                "_`../configuration/file-format.md#macros|macros`_. "),
         example =>
             ["define_macro:",
              "  DEBUG: debug",

--- a/test/configtest_tests.erl
+++ b/test/configtest_tests.erl
@@ -1,0 +1,187 @@
+%%%-------------------------------------------------------------------
+%%% Author  : Badlop <badlop@process-one.net>
+%%% Created : 5 Feb 2025 by Badlop <badlop@process-one.net>
+%%%
+%%%
+%%% ejabberd, Copyright (C) 2002-2025   ProcessOne
+%%%
+%%% This program is free software; you can redistribute it and/or
+%%% modify it under the terms of the GNU General Public License as
+%%% published by the Free Software Foundation; either version 2 of the
+%%% License, or (at your option) any later version.
+%%%
+%%% This program is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%%% General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License along
+%%% with this program; if not, write to the Free Software Foundation, Inc.,
+%%% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%%%
+%%%-------------------------------------------------------------------
+
+-module(configtest_tests).
+
+-compile(export_all).
+
+-include("suite.hrl").
+
+%%%==================================
+
+single_cases() ->
+    {configtest_single,
+     [sequence],
+     [single_test(macro_over_keyword),
+      single_test(keyword_inside_macro),
+      single_test(macro_and_keyword),
+      single_test(macro_double),
+      single_test(keyword_double),
+
+      single_test(macro_toplevel_global_atom),
+      single_test(macro_toplevel_global_string),
+      single_test(macro_toplevel_global_string_inside),
+      single_test(macro_toplevel_local_atom),
+      single_test(macro_toplevel_local_string),
+      single_test(macro_toplevel_local_string_inside),
+
+      single_test(keyword_toplevel_global_atom),
+      single_test(keyword_toplevel_global_string),
+      single_test(keyword_toplevel_global_string_inside),
+      single_test(keyword_toplevel_local_atom),
+      single_test(keyword_toplevel_local_string),
+      single_test(keyword_toplevel_local_string_inside),
+
+      single_test(macro_module_atom),
+      single_test(macro_module_string),
+      single_test(macro_module_string_inside),
+
+      single_test(keyword_module_atom),
+      single_test(keyword_module_string),
+      single_test(keyword_module_string_inside),
+
+      single_test(toplevel_global_predefined),
+      single_test(toplevel_local_predefined),
+      single_test(module_predefined)]}.
+
+%% Interactions
+
+macro_over_keyword(_) ->
+    toplevel_global(macro, macro_over_keyword).
+
+keyword_inside_macro(_) ->
+    toplevel_global(<<"+macro+/-keyword-">>, keyword_inside_macro).
+
+macro_and_keyword(_) ->
+    toplevel_global(<<"+macro+&-keyword-">>, macro_and_keyword).
+
+macro_double(_) ->
+    toplevel_global(<<"macro--macro">>, macro_double).
+
+keyword_double(_) ->
+    toplevel_global(<<"keyword--keyword">>, keyword_double).
+
+%% Macro Toplevel
+
+macro_toplevel_global_atom(_) ->
+    toplevel_global(mtga, mtga).
+
+macro_toplevel_global_string(_) ->
+    toplevel_global(<<"Mtgs">>, mtgs).
+
+macro_toplevel_global_string_inside(_) ->
+    toplevel_global(<<"Mtgsi">>, mtgsi).
+
+macro_toplevel_local_atom(_) ->
+    toplevel_local(mtla, mtla).
+
+macro_toplevel_local_string(_) ->
+    toplevel_local(<<"Mtls">>, mtls).
+
+macro_toplevel_local_string_inside(_) ->
+    toplevel_local(<<"Mtlsi">>, mtlsi).
+
+%% Keyword Toplevel
+
+keyword_toplevel_global_atom(_) ->
+    toplevel_global(ktga, ktga).
+
+keyword_toplevel_global_string(_) ->
+    toplevel_global(<<"Ktgs">>, ktgs).
+
+keyword_toplevel_global_string_inside(_) ->
+    toplevel_global(<<"Ktgsi">>, ktgsi).
+
+keyword_toplevel_local_atom(_) ->
+    toplevel_local(ktla, ktla).
+
+keyword_toplevel_local_string(_) ->
+    toplevel_local(<<"Ktls">>, ktls).
+
+keyword_toplevel_local_string_inside(_) ->
+    toplevel_local(<<"Ktlsi">>, ktlsi).
+
+%% Macro Module
+
+macro_module_atom(_) ->
+    module(mma, mma).
+
+macro_module_string(_) ->
+    module(<<"Mms">>, mms).
+
+macro_module_string_inside(_) ->
+    module(<<"Mmsi">>, mmsi).
+
+%% Keyword Module
+
+keyword_module_atom(_) ->
+    module(kma, kma).
+
+keyword_module_string(_) ->
+    module(<<"Kms">>, kms).
+
+keyword_module_string_inside(_) ->
+    module(<<"Kmsi">>, kmsi).
+
+%% Predefined
+
+toplevel_global_predefined(_) ->
+    Semver = ejabberd_option:version(),
+    Version = misc:semver_to_xxyy(Semver),
+    String = <<"tgp - semver: ", Semver/binary, ", version: ", Version/binary>>,
+    toplevel_global(String, tgp).
+
+toplevel_local_predefined(_) ->
+    Semver = ejabberd_option:version(),
+    Version = misc:semver_to_xxyy(Semver),
+    String = <<"tlp - semver: ", Semver/binary, ", version: ", Version/binary>>,
+    toplevel_local(String, tlp).
+
+module_predefined(_) ->
+    Host = <<"configtest.localhost">>,
+    Semver = ejabberd_option:version(),
+    Version = misc:semver_to_xxyy(Semver),
+    String = <<"mp - host: ", Host/binary, ", semver: ", Semver/binary, ", version: ", Version/binary>>,
+    module(String, predefined_keywords).
+
+%%%==================================
+%%%% internal functions
+
+single_test(T) ->
+    list_to_atom("configtest_" ++ atom_to_list(T)).
+
+toplevel_global(Result, Option) ->
+    ?match(Result, ejabberd_config:get_option(Option)).
+
+toplevel_local(Result, Option) ->
+    Host = <<"configtest.localhost">>,
+    ?match(Result, ejabberd_config:get_option({Option, Host})).
+
+module(Result, Option) ->
+    Host = <<"configtest.localhost">>,
+    Module = mod_configtest,
+    ?match(Result, gen_mod:get_module_opt(Host, Module, Option)).
+
+%%%==================================
+
+%%% vim: set foldmethod=marker foldmarker=%%%%,%%%=:

--- a/test/ejabberd_SUITE.erl
+++ b/test/ejabberd_SUITE.erl
@@ -60,6 +60,7 @@ init_per_suite(Config) ->
     NewConfig.
 
 start_ejabberd(_) ->
+    application:set_env(ejabberd, external_beams, "../../lib/ejabberd/test/"),
     {ok, _} = application:ensure_all_started(ejabberd, transient).
 
 end_per_suite(_Config) ->
@@ -398,6 +399,7 @@ no_db_tests() ->
      auth_external_wrong_server,
      auth_external_invalid_cert,
      commands_tests:single_cases(),
+     configtest_tests:single_cases(),
      jidprep_tests:single_cases(),
      sm_tests:single_cases(),
      sm_tests:master_slave_cases(),

--- a/test/ejabberd_SUITE_data/configtest.yml
+++ b/test/ejabberd_SUITE_data/configtest.yml
@@ -1,0 +1,119 @@
+
+define_macro:
+  CONFIGTEST_CONFIG:
+    modules:
+      mod_mam: {}
+      mod_muc: {}
+
+## Interactions
+
+define_macro:
+  MOK: macro
+
+define_keyword:
+  MOK: keyword
+
+macro_over_keyword: MOK
+
+##
+
+define_keyword:
+  KIM_KEYWORD: "-keyword-"
+
+define_macro:
+  KIM_MACRO: "+macro+/@KIM_KEYWORD@"
+
+keyword_inside_macro: KIM_MACRO
+
+##
+
+define_macro:
+  MAK_MACRO: "+macro+"
+
+define_keyword:
+  MAK_KEYWORD: "-keyword-"
+
+macro_and_keyword: "@MAK_MACRO@&@MAK_KEYWORD@"
+
+##
+
+define_macro:
+  MD: "macro"
+
+macro_double: "@MD@--@MD@"
+
+##
+
+define_keyword:
+  KD: "keyword"
+
+keyword_double: "@KD@--@KD@"
+
+## Macro Toplevel
+
+define_macro:
+  MTGA: mtga
+  MTGS: "Mtgs"
+  MTLA: mtla
+  MTLS: "Mtls"
+
+mtga: MTGA
+mtgs: MTGS
+mtgsi: "@MTGS@i"
+
+host_config:
+  configtest.localhost:
+    mtla: MTLA
+    mtls: MTLS
+    mtlsi: "@MTLS@i"
+
+## Keyword Toplevel
+
+define_keyword:
+  KTGA: ktga
+  KTLA: ktla
+  KTGS: "Ktgs"
+  KTLS: "Ktls"
+
+ktga: KTGA
+ktgs: KTGS
+ktgsi: "@KTGS@i"
+
+host_config:
+  configtest.localhost:
+    ktla: KTLA
+    ktls: KTLS
+    ktlsi: "@KTLS@i"
+
+## Macro Module
+## Keyword Module
+## Predefined Module
+
+define_macro:
+  MMA: mma
+  MMS: "Mms"
+
+define_keyword:
+  KMA: kma
+  KMS: "Kms"
+
+append_host_config:
+  configtest.localhost:
+    modules:
+      mod_configtest:
+        mma: MMA
+        mms: MMS
+        mmsi: "@MMS@i"
+        kma: KMA
+        kms: KMS
+        kmsi: "@KMS@i"
+        predefined_keywords: "mp - host: @HOST@, semver: @SEMVER@, version: @VERSION@"
+
+## Predefined
+
+tgp: "tgp - semver: @SEMVER@, version: @VERSION@"
+
+host_config:
+  configtest.localhost:
+    tlp: "tlp - semver: @SEMVER@, version: @VERSION@"
+

--- a/test/ejabberd_SUITE_data/ejabberd.yml
+++ b/test/ejabberd_SUITE_data/ejabberd.yml
@@ -1,5 +1,6 @@
 include_config_file:
   - macros.yml
+  - configtest.yml
   - ejabberd.extauth.yml
   - ejabberd.ldap.yml
   - ejabberd.mnesia.yml
@@ -10,6 +11,7 @@ include_config_file:
   - ejabberd.sqlite.yml
 
 host_config:
+  configtest.localhost: CONFIGTEST_CONFIG
   pgsql.localhost: PGSQL_CONFIG
   sqlite.localhost: SQLITE_CONFIG
   mysql.localhost: MYSQL_CONFIG
@@ -25,6 +27,7 @@ host_config:
 
 hosts:
   - localhost
+  - configtest.localhost
   - mnesia.localhost
   - redis.localhost
   - mysql.localhost

--- a/test/ejabberd_test_options.erl
+++ b/test/ejabberd_test_options.erl
@@ -1,0 +1,114 @@
+%%%----------------------------------------------------------------------
+%%% ejabberd, Copyright (C) 2002-2025   ProcessOne
+%%%
+%%% This program is free software; you can redistribute it and/or
+%%% modify it under the terms of the GNU General Public License as
+%%% published by the Free Software Foundation; either version 2 of the
+%%% License, or (at your option) any later version.
+%%%
+%%% This program is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%%% General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License along
+%%% with this program; if not, write to the Free Software Foundation, Inc.,
+%%% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%%%
+%%%----------------------------------------------------------------------
+-module(ejabberd_test_options).
+-behaviour(ejabberd_config).
+
+-export([opt_type/1, options/0, globals/0, doc/0]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+-spec opt_type(atom()) -> econf:validator().
+
+opt_type(macro_over_keyword) ->
+    econf:atom();
+
+opt_type(keyword_inside_macro) ->
+    econf:binary();
+
+opt_type(macro_and_keyword) ->
+    econf:binary();
+
+opt_type(macro_double) ->
+    econf:binary();
+
+opt_type(keyword_double) ->
+    econf:binary();
+
+opt_type(mtga) ->
+    econf:atom();
+
+opt_type(mtgs) ->
+    econf:binary();
+
+opt_type(mtgsi) ->
+    econf:binary();
+
+opt_type(mtla) ->
+    econf:atom();
+
+opt_type(mtls) ->
+    econf:binary();
+
+opt_type(mtlsi) ->
+    econf:binary();
+
+opt_type(ktga) ->
+    econf:atom();
+
+opt_type(ktgs) ->
+    econf:binary();
+
+opt_type(ktgsi) ->
+    econf:binary();
+
+opt_type(ktla) ->
+    econf:atom();
+
+opt_type(ktls) ->
+    econf:binary();
+
+opt_type(ktlsi) ->
+    econf:binary();
+
+opt_type(tgp) ->
+    econf:binary();
+
+opt_type(tlp) ->
+    econf:binary().
+
+options() ->
+    [{macro_over_keyword, undefined},
+     {keyword_inside_macro, undefined},
+     {macro_and_keyword, undefined},
+     {macro_double, undefined},
+     {keyword_double, undefined},
+     {mtga, undefined},
+     {mtgs, undefined},
+     {mtgsi, undefined},
+     {mtla, undefined},
+     {mtls, undefined},
+     {mtlsi, undefined},
+     {ktga, undefined},
+     {ktgs, undefined},
+     {ktgsi, undefined},
+     {ktla, undefined},
+     {ktls, undefined},
+     {ktlsi, undefined},
+     {tgp, undefined},
+     {tlp, undefined}
+    ].
+
+-spec globals() -> [atom()].
+globals() ->
+    [].
+
+doc() ->
+    ejabberd_options_doc:doc().
+

--- a/test/mod_configtest.erl
+++ b/test/mod_configtest.erl
@@ -1,0 +1,45 @@
+-module(mod_configtest).
+-behaviour(gen_mod).
+
+-export([start/2, stop/1, reload/3, mod_opt_type/1, mod_options/1, depends/2, mod_doc/0]).
+
+start(_Host, _Opts) ->
+    ok.
+
+stop(_Host) ->
+    ok.
+
+reload(_Host, _NewOpts, _OldOpts) ->
+    ok.
+
+depends(_Host, _Opts) ->
+    [].
+
+mod_opt_type(mma) ->
+    econf:atom();
+mod_opt_type(mms) ->
+    econf:binary();
+mod_opt_type(mmsi) ->
+    econf:binary();
+
+mod_opt_type(kma) ->
+    econf:atom();
+mod_opt_type(kms) ->
+    econf:binary();
+mod_opt_type(kmsi) ->
+    econf:binary();
+
+mod_opt_type(predefined_keywords) ->
+    econf:binary().
+
+mod_options(_) ->
+    [{mma, undefined},
+     {mms, undefined},
+     {mmsi, undefined},
+     {kma, undefined},
+     {kms, undefined},
+     {kmsi, undefined},
+     {predefined_keywords, undefined}].
+
+mod_doc() ->
+    #{}.

--- a/test/suite.erl
+++ b/test/suite.erl
@@ -84,6 +84,7 @@ init_config(Config) ->
 		       {priv_dir, PrivDir}]),
     MacrosPath = filename:join([CWD, "macros.yml"]),
     ok = file:write_file(MacrosPath, MacrosContent),
+    copy_configtest_yml(DataDir, CWD),
     copy_backend_configs(DataDir, CWD, Backends),
     setup_ejabberd_lib_path(Config),
     case application:load(sasl) of
@@ -137,11 +138,32 @@ init_config(Config) ->
      {backends, Backends}
      |Config].
 
+copy_configtest_yml(DataDir, CWD) ->
+    Files = filelib:wildcard(filename:join([DataDir, "configtest.yml"])),
+    lists:foreach(
+	fun(Src) ->
+	    ct:pal("copying ~p", [Src]),
+	    File = filename:basename(Src),
+	    case string:tokens(File, ".") of
+		["configtest", "yml"] ->
+		    Dst = filename:join([CWD, File]),
+		    case true of
+			true ->
+			    {ok, _} = file:copy(Src, Dst);
+			false ->
+			    ok
+		    end;
+		_ ->
+		    ok
+	    end
+	end, Files).
+
+
 copy_backend_configs(DataDir, CWD, Backends) ->
     Files = filelib:wildcard(filename:join([DataDir, "ejabberd.*.yml"])),
     lists:foreach(
 	fun(Src) ->
-	    io:format("copying ~p", [Src]),
+	    ct:pal("copying ~p", [Src]),
 	    File = filename:basename(Src),
 	    case string:tokens(File, ".") of
 		["ejabberd", SBackend, "yml"] ->


### PR DESCRIPTION
**update 17 february**: keyword feature greately improved, and now macros can be used inside strings.

Macros are replaced in the yconf library, this is very powerful at the YAML level... but unfortunately macros cannot be defined inside host_config.

This PR adds a new option, define_keyword, complementary to define_macro. As define_keyword internal code is implemented in ejabberd, define_keyword can be set in host_config.

In ejabberd there were already a few keywords hard-coded in specific options, for example some module hosts can use the keyword @HOST@. This PR allows all the options to use this and other keywords, no need to add code for each option.

Tests are also added for all those features.

---

# Release Notes

<details>

## Keywords predefined for all options

Some options in ejabberd supported the possibility to use hard-coded keywords.  For example, many modules like mod_vcard could used `HOST` in their option `hosts`.  Also, the `captcha_cmd` toplevel option could use `VERSION` and `SEMVER` keywords.  This was implemented for each individual option.

Now those keywords are predefined and can be used by any option, and this is implemented in ejabberd core, no need to implement the keyword substitution in each option.

The predefined keywords are: `HOST`, `HOME`, `VERSION` and `SEMVER`.

For example, this configuration is possible without requiring any implementation in the option source code:

```yaml
ext_api_url: "http://example.org/@VERSION@/api"
```

## New define_keyword option

Now you can define your own keywords, similarly to how macros are defined:

```yaml
define_keyword:
  SCRIPT: "captcha.sh"

captcha_cmd: "tools/@SCRIPT@"
```

## Macros can be used inside string

Macros can be used inside string options, similarly to how keywords can be used.

This is now possible:

```yaml
define_macro:
  SCRIPT: "captcha.sh"

captcha_cmd: "tools/@SCRIPT@"
```
</details>

# Documentation

<details>

This is the documentation that could be included in the Docs site. Notice that the markdown and links in this github issue may not be perfect, as it's designed for the docs site.

## Macros and Keywords

<!-- md:version improved in [25.xx](../../archive/25.xx/index.md) -->

In the ejabberd configuration file, you can define a macro or keyword for a value (atom, integer, string...) and later use it when configuring an ejabberd option.

**Macros** is a feature implemented internally by the [yconf](https://github.com/processone/yconf) library and are replaced early and transparently to ejabberd.  However, macros [cannot](#macro-and-host_config) be defined inside `host_config`.

**Keywords** is a feature similar to macros, implemented by ejabberd itself, and are replaced after macro replacement.  Keywords can be defined inside `host_config` for module options, but not for toplevel options.  Keywords cannot be used in those toplevel options: [hosts](toplevel.md#hosts), [loglevel](toplevel.md#loglevel), [version](toplevel.md#version).

First [define_macro](toplevel.md#define_macro) and [define_keyword](toplevel.md#define_keyword) and then use them like this:

```yaml
define_macro:
  NAME1: value1

define_keyword:
  NAME2: "value2"

some_option1: NAME1
other_option1: "I am @NAME1@"

some_option2: NAME2
other_option2: "I am @NAME2@"
```

where:

- **NAME**: should be specified in capital letters for convenience.  Duplicated macro/keyword names are not allowed.  If a macro is defined with the same name than a keyword, the macro is used.

- **value**: for all options, the value can be any valid YAML element.  It is also possible to use as value the name of another macro.

- **use** a macro/keyword when configuring the option: simply set `NAME` instead of option value.  Macros are processed after additional configuration files have been included, so it is possible to use macros that are defined in configuration files included before the usage.

- **use inside a string**: surround its name with `@` characters

Let's see examples of all this in detail:

### Atom

``` yaml
define_macro:
  ANON: both

define_keyword:
  TLS: optional

anonymous_protocol: ANON
s2s_use_starttls: TLS
```

The resulting configuration is:

``` yaml
anonymous_protocol: both
s2s_use_starttls: optional
```

### Integer

``` yaml
define_macro:
  LOG_LEVEL_NUMBER: 5
  NUMBER_PORT_C2S: 5222

define_keyword:
  NUMBER_PORT_HTTP: 5280

loglevel: LOG_LEVEL_NUMBER

listen:
  -
    port: NUMBER_PORT_C2S
    module: ejabberd_c2s
  -
    port: NUMBER_PORT_HTTP
    module: ejabberd_http
```

The resulting configuration is:

``` yaml
loglevel: 5

listen:
  -
    port: 5222
    module: ejabberd_c2s
  -
    port: 5280
    module: ejabberd_http
```

### Map

Option values can be any arbitrary YAML value:

``` yaml
define_macro:
  USERBOB:
    user:
      - bob@localhost

define_keyword:
  USERJAN:
    user:
      - jan@localhost

acl:
  admin: USERBOB
  moderator: USERJAN
```

The resulting configuration is:

``` yaml
acl:
  admin:
    user:
      - bob@localhost
  moderator:
    user:
      - jan@localhost
```

### String

``` yaml
define_macro:
  NAME: "MUC Service"
  PERSISTENT: true

define_keyword:
  TITLE: "Example Room"

modules:
  mod_muc:
    name: NAME
    default_room_options:
      persistent: true
      title: TITLE
```

The resulting configuration is:

``` yaml
modules:
  mod_muc:
    name: "MUC Service"
    default_room_options:
      persistent: PERSISTENT
      title: "Example Room"
```

### Inside string

A macro or keyword can be used inside an option string:

``` yaml
define_keyword:
  CMD: "captcha"

captcha_cmd: "tools/@CMD@.sh"
```

is equivalent to:

``` yaml
define_keyword:
  CMD: "tools/captcha.sh"

captcha_cmd: "@CMD@"
```

is equivalent to:

``` yaml
define_keyword:
  CMD: "tools/captcha.sh"

captcha_cmd: CMD
```

The resulting configuration in all the cases is:

``` yaml
captcha_cmd: tools/captcha.sh
```

### Macro over keyword

If a macro and a keyword are defined with the same name, the macro definition takes precedence and the keyword definition is ignored:

``` yaml
define_macro:
  LANGUAGE: "bg"

define_keyword:
  LANGUAGE: "pt"

language: LANGUAGE
```

The resulting configuration is:

``` yaml
language: "bg"
```

### Keyword inside macro

A macro definition can use a keyword:

``` yaml
define_macro:
  MACRO: "tools/@KEYWORD@"

define_keyword:
  KEYWORD: "captcha.sh"

captcha_cmd: MACRO
```

The resulting configuration is:

``` yaml
captcha_cmd: "tools/captcha.sh"
```

### Predefined keywords

Several keywords are predefined automatically by ejabberd, so you can use them without need to define them explicitly:

- **HOST**: the virtual [host name](../basic/#host-names), for example `"example.org"`.  That keyword is only predefined for module options, not toplevel options.
- **HOME**: the home directory of the user running ejabberd, for example `"/home/ejabberd"`
- **VERSION**: ejabberd version number in `XX.YY` format, for example `"24.05"`
- **SEMVER**: ejabberd version number in [semver format](https://hexdocs.pm/elixir/1.18.2/Version.html) when compiled with Elixir’s mix (`"24.5"`), otherwise it's in `XX.YY` format (`"24.05"`)

It is possible to overwrite predefined keywords, global or for a vhost like in this example:

```yaml
host_config:
  localhost:
    define_keyword:
      VERSION: "1.2.3"

ext_api_url: "http://localhost/@VERSION@"
```

The resulting behaviour is equivalent to a configuration like:

``` yaml
host_config:
  localhost:
    ext_api_url: "http://localhost/1.2.3"

ext_api_url: "http://localhost/25.xx"
```

### Macro and host_config

Macros can be **used** inside [host_config](toplevel.md#host_config):

``` yaml
define_macro:
  MYSQL_PORT: 1234
  PGSQL_PORT: 4567

host_config:
  mysql.localhost:
    sql_port: MYSQL_PORT
  pgsql.localhost:
    sql_port: MYSQL_PORT
```

The resulting configuration is:

``` yaml
host_config:
  mysql.localhost:
    sql_port: 1234
  pgsql.localhost:
    sql_port: 4567
```

!!! warning "Don't use macro defined in host_config"

    Macros can not be **defined** inside host_config.
    Use the previous method instead.
    That problematic macro is not replaced:

    ``` yaml
    host_config:
      mysql.localhost:
        define_macro:
          SQL_PORT: 1234
      pgsql.localhost:
        define_macro:
          SQL_PORT: 4567

    sql_port: SQL_PORT

    # [critical] Failed to start ejabberd application:
    #   Invalid value of option sql_port:
    #   Expected integer, got string instead
    ```

### Keyword and host_config

Keywords can be **used** and **defined** inside [host_config](toplevel.md#host_config):

``` yaml
hosts:
 - localhost
 - example.org

define_keyword:
  HOSTNAME: "Generic Name"

host_config:
  example.org:
    define_keyword:
      HOSTNAME: "Example Host"

modules:
  mod_vcard:
    name: "vJUD of @HOSTNAME@"
```

The resulting configuration is:

``` yaml
host_config:
  localhost:
    modules:
      mod_vcard:
        name: "vJUD of Generic Name"
  example.org:
    modules:
      mod_vcard:
        name: "vJUD of Example Host"
```

!!! warning "Don't use in toplevel a keyword defined in host_config"

    Keywords can be defined inside `host_config`,
    but only if they are being used in module options,
    not in toplevel options.
    That problematic keyword is not replaced:

    ``` yaml
    host_config:
      mysql.localhost:
        define_keyword:
          SQL_PORT: 1234
      pgsql.localhost:
        define_keyword:
          SQL_PORT: 4567

    sql_port: SQL_PORT

    # [critical] Failed to start ejabberd application:
    #   Invalid value of option sql_port:
    #   Expected integer, got string instead
    ```

</details>
