### PR TITLE
missing comma in postgres schema

### DIFF
--- a/sql/pg.sql
+++ b/sql/pg.sql
@@ -18,7 +18,7 @@
 
 CREATE TABLE users (
     username text NOT NULL,
-    "type" smallint NOT NULL
+    "type" smallint NOT NULL,
     "password" text NOT NULL,
     serverkey text NOT NULL DEFAULT '',
     salt text NOT NULL DEFAULT '',


### PR DESCRIPTION
Nothing more to say than the title. A comma is missing which cause the sql import to fail because of invalid syntax.

edit: fixes #4405 
