### PR TITLE
Accepting a proxied connection only in debug log

### DIFF
--- a/src/ejabberd_listener.erl
+++ b/src/ejabberd_listener.erl
@@ -341,7 +341,7 @@ accept(ListenSocket, Module, State, Sup, Interval, Proxy, Arity) ->
 				       gen_tcp:close(Socket),
 				       none
 			       end,
-		    ?INFO_MSG("(~p) Accepted proxied connection ~ts -> ~ts",
+		    ?DEBUG("(~p) Accepted proxied connection ~ts -> ~ts",
 			      [Receiver,
 			       ejabberd_config:may_hide_data(
 				 format_endpoint({PPort, PAddr, tcp})),


### PR DESCRIPTION
I believe accepting a proxied connection should not be in the log at level INFO. Level DEBUG would be right.

Reason: 

1. other connections are also in DEBUG-Level and not in INFO
2. INFO-level log is cluttered with these log-messages because the reverse-proxy (e.g. haproxy) might check the availability of the ejabberd-backend on short interval (e.g. every 30 seconds or so). Every check generates a log entry on level INFO.
