### PR TITLE
CI: bump XMPP-Interop-Testing/xmpp-interop-tests-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     - name: Run XMPP Interoperability Tests against CI server.
       if: matrix.otp == '27'
       continue-on-error: true
-      uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.5.0
+      uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.6.0
       with:
         domain: 'localhost'
         adminAccountUsername: 'admin'


### PR DESCRIPTION
Updates this GitHub Action that's used to execute XMPP-based interop tests from v1.5.0 to v1.6.0.

In this update, 524 new tests were added (more than doubling the amount of tests that previously existed).
