### PR TITLE
Update Dockerfile

### DIFF
--- a/.github/container/Dockerfile
+++ b/.github/container/Dockerfile
@@ -19,6 +19,11 @@ RUN go install -v \
 FROM docker.io/erlang:${OTP_VSN}-alpine AS ejabberd
 
 RUN apk -U add --no-cache \
+        python3 \
+        py3-pip \
+        build-base \
+        postgresql-dev \
+        python3-dev \
         autoconf \
         automake \
         bash \
@@ -36,6 +41,9 @@ RUN apk -U add --no-cache \
         sqlite-dev \
         yaml-dev \
         zlib-dev
+
+# Install Python packages globally
+RUN pip3 install --no-cache-dir --break-system-packages bcrypt psycopg2
 
 ARG ELIXIR_VSN
 RUN wget -O - https://github.com/elixir-lang/elixir/archive/v$ELIXIR_VSN.tar.gz \
@@ -170,6 +178,15 @@ RUN apk -U upgrade --available --no-cache \
         tini \
     && rm /tmp/runDeps \
     && ln -fs /usr/lib/libtdsodbc.so.0 /usr/lib/libtdsodbc.so
+
+RUN apk -U add --no-cache \
+        python3 \
+        py3-pip \
+        build-base \
+        postgresql-dev \
+        python3-dev
+# Install Python packages globally
+RUN pip3 install --no-cache-dir --break-system-packages bcrypt psycopg2
 
 ARG USER
 ARG UID


### PR DESCRIPTION
Dockerfile: add Python & psycopg2 support for external auth scripts

This change installs python3, pip, and required build deps in both build and runtime stages, and globally installs bcrypt and psycopg2.

Motivation:
- ejabberd supports external authentication scripts written in Python.
- These scripts often require bcrypt (password hashing) and psycopg2 (PostgreSQL driver).
- Currently, users need to extend the official image to add these dependencies manually.

With this change, the official Docker image can run Python auth scripts out of the box.

## Summary

This PR updates the Dockerfile to include Python support and
common dependencies needed for ejabberd authentication scripts.

### Changes
- Install `python3`, `py3-pip`, `python3-dev`, `postgresql-dev`,
  and build tools via `apk`.
- Install Python packages `bcrypt` and `psycopg2` globally.

### Motivation
Many ejabberd deployments rely on custom external authentication
scripts, frequently written in Python. A common pattern is to use:

- `bcrypt` for password hashing
- `psycopg2` for PostgreSQL access

At present, the official Docker image does not include these
dependencies, forcing users to extend the Dockerfile themselves.

### Benefits
- Provides out-of-the-box support for Python authentication scripts.
- Reduces friction for users deploying ejabberd with PostgreSQL and bcrypt-based password verification.
- Makes the image more immediately useful in production without customization.

### Notes
- The additions are lightweight (~a few MB).
- Maintains compatibility with existing builds.
- If the project prefers minimal images, an alternative approach
  would be to publish an additional `-with-python` variant.

---