### PR TITLE
CI: bump XMPP-Interop-Testing/xmpp-interop-tests-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     - name: Run XMPP Interoperability Tests against CI server.
       if: matrix.otp == '27'
       continue-on-error: true
-      uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.6.0
+      uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.6.1
       with:
         domain: 'localhost'
         adminAccountUsername: 'admin'


### PR DESCRIPTION
Updates this GitHub Action that's used to execute XMPP-based interop tests from v1.6.0 to v1.6.1.

This is a bugfix release that should increase the stability / predictability of test execution.

A notable change is that the file structure in which XMPP stanzas are generated (which is provided as debug output) has changed. They are still stored in the directory denoted by the logDir argument, but the file structure in that directory has changed somewhat.