### PR TITLE
Rename New SQL schema to Multihost, and Default to Singlehost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
         sudo -u postgres psql ejabberd_test -c "GRANT ALL PRIVILEGES ON ALL
                                                 SEQUENCES IN SCHEMA public
                                                 TO ejabberd_test;"
-        sed -i 's|new_schema, false|new_schema, true|g' test/suite.erl
+        sed -i 's|multihost_schema, false|multihost_schema, true|g' test/suite.erl
     - name: Run DB tests on new schema (mssql, mysql, pgsql)
       run: CT_BACKENDS=mssql,mysql,pgsql make test
       id: ctnewschema

--- a/configure.ac
+++ b/configure.ac
@@ -192,12 +192,20 @@ AC_ARG_ENABLE(mysql,
 esac],[if test "x$mysql" = "x"; then mysql=false; fi])
 
 AC_ARG_ENABLE(new_sql_schema,
-[AS_HELP_STRING([--enable-new-sql-schema],[use new SQL schema by default (default: no)])],
+[AS_HELP_STRING([--enable-new-sql-schema],[obsolete, use --enable-multihost-sql-schema instead (default: no)])],
 [case "${enableval}" in
-  yes) new_sql_schema=true ;;
-  no)  new_sql_schema=false ;;
+  yes) multihost_sql_schema=true ;;
+  no)  multihost_sql_schema=false ;;
   *) AC_MSG_ERROR(bad value ${enableval} for --enable-new-sql-schema) ;;
-esac],[new_sql_schema=false])
+esac],[multihost_sql_schema=false])
+
+AC_ARG_ENABLE(multihost_sql_schema,
+[AS_HELP_STRING([--enable-multihost-sql-schema],[use multihost SQL schema by default (default: no)])],
+[case "${enableval}" in
+  yes) multihost_sql_schema=true ;;
+  no)  multihost_sql_schema=false ;;
+  *) AC_MSG_ERROR(bad value ${enableval} for --enable-multihost-sql-schema) ;;
+esac],[multihost_sql_schema=false])
 
 AC_ARG_ENABLE(odbc,
 [AS_HELP_STRING([--enable-odbc],[enable pure ODBC support (default: no)])],
@@ -318,7 +326,7 @@ esac
 AC_MSG_RESULT([build tool to use (change using --with-rebar): $rebar])
 
 AC_SUBST(roster_gateway_workaround)
-AC_SUBST(new_sql_schema)
+AC_SUBST(multihost_sql_schema)
 AC_SUBST(full_xml)
 AC_SUBST(odbc)
 AC_SUBST(mssql)

--- a/include/ejabberd_sql.hrl
+++ b/include/ejabberd_sql.hrl
@@ -72,4 +72,4 @@
 -record(sql_schema_info,
         {db_type :: pgsql | mysql | sqlite,
          db_version :: any(),
-         new_schema = true :: boolean()}).
+         multihost_schema = true :: boolean()}).

--- a/mix.exs
+++ b/mix.exs
@@ -110,7 +110,7 @@ defmodule Ejabberd.MixProject do
                             {config(:debug), :debug_info},
                             {not config(:debug), {:debug_info, false}},
                             {config(:roster_gateway_workaround), {:d, :ROSTER_GATEWAY_WORKAROUND}},
-                            {config(:new_sql_schema), {:d, :NEW_SQL_SCHEMA}}
+                            {config(:multihost_sql_schema), {:d, :MULTIHOST_SQL_SCHEMA}}
                            ], do:
     option
   end

--- a/rebar.config
+++ b/rebar.config
@@ -144,7 +144,7 @@
             {if_var_false, debug, no_debug_info},
             {if_var_true, debug, debug_info},
             {if_var_true, elixir, {d, 'ELIXIR_ENABLED'}},
-            {if_var_true, new_sql_schema, {d, 'NEW_SQL_SCHEMA'}},
+            {if_var_true, multihost_sql_schema, {d, 'MULTIHOST_SQL_SCHEMA'}},
             {if_var_true, roster_gateway_workaround, {d, 'ROSTER_GATEWAY_WORKAROUND'}},
             {if_var_true, sip, {d, 'SIP'}},
             {if_var_true, stun, {d, 'STUN'}},

--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -1169,9 +1169,9 @@ get_commands_spec() ->
 			longdesc = "This command is exclusive for the ejabberdctl command-line script, "
 			"don't attempt to execute it using any other API frontend.",
 			note = "added in 24.02",
-			args = [{db_type, string}, {db_version, string}, {new_schema, string}],
+			args = [{db_type, string}, {db_version, string}, {multihost_schema, string}],
                         args_desc = ["Database type: pgsql | mysql | sqlite",
                                      "Your database version: 16.1, 8.2.0...",
-                                     "Use new schema: 0, false, 1 or true"],
+                                     "Use multihost schema: 0, false, 1 or true"],
                         args_example = ["pgsql", "16.1", "true"]}
     ].

--- a/src/ejabberd_option.erl
+++ b/src/ejabberd_option.erl
@@ -162,6 +162,7 @@
 -export([sql_prepared_statements/0, sql_prepared_statements/1]).
 -export([sql_query_timeout/0, sql_query_timeout/1]).
 -export([sql_queue_type/0, sql_queue_type/1]).
+-export([sql_schema_multihost/0]).
 -export([sql_server/0, sql_server/1]).
 -export([sql_ssl/0, sql_ssl/1]).
 -export([sql_ssl_cafile/0, sql_ssl_cafile/1]).
@@ -1103,6 +1104,10 @@ sql_queue_type() ->
 -spec sql_queue_type(global | binary()) -> 'file' | 'ram'.
 sql_queue_type(Host) ->
     ejabberd_config:get_option({sql_queue_type, Host}).
+
+-spec sql_schema_multihost() -> boolean().
+sql_schema_multihost() ->
+    ejabberd_config:get_option({sql_schema_multihost, global}).
 
 -spec sql_server() -> binary().
 sql_server() ->

--- a/src/ejabberd_options.erl
+++ b/src/ejabberd_options.erl
@@ -21,10 +21,10 @@
 
 -export([opt_type/1, options/0, globals/0, doc/0]).
 
--ifdef(NEW_SQL_SCHEMA).
--define(USE_NEW_SQL_SCHEMA_DEFAULT, true).
+-ifdef(MULTIHOST_SQL_SCHEMA).
+-define(USE_MULTIHOST_SQL_SCHEMA_DEFAULT, true).
 -else.
--define(USE_NEW_SQL_SCHEMA_DEFAULT, false).
+-define(USE_MULTIHOST_SQL_SCHEMA_DEFAULT, false).
 -endif.
 
 -include_lib("kernel/include/inet.hrl").
@@ -267,6 +267,8 @@ opt_type(negotiation_timeout) ->
 opt_type(net_ticktime) ->
     econf:timeout(second);
 opt_type(new_sql_schema) ->
+    econf:bool();
+opt_type(sql_schema_multihost) ->
     econf:bool();
 opt_type(update_sql_schema) ->
     econf:bool();
@@ -632,7 +634,8 @@ options() ->
      {modules, []},
      {negotiation_timeout, timer:seconds(120)},
      {net_ticktime, timer:seconds(60)},
-     {new_sql_schema, ?USE_NEW_SQL_SCHEMA_DEFAULT},
+     {new_sql_schema, ?USE_MULTIHOST_SQL_SCHEMA_DEFAULT},
+     {sql_schema_multihost, ?USE_MULTIHOST_SQL_SCHEMA_DEFAULT},
      {update_sql_schema, true},
      {update_sql_schema_timeout, timer:minutes(5)},
      {oauth_access, none},
@@ -822,6 +825,7 @@ globals() ->
      sm_cache_life_time,
      sm_cache_missed,
      sm_cache_size,
+     sql_schema_multihost,
      trusted_proxies,
      validate_stream,
      version,

--- a/src/ejabberd_options_doc.erl
+++ b/src/ejabberd_options_doc.erl
@@ -992,23 +992,30 @@ doc() ->
                "bugs. Usually leaving default value of this is option is best, "
                "tweak it only if you know what you are doing. "
                "The default value is '1 minute'.")}},
-     {new_sql_schema,
+     {sql_schema_multihost,
       #{value => "true | false",
+        note => "renamed in 25.xx",
         desc =>
             {?T("Whether to use the "
-                "_`database.md#default-and-new-schemas|new SQL schema`_. "
+                "_`database.md#default-and-new-schemas|multihost SQL schema`_. "
                 "All schemas are located "
                 "at <https://github.com/processone/ejabberd/tree/~s/sql>. "
-                "There are two schemas available. The default legacy schema "
+                "There are two schemas available. The legacy 'singlehost' schema "
                 "stores one XMPP domain into one ejabberd database. "
-                "The 'new' schema can handle several XMPP domains in a "
-                "single ejabberd database. Using this 'new' schema is best when "
+                "The 'multihost' schema can handle several XMPP domains in a "
+                "single ejabberd database. The 'multihost' schema is preferable when "
                 "serving several XMPP domains and/or changing domains from "
                 "time to time. This avoid need to manage several databases and "
                 "handle complex configuration changes. The default depends on "
-                "configuration flag '--enable-new-sql-schema' which is set "
+                "configuration flag '--enable-sql-schema-multihost' which is set "
                 "at compile time."),
              [binary:part(ejabberd_config:version(), {0,5})]}}},
+     {new_sql_schema,
+      #{value => "true | false",
+        note => "obsoleted in 25.xx",
+        desc =>
+            {?T("This option was renamed to _`sql_schema_multihost`_ in ejabberd 25.xx. "
+                "Please update your configuration to use the new option name")}}},
      {update_sql_schema,
       #{value => "true | false",
         note => "updated in 24.06",

--- a/src/ejabberd_sql.erl
+++ b/src/ejabberd_sql.erl
@@ -41,6 +41,7 @@
 	 abort/1,
 	 restart/1,
 	 use_new_schema/0,
+	 use_multihost_schema/0,
 	 sql_query_to_iolist/1,
 	 sql_query_to_iolist/2,
 	 escape/1,
@@ -69,6 +70,8 @@
 
 -export([connecting/2, connecting/3,
 	 session_established/2, session_established/3]).
+
+-deprecated({use_new_schema, 0}).
 
 -ifdef(OTP_BELOW_28).
 -ifdef(OTP_BELOW_26).
@@ -353,8 +356,11 @@ sqlite_file(Host) ->
 	    binary_to_list(File)
     end.
 
+use_multihost_schema() ->
+    ejabberd_option:sql_schema_multihost().
+
 use_new_schema() ->
-    ejabberd_option:new_sql_schema().
+    use_multihost_schema().
 
 -spec get_worker(binary()) -> atom().
 get_worker(Host) ->

--- a/src/ejabberd_sql_pt.erl
+++ b/src/ejabberd_sql_pt.erl
@@ -40,7 +40,7 @@
                 res_pos = 0,
                 server_host_used = false,
                 used_vars = [],
-                use_new_schema,
+                use_multihost_schema,
                 need_timestamp_pass = false,
                 need_array_pass = false,
                 has_list = false}).
@@ -245,13 +245,13 @@ transform_insert(Form, TableArg, FieldsArg) ->
 parse(S, Loc, UseNewSchema) ->
     parse1(S, [],
            #state{loc = Loc,
-                  use_new_schema = UseNewSchema}).
+                  use_multihost_schema = UseNewSchema}).
 
 parse(S, ParamPos, Loc, UseNewSchema) ->
     parse1(S, [],
            #state{loc = Loc,
                   param_pos = ParamPos,
-                  use_new_schema = UseNewSchema}).
+                  use_multihost_schema = UseNewSchema}).
 
 parse1([], Acc, State) ->
     State1 = append_string(lists:reverse(Acc), State),
@@ -300,7 +300,7 @@ parse1([$%, $( | S], Acc, State) ->
                 State3 =
                     State2#state{server_host_used = {true, Name},
                                  used_vars = [Name | State2#state.used_vars]},
-                case State#state.use_new_schema of
+                case State#state.use_multihost_schema of
                     true ->
                         Convert =
                             erl_syntax:application(
@@ -469,7 +469,7 @@ make_sql_query(State) ->
     make_sql_query(State, unknown).
 
 make_sql_query(State, Type) ->
-    Hash = erlang:phash2(State#state{loc = undefined, use_new_schema = true}),
+    Hash = erlang:phash2(State#state{loc = undefined, use_multihost_schema = true}),
     SHash = <<"Q", (integer_to_binary(Hash))/binary>>,
     Query = pack_query(State#state.'query'),
     Flags = case State#state.has_list of true -> 1; _ -> 0 end,
@@ -938,7 +938,7 @@ make_schema_check(New, Old) ->
     erl_syntax:case_expr(
       erl_syntax:application(
         erl_syntax:atom(ejabberd_sql),
-        erl_syntax:atom(use_new_schema),
+        erl_syntax:atom(use_multihost_schema),
         []),
       [erl_syntax:clause(
          [erl_syntax:abstract(true)],

--- a/src/ejabberd_sql_schema.erl
+++ b/src/ejabberd_sql_schema.erl
@@ -49,7 +49,7 @@ start(Host) ->
                                   #sql_schema_info{
                                      db_type = DBType,
                                      db_version = DBVersion,
-                                     new_schema = ejabberd_sql:use_new_schema()}
+                                     multihost_schema = ejabberd_sql:use_multihost_schema()}
                           end),
                     Table = filter_table_sh(SchemaInfo, schema_table()),
                     Res = create_table(Host, SchemaInfo, Table),
@@ -268,7 +268,7 @@ table_exists(Host, Table) ->
       end).
 
 filter_table_sh(SchemaInfo, Table) ->
-    case {SchemaInfo#sql_schema_info.new_schema, Table#sql_table.name} of
+    case {SchemaInfo#sql_schema_info.multihost_schema, Table#sql_table.name} of
         {true, _} ->
             Table;
         {_, <<"route">>} ->
@@ -407,7 +407,7 @@ get_current_version(Host, Module, Schemas) ->
 
 sqlite_table_copy_t(SchemaInfo, Table) ->
     TableName = Table#sql_table.name,
-    NewTableName = <<"new_", TableName/binary>>,
+    NewTableName = <<"multihost_", TableName/binary>>,
     NewTable = Table#sql_table{name = NewTableName},
     create_table_t(SchemaInfo, NewTable),
     Columns = lists:join(<<",">>,
@@ -777,7 +777,7 @@ should_update_schema(Host) ->
         end,
     case ejabberd_option:update_sql_schema() andalso SupportedDB of
         true ->
-            case ejabberd_sql:use_new_schema() of
+            case ejabberd_sql:use_multihost_schema() of
                 true ->
                     lists:member(sql, ejabberd_option:auth_method(Host));
                 false ->
@@ -850,7 +850,7 @@ update_schema(Host, Module, RawSchemas) ->
                           #sql_schema_info{
                              db_type = DBType,
                              db_version = DBVersion,
-                             new_schema = ejabberd_sql:use_new_schema()}
+                             multihost_schema = ejabberd_sql:use_multihost_schema()}
                   end),
             Schemas = preprocess_schemas(SchemaInfo, RawSchemas),
             Version = get_current_version(Host, Module, Schemas),
@@ -954,7 +954,7 @@ do_update_schema(Host, Module, SchemaInfo, Schema) ->
                    end;
                ({create_index, TableName, Columns1}) ->
                    Columns =
-                       case ejabberd_sql:use_new_schema() of
+                       case ejabberd_sql:use_multihost_schema() of
                            true ->
                                Columns1;
                            false ->
@@ -1005,7 +1005,7 @@ do_update_schema(Host, Module, SchemaInfo, Schema) ->
                    end;
                ({update_primary_key, TableName, Columns1}) ->
                    Columns =
-                       case ejabberd_sql:use_new_schema() of
+                       case ejabberd_sql:use_multihost_schema() of
                            true ->
                                Columns1;
                            false ->
@@ -1071,7 +1071,7 @@ do_update_schema(Host, Module, SchemaInfo, Schema) ->
                    end;
                ({drop_index, TableName, Columns1}) ->
                    Columns =
-                       case ejabberd_sql:use_new_schema() of
+                       case ejabberd_sql:use_multihost_schema() of
                            true ->
                                Columns1;
                            false ->
@@ -1160,7 +1160,7 @@ print_schema(SDBType, SDBVersion, SNewSchema) ->
             "false" -> false;
             "true" -> true;
             _ ->
-                io:format("new_schema must be one of the following: "
+                io:format("multihost_schema must be one of the following: "
                           "'0', '1', 'false', 'true'~n"),
                 error
         end,
@@ -1172,7 +1172,7 @@ print_schema(SDBType, SDBVersion, SNewSchema) ->
                 #sql_schema_info{
                    db_type = DBType,
                    db_version = DBVersion,
-                   new_schema = NewSchema},
+                   multihost_schema = NewSchema},
             Mods = ejabberd_config:beams(all),
             lists:foreach(
               fun(Mod) ->

--- a/src/ejabberd_sql_sup.erl
+++ b/src/ejabberd_sql_sup.erl
@@ -196,7 +196,7 @@ check_sqlite_db(Host) ->
 
 create_sqlite_tables(DB) ->
     SqlDir = misc:sql_dir(),
-    Filename = case ejabberd_sql:use_new_schema() of
+    Filename = case ejabberd_sql:use_multihost_schema() of
         true -> "lite.new.sql";
         false -> "lite.sql"
     end,

--- a/src/mod_admin_update_sql.erl
+++ b/src/mod_admin_update_sql.erl
@@ -1,7 +1,7 @@
 %%%-------------------------------------------------------------------
 %%% File    : mod_admin_update_sql.erl
 %%% Author  : Alexey Shchepin <alexey@process-one.net>
-%%% Purpose : Convert SQL DB to the new format
+%%% Purpose : Convert the SQL database from singlehost to multihost
 %%% Created :  9 Aug 2017 by Alexey Shchepin <alexey@process-one.net>
 %%%
 %%%
@@ -65,7 +65,7 @@ depends(_Host, _Opts) ->
 
 get_commands_spec() ->
     [#ejabberd_commands{name = update_sql, tags = [sql],
-                        desc = "Convert MS SQL, MySQL or PostgreSQL DB to the new format",
+                        desc = "Convert SQL database from singlehost to multihost (MS SQL, MySQL, PostgreSQL)",
                         note = "improved in 23.04",
                         module = ?MODULE, function = update_sql,
                         args = [],
@@ -119,11 +119,11 @@ update_sql(Host) ->
     end.
 
 check_config() ->
-    case ejabberd_sql:use_new_schema() of
+    case ejabberd_sql:use_multihost_schema() of
         true -> ok;
         false ->
-            ejabberd_config:set_option(new_sql_schema, true),
-            io:format('~nNOTE: you must add "new_sql_schema: true" to ejabberd.yml before next restart~n~n', [])
+            ejabberd_config:set_option(sql_schema_multihost, true),
+            io:format('~nNOTE: you must add "sql_schema_multihost: true" to ejabberd.yml before next restart~n~n', [])
     end.
 
 update_tables(State) ->

--- a/src/mod_mam_sql.erl
+++ b/src/mod_mam_sql.erl
@@ -656,7 +656,7 @@ make_sql_query(User, LServer, MAMQuery, RSM, ExtraUsernames) ->
     SUser = ToString(User),
     SServer = ToString(LServer),
 
-    HostMatch = case ejabberd_sql:use_new_schema() of
+    HostMatch = case ejabberd_sql:use_multihost_schema() of
 		    true ->
 			[<<" and server_host=", SServer/binary>>];
 		    _ ->

--- a/src/mod_roster.erl
+++ b/src/mod_roster.erl
@@ -1192,7 +1192,7 @@ import_stop(_LServer, _DBType) ->
     ok.
 
 row_length() ->
-    case ejabberd_sql:use_new_schema() of
+    case ejabberd_sql:use_multihost_schema() of
         true -> 10;
         false -> 9
     end.

--- a/src/mod_vcard_sql.erl
+++ b/src/mod_vcard_sql.erl
@@ -332,7 +332,7 @@ make_matchspec(LServer, Data) ->
     filter_fields(Data, <<"">>, LServer).
 
 filter_fields([], Match, LServer) ->
-    case ejabberd_sql:use_new_schema() of
+    case ejabberd_sql:use_multihost_schema() of
         true ->
             SQLType = ejabberd_option:sql_type(LServer),
             SServer = ejabberd_sql:to_string_literal(SQLType, LServer),

--- a/test/ejabberd_SUITE.erl
+++ b/test/ejabberd_SUITE.erl
@@ -1089,7 +1089,7 @@ update_sql(Host, Config) ->
     end.
 
 schema_suffix(Config) ->
-    case ejabberd_sql:use_new_schema() of
+    case ejabberd_sql:use_multihost_schema() of
         true ->
             case ?config(update_sql, Config) of
                 true ->  ".sql";

--- a/test/ejabberd_SUITE_data/ejabberd.yml
+++ b/test/ejabberd_SUITE_data/ejabberd.yml
@@ -165,7 +165,7 @@ shaper:
 certfiles:
   - CERTFILE
 
-new_sql_schema: NEW_SCHEMA
+sql_schema_multihost: MULTIHOST_SCHEMA
 
 update_sql_schema: UPDATE_SQL_SCHEMA
 

--- a/test/ejabberd_SUITE_data/macros.yml
+++ b/test/ejabberd_SUITE_data/macros.yml
@@ -13,7 +13,7 @@ define_macro:
   PRIV_DIR: "@@priv_dir@@"
   PUT_URL: "http://upload.@HOST@:@@web_port@@/upload"
   GET_URL: "http://upload.@HOST@:@@web_port@@/upload"
-  NEW_SCHEMA: @@new_schema@@
+  MULTIHOST_SCHEMA: @@multihost_schema@@
   UPDATE_SQL_SCHEMA: @@update_sql_schema@@
   MYSQL_USER: "@@mysql_user@@"
   MYSQL_SERVER: "@@mysql_server@@"

--- a/test/suite.erl
+++ b/test/suite.erl
@@ -63,7 +63,7 @@ init_config(Config) ->
 		      MacrosContentTpl,
 		      [{c2s_port, 5222},
 		       {loglevel, 4},
-		       {new_schema, false},
+		       {multihost_schema, false},
 		       {update_sql_schema, true},
 		       {s2s_port, 5269},
 		       {stun_port, 3478},

--- a/vars.config.in
+++ b/vars.config.in
@@ -22,7 +22,7 @@
 {roster_gateway_workaround, @roster_gateway_workaround@}.
 {full_xml, @full_xml@}.
 {debug, @debug@}.
-{new_sql_schema, @new_sql_schema@}.
+{multihost_sql_schema, @multihost_sql_schema@}.
 
 {tools, @tools@}.
 


### PR DESCRIPTION
When ejabberd first got support for SQL storage, it only supported one vhost, so it made sense to **not** store the host in the SQL tables. Additionally, the SQL schema in ejabberd followed that of jabberd14, which didn't support vhost either.

When ejabberd got support for multiple vhosts, if several of them want to use SQL storage, the solution is to configure a different SQL database for each vhost using the `host_config` toplevel option.

However, when there are many vhosts configured in ejabberd, all of them using SQL storage, it is preferable to setup one single SQL database, and store the vhost in the tables. When that feature was added to ejabberd, it got the name of "new SQL schema". And the previous  SQL schema was called "legacy", "old", and nowadays "default".

The problem with the terms "default" and "new" is that they are circumstantial, and do not really describe the schema features or purposes.

I propose to rename:
 - "default SQL schema" --> "singlehost SQL schema"
 - "new SQL schema" --> "multihost SQL schema"

---

Right now all names are supported, the previous (obsolete) and the renamed (preferred). The changes relevant to the usage are:

When preparing configuration, the arguments:
```
  ./configure --enable-new-sql-schema
  ./configure --enable-multihost-sql-schema
```

When configuring ejabberd, the toplevel options:
```
  new_sql_schema: true
  sql_schema_multihost: true
```

When developing source code, the functions:
```
  ejabberd_sql:use_new_schema()
  ejabberd_sql:use_multihost_schema()
```