### PR TITLE
CI: bump XMPP-Interop-Testing/xmpp-interop-tests-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     - name: Run XMPP Interoperability Tests against CI server.
       if: matrix.otp == '27'
       continue-on-error: true
-      uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.6.1
+      uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.7.1
       with:
         domain: 'localhost'
         adminAccountUsername: 'admin'


### PR DESCRIPTION
Updates this GitHub Action that's used to execute XMPP-based interop tests from v1.6.1 to v1.7.1.

This does not bring a significant amount of new tests (although some early tests for XEP-0060: 'Publish/Subscribe' were added), but does improve the stability of the existing tests (meaning: less false positives and less 'flacky' tests).

Additional configuration options have been added:

- there now are three different ways to provision test accounts on the server-under-test. That should make it easier for some to embed our tests to their pipeline
- the failOnImpossibleTest option fails the test run if any configured tests were impossible to execute, ensuring all intended tests actually ran.
