### PR TITLE
Update the supported XEP-0363 version in the doap file

### DIFF
--- a/ejabberd.doap
+++ b/ejabberd.doap
@@ -650,7 +650,7 @@
     <implements>
       <xmpp:SupportedXep>
         <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0363.html"/>
-        <xmpp:version>0.3.0</xmpp:version>
+        <xmpp:version>1.2.0</xmpp:version>
         <xmpp:since>15.10</xmpp:since>
         <xmpp:status>complete</xmpp:status>
         <xmpp:note>mod_http_upload</xmpp:note>


### PR DESCRIPTION
Client developers that are interested in HTTP file upload purposes (XEP-0363 v1.2.0) are often unaware that it is already supported by ejabberd.
Since this feature is not available yet in other server software, the lack of knowledge of ejabberd support can discourage client authors from implementing this feature.

This feature was implemented in https://github.com/processone/xmpp/commit/fb832862733a3d67832f90b64df15d5154e9ad2f / https://github.com/processone/ejabberd/commit/ff3d33dde491a6aa585a3f8be806360c20ce6ca0 and was part of the 25.08 release.