### PR TITLE
CI: bump XMPP-Interop-Testing/xmpp-interop-tests-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     - name: Run XMPP Interoperability Tests against CI server.
       if: matrix.otp == '27'
       continue-on-error: true
-      uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.7.1
+      uses: XMPP-Interop-Testing/xmpp-interop-tests-action@v1.7.2
       with:
         domain: 'localhost'
         adminAccountUsername: 'admin'


### PR DESCRIPTION
Updates this GitHub Action that's used to execute XMPP-based interop tests from v1.7.1 to v1.7.2.

This bugfix release introduces some changes that improve the stability of the tests. Highlights include:

- No longer includes tests that verify client, instead of server behavior
- Add prerequisite checks for various tests, to prevent them from failing if the server under test doesn't support the feature
- Remove prerequisite checks for other tests where they needlessly prevent a test from executing
