### PR TITLE
fix nasty ssl warnings

### DIFF
--- a/src/ejabberd_c2s.erl
+++ b/src/ejabberd_c2s.erl
@@ -344,7 +344,7 @@ process_terminated(#{sid := SID, jid := JID, user := U, server := S, resource :=
     bounce_message_queue(SID, JID),
     State1;
 process_terminated(#{stop_reason := {tls, _}} = State, Reason) ->
-    ?WARNING_MSG("(~ts) Failed to secure c2s connection: ~ts",
+    ?INFO_MSG("(~ts) Failed to secure c2s connection: ~ts",
 		 [case maps:find(socket, State) of
 		      {ok, Socket} -> xmpp_socket:pp(Socket);
 		      _ -> <<"unknown">>

--- a/src/ejabberd_s2s_in.erl
+++ b/src/ejabberd_s2s_in.erl
@@ -285,8 +285,12 @@ terminate(Reason, #{auth_domains := AuthDomains,
 		    socket := Socket} = State) ->
     case maps:get(stop_reason, State, undefined) of
 	{tls, _} = Err ->
-	    ?WARNING_MSG("(~ts) Failed to secure inbound s2s connection: ~ts",
-			 [xmpp_socket:pp(Socket), xmpp_stream_in:format_error(Err)]);
+            RServer = case State of
+                         #{remote_server := RS} -> RS;
+                         _ -> <<"unknown">>
+                     end,
+	    ?WARNING_MSG("(~ts) Failed to secure inbound s2s connection to ~ts: ~ts",
+			 [xmpp_socket:pp(Socket), RServer, xmpp_stream_in:format_error(Err)]);
 	_ ->
 	    ok
     end,


### PR DESCRIPTION
The way those SSL warning messages are designed today tend to clog up log files without delivering worthwhile information that would enable an admin to take some action. That’s why I’d demote c2s warnings to info msgs while adding source information to s2s_in warnings.