### PR TITLE
mod_conversejs: Expand is_served_file for more types of assets

### DIFF
--- a/src/mod_conversejs.erl
+++ b/src/mod_conversejs.erl
@@ -126,10 +126,13 @@ is_served_file([<<"converse.min.css">>]) -> true;
 is_served_file([<<"converse.min.js.map">>]) -> true;
 is_served_file([<<"converse.min.css.map">>]) -> true;
 is_served_file([<<"emojis.js">>]) -> true;
+is_served_file([<<"emoji.json">>]) -> true;
 is_served_file([<<"locales">>, _]) -> true;
 is_served_file([<<"locales">>, <<"dayjs">>, _]) -> true;
 is_served_file([<<"webfonts">>, _]) -> true;
 is_served_file([<<"plugins">>, _]) -> true;
+is_served_file([<<"sounds">>, _]) -> true;
+is_served_file([<<"images">>| _]) -> true;
 is_served_file(_) -> false.
 
 serve(Host, LocalPath) ->
@@ -174,7 +177,13 @@ content_type(Filename) ->
         ".map"  -> "application/json";
         ".ttf"  -> "font/ttf";
         ".woff"  -> "font/woff";
-        ".woff2"  -> "font/woff2"
+        ".woff2" -> "font/woff2";
+        ".mp3"   -> "audio/mpeg";
+        ".ogg"   -> "audio/ogg";
+        ".png"   -> "image/png";
+        ".svg"   -> "image/svg+xml";
+        ".ico"   -> "image/vnd.microsoft.icon";
+        ".json"  -> "application/json"
     end.
 
 %%----------------------------------------------------------------------


### PR DESCRIPTION
New versions of conversejs (I tested [12.0.0](https://github.com/conversejs/converse.js/releases/download/v12.0.0/converse.js-12.0.0.tgz)) use more types of assets, sounds and images in particular. The directory structure looks like that:

<details>

```
./converse.min.js
./converse.js
./converse-no-dependencies.js
./converse.min.esm.js.map
./images
./images/favicon.ico
./images/custom_emojis
./images/custom_emojis/xmpp.png
./images/custom_emojis/converse.png
./images/logo
./images/logo/conversejs-filled-512.png
./images/logo/conversejs-gold-gradient.svg
./images/logo/conversejs-filled-192.svg
./images/logo/conversejs-filled.svg
./images/logo/conversejs-filled-512.svg
./images/logo/conversejs-filled-192.png
./plugins
./plugins/libsignal-protocol.js
./plugins/libsignal-protocol.min.js
./shared-connection-worker.js
./converse.css.map
./converse-headless.js.map
./converse-headless.min.js
./emoji.json
./tmp.css
./tmp.css.map
./converse.min.css
./converse.esm.js
./sounds
./sounds/README
./sounds/msg_received.ogg
./sounds/msg_received.mp3
./converse.esm.js.map
./locales
./locales/si-LC_MESSAGES-converse-po.js
...
./locales/dayjs
./locales/dayjs/bo-js.js.map
...
./converse.js.map
./converse-no-dependencies.js.map
./converse.min.css.map
./converse.min.esm.js
./converse-headless.esm.js.map
./website.css.map
./manifest.json
./website.css
./converse.css
./webfonts
./webfonts/baumans.ttf
./webfonts/muli.ttf
./converse-headless.js
./converse-headless.min.js.map
./website.min.css
./converse-headless.min.esm.js.map
./converse-headless.esm.js
./converse.min.js.map
./converse-headless.min.esm.js
```

</details>

This simple fix accounts for the new types of assets and extends types of files being served. I've tested it manually.