### PR TITLE
validate checksum for downloads

### DIFF
--- a/tools/dl_invites_page_deps.sh
+++ b/tools/dl_invites_page_deps.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+set -e
+
+jquery_checksum='fc9a93dd241f6b045cbff0481cf4e1901becd0e12fb45166a8f17f95823f0b1a';
+bootstrap4_checksum='dc9b29fe7100e69d1a512860497bd2237eadccde6e813e588416429359832dce';
+
+check() {
+  echo "$1 $2" | sha256sum -c - || (echo "checksum failed: $2 (does not match $1)"; exit 1)
+}
+
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <install_dir>"
     exit 1
@@ -7,10 +16,16 @@ fi
 install_dir="$1"
 
 mkdir -p "$install_dir/jquery"
-curl -s -o "$install_dir/jquery/jquery.min.js" https://code.jquery.com/jquery-3.7.1.min.js
+jquery="$(mktemp /tmp/jquery.XXXXXXXXX)"
+curl -s -o $jquery https://code.jquery.com/jquery-3.7.1.min.js
+check $jquery_checksum $jquery
+mv $jquery "$install_dir/jquery/jquery.min.js"
 
-curl -L -s -o /tmp/bootstrap4.zip https://github.com/twbs/bootstrap/releases/download/v4.6.2/bootstrap-4.6.2-dist.zip
-unzip -d "$install_dir" /tmp/bootstrap4.zip
+bootstrap4="$(mktemp /tmp/bootstrap4.XXXXXXXXX)"
+curl -L -s -o $bootstrap4 https://github.com/twbs/bootstrap/releases/download/v4.6.2/bootstrap-4.6.2-dist.zip
+check $bootstrap4_checksum $bootstrap4
+
+unzip -q -d "$install_dir" $bootstrap4
 mv "$install_dir/bootstrap-4.6.2-dist" "$install_dir/bootstrap4"
-rm /tmp/bootstrap4.zip
+rm $bootstrap4
 echo "landing page dependencies for mod_invites installed to $install_dir"


### PR DESCRIPTION
also use mktemp for temporary files
also use set -e to stop in case of error

This is a security fix to make sure downloaded files can not be tempered with, remote or locally.

This script creates a hard dependency on code.jquery.com (and github fwiiw). Just to be aware. There are no fallbacks at this moment.

Alternative would be to use a package manager like `npm` or `yarn` which might handle such situations automatically.
But of course would add a lot of bloat too. YMMV