### PR TITLE
fix: use correct hook name in filter_presence_hook

### DIFF
--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2152,7 +2152,7 @@ filter_presence_hook(#state{users = Users} = StateData, Nick, #presence{from = F
 		 end,
     Pres2 = xmpp:append_subtags(xmpp:remove_subtag(Pres, #occupant_id{}),
 				[#occupant_id{id = OccupantId}]),
-    ejabberd_hooks:run_fold(muc_filter_message,
+    ejabberd_hooks:run_fold(muc_filter_presence,
 			    StateData#state.server_host,
 			    Pres2,
 			    [StateData, Nick]).


### PR DESCRIPTION
As part of the `occupant_id` refactor in https://github.com/processone/ejabberd/commit/77329841337ea4aae10726484f6e7c8370b38962, the `muc_filter_presence` hook was incorrectly copied from `muc_filter_message` which broke anything relying on the presence hook.

This PR simply corrects the hook name.