### PR TITLE
set meta.pre-auth to skip redirect_url if token validated

### DIFF
--- a/src/mod_invites_register.erl
+++ b/src/mod_invites_register.erl
@@ -74,7 +74,8 @@ c2s_unauthenticated_packet(#{invite := Invite} = State,
                    IQ1 = xmpp:set_els(IQ, [Register]),
                    User = Invite#invite_token.account_name,
                    IQ2 = xmpp:set_from_to(IQ1, jid:make(User, Server), jid:make(Server)),
-                   ResIQ = mod_register:process_iq(IQ2),
+                   Meta = xmpp:get_meta(IQ2),
+                   ResIQ = mod_register:process_iq(xmpp:set_meta(IQ2, Meta#{pre_auth => true})),
                    ResIQ1 = xmpp:set_from_to(ResIQ, jid:make(Server), undefined),
                    {stop, ejabberd_c2s:send(State, ResIQ1)}
                 end);

--- a/src/mod_register.erl
+++ b/src/mod_register.erl
@@ -215,8 +215,9 @@ process_iq(#iq{type = get, from = From, to = To, id = ID, lang = Lang} = IQ,
     Instr = translate:translate(
 	      Lang, ?T("Choose a username and password to register "
 		       "with this server")),
+    IsPreAuth = maps:get(pre_auth, xmpp:get_meta(IQ), false) == true,
     URL = mod_register_opt:redirect_url(Server),
-    if (URL /= undefined) and not IsRegistered ->
+    if (URL /= undefined) and not IsRegistered and not IsPreAuth ->
 	    Desc = str:translate_and_format(Lang, ?T("To register, visit ~s"), [URL]),
 	    xmpp:make_iq_result(
 	      IQ, #register{instructions = Desc,


### PR DESCRIPTION
If mod_register has redirect_url configured, we skip using it if a valid token has been presented.

This way you can have two paths into registration: either an invite token or you redirect to a custom web form.

Fixes processone/ejabberd#4534
