### PR TITLE
mod_invites: remove dependency on jquery

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -230,11 +230,9 @@ else
   INSTALL_INVITES_DEPS=npm install
 endif
 
-invites-deps: priv/mod_invites/static/bootstrap/ priv/mod_invites/static/jquery/
+invites-deps: priv/mod_invites/static/bootstrap/
 
 priv/mod_invites/static/bootstrap/:
-	$(INSTALL_INVITES_DEPS)
-priv/mod_invites/static/jquery/:
 	$(INSTALL_INVITES_DEPS)
 
 src: $(DEPSDIR)/.built
@@ -324,7 +322,7 @@ BINARIES=$(DEPSDIR)/epam/priv/bin/epam $(DEPSDIR)/eimp/priv/bin/eimp $(DEPSDIR)/
 DEPS_FILES_FILTERED=$(filter-out $(BINARIES) $(DEPSDIR)/elixir/ebin/elixir.app,$(DEPS_FILES))
 DEPS_DIRS=$(sort $(DEPSDIR)/ $(foreach DEP,$(DEPS),$(DEPSDIR)/$(DEP)/) $(dir $(DEPS_FILES)))
 
-MAIN_FILES=$(filter-out %/configure.beam,$(call FILES_WILDCARD,$(EBINDIR)/*.beam $(EBINDIR)/*.app priv/msgs/*.msg priv/css/*.css priv/img/*.png priv/js/*.js priv/lib/* priv/mod_invites/* priv/mod_invites/static/* priv/mod_invites/static/bootstrap/css/bootstrap.min.css priv/mod_invites/static/bootstrap/js/bootstrap.min.js priv/mod_invites/static/jquery/jquery.min.js \
+MAIN_FILES=$(filter-out %/configure.beam,$(call FILES_WILDCARD,$(EBINDIR)/*.beam $(EBINDIR)/*.app priv/msgs/*.msg priv/css/*.css priv/img/*.png priv/js/*.js priv/lib/* priv/mod_invites/* priv/mod_invites/static/* priv/mod_invites/static/bootstrap/css/bootstrap.min.css priv/mod_invites/static/bootstrap/js/bootstrap.min.js \
 	priv/mod_invites/static/logos/* include/*.hrl COPYING))
 MAIN_DIRS=$(sort $(dir $(MAIN_FILES)) priv/bin priv/sql priv/lua priv/mod_invites)
 
@@ -567,7 +565,7 @@ clean:
 	rm -rf test/*.beam
 	rm -f rebar.lock
 	rm -f ejabberdctl.example ejabberd.init ejabberd.service
-	rm -rf priv/mod_invites/static/{jquery,bootstrap4}
+	rm -rf priv/mod_invites/static/bootstrap
 	$(REBAR) clean $(CLEANARG)
 
 clean-rel:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "bootstrap": "^5.3.8",
-        "jquery": "^4.0.0"
+        "bootstrap": "^5.3.8"
       }
     },
     "node_modules/@popperjs/core": {
@@ -42,12 +41,6 @@
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
-    },
-    "node_modules/jquery": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
-      "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
-      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,14 +2,11 @@
   "name": "ejabberd",
   "version": "1.0.0",
   "dependencies": {
-    "bootstrap": "^5.3.8",
-    "jquery": "^4.0.0"
+    "bootstrap": "^5.3.8"
   },
   "scripts": {
-    "postinstall": "npm run -s clean && npm run -s mkdir-jquery && npm run -s cp-jquery && npm run -s cp-bootstrap",
-    "clean": "rm -rf priv/mod_invites/static/{jquery,bootstrap}",
-    "mkdir-jquery": "mkdir -p priv/mod_invites/static/jquery",
-    "cp-jquery": "cp node_modules/jquery/dist/jquery.min.js priv/mod_invites/static/jquery/jquery.min.js",
+    "postinstall": "npm run -s clean && npm run -s cp-bootstrap",
+    "clean": "rm -rf priv/mod_invites/static/bootstrap",
     "cp-bootstrap": "cp -r node_modules/bootstrap/dist priv/mod_invites/static/bootstrap"
   }
 }

--- a/priv/mod_invites/base_min.html
+++ b/priv/mod_invites/base_min.html
@@ -23,8 +23,7 @@
     </div>
     {% block qr_code %}{% endblock %}
     {% block extra_scripts %}{% endblock %}
-    <script src="{{ static }}/jquery/jquery.min.js" integrity="sha384-fgGyf7Mo7DURSOMnOy7ed+dkq5Job205Gnzu6QIg0BOHKaqt4D76Dt8VlDCzcMHV"></script>
     <script src="{{ static }}/bootstrap/js/bootstrap.min.js" integrity="sha384-G/EV+4j2dNv+tEPo3++6LCgdCROaejBqfUeNjuKAiuXbjrxilcCdDz6ZAVfHWe1Y"></script>
-    <script src="{{ static }}/invite.js" integrity="sha384-ov8LmXw6nEmT+QvXBRPMol0e90WFX9ZysvQudQ7H+nYDyolH4K/+GKJhq7qmTk4T"></script>
+    <script src="{{ static }}/invite.js" integrity="sha384-9dl7uTP5+QJJfidqZFZB530NVQnp58oBvUdbj6mjFPKPNUWhl85g4kP9BStp0bpv"></script>
   </body>
 </html>

--- a/priv/mod_invites/howto
+++ b/priv/mod_invites/howto
@@ -1,0 +1,7 @@
+# HOWTO
+
+## How to create checksums for included css and js files used in templates
+
+```sh
+openssl dgst -sha384 -binary priv/mod_invites/static/invite.js | openssl base64 -A
+```

--- a/priv/mod_invites/static/invite.js
+++ b/priv/mod_invites/static/invite.js
@@ -89,8 +89,11 @@
                         badge.classList.remove("text-bg-info");
                     }
                 }
-                if (!has_platform)
-                    $(card).find("a.btn").removeClass("btn-primary").addClass("btn-secondary");
+                if (!has_platform) {
+                    const button = card.querySelector('a.btn');
+                    button.classList.remove('btn-primary');
+                    button.classList.add('btn-secondary');
+                }
             }
             const show_all_clients_button_container = document.getElementById('show-all-clients-button-container');
             if (show_all_clients_button_container) {

--- a/tools/dl_invites_page_deps.sh
+++ b/tools/dl_invites_page_deps.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-
 set -e
 
-jquery_checksum='39a546ea9ad97f8bfaf5d3e0e8f8556adb415e470e59007ada9759dce472adaa';
 bootstrap_checksum='3258c873cbcb1e2d81f4374afea2ea6437d9eee9077041073fd81dd579c5ba6b';
 
 check() {
@@ -14,12 +12,6 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 install_dir="$1"
-
-mkdir -p "$install_dir/jquery"
-jquery="$(mktemp /tmp/jquery.XXXXXXXXX)"
-curl -s -o $jquery https://code.jquery.com/jquery-4.0.0.min.js
-check $jquery_checksum $jquery
-mv $jquery "$install_dir/jquery/jquery.min.js"
 
 bootstrap="$(mktemp /tmp/bootstrap.XXXXXXXXX)"
 curl -L -s -o $bootstrap https://github.com/twbs/bootstrap/releases/download/v5.3.8/bootstrap-5.3.8-dist.zip


### PR DESCRIPTION
Since bootstrap5 doesn't depend on jquery anymore and we've only been using it at one single place, there was no reason to keep it around any longer.

Fixes #4555