### PR TITLE
don't crash in get_invite_by_invitee_t for sql backend

### DIFF
--- a/src/mod_invites.erl
+++ b/src/mod_invites.erl
@@ -74,7 +74,7 @@
 -callback expire_tokens(User :: binary(), Server :: binary()) -> non_neg_integer().
 -callback get_invite(Host :: binary(), Token :: binary()) ->
     invite_token() | {error, not_found}.
--callback get_invite_by_invitee_t(Host :: binary(), InviteeJid :: binary()) ->
+-callback get_invite_by_invitee_t(Host :: binary(), Invitee :: {User :: binary(), Host :: binary()}) ->
     invite_token() | {error, not_found}.
 -callback get_invites_t(Host :: binary(), Inviter :: {User :: binary(), Host :: binary()}) ->
     [invite_token()].
@@ -934,11 +934,10 @@ find_invites_tree_root_t(Now, Host, Invitee, Lvl) ->
 
 -spec get_invite_by_invitee_t(binary(), {binary(), binary()}) ->
                                  invite_token() | {error, not_found}.
+get_invite_by_invitee_t(_Host, {<<>>, _Server}) ->
+    {error, not_found};
 get_invite_by_invitee_t(Host, {User, Server}) ->
-    InviteeJid =
-        jid:encode(
-            jid:make(User, Server)),
-    db_call(Host, get_invite_by_invitee_t, [Host, InviteeJid]).
+    db_call(Host, get_invite_by_invitee_t, [Host, {User, Server}]).
 
 maybe_block_speedy_goat(Now, CreatedAt, Lvl) when Lvl == ?SPEEDY_GOAT_LEVELS ->
     Then = calendar:datetime_to_gregorian_seconds(CreatedAt),

--- a/src/mod_invites_mnesia.erl
+++ b/src/mod_invites_mnesia.erl
@@ -32,8 +32,6 @@
          remove_user/2, set_invitee/5, transaction/2]).
 
 -include("mod_invites.hrl").
--include("logger.hrl").
--include_lib("xmpp/include/xmpp.hrl").
 
 %% @format-begin
 
@@ -72,12 +70,22 @@ get_invite(_Host, Token) ->
             {error, not_found}
     end.
 
-get_invite_by_invitee_t(_Host, InviteeJid) ->
-    case mnesia:index_read(invite_token, InviteeJid, #invite_token.invitee) of
-        [#invite_token{type = Type} = Invite] when Type /= roster_only ->
+get_invite_by_invitee_t(_Host, {User, Host}) ->
+    Invitee = jid:encode(jid:make(User, Host)),
+    Invites = mnesia:index_read(invite_token, Invitee, #invite_token.invitee),
+    case [I || I = #invite_token{type = Type, account_name = AccountName} <- Invites,
+               Type =/= roster_only orelse AccountName == User] of
+        [Invite] ->
             Invite;
-        _ ->
-            {error, not_found}
+        [] ->
+            %% It might be a roster_only invite was used to create account but invitee has not been
+            %% set
+            case mnesia:index_read(invite_token, User, #invite_token.account_name) of
+                [#invite_token{type = Type} = Invite] when Type == roster_only  ->
+                    Invite;
+                _ ->
+                    {error, not_found}
+            end
     end.
 
 get_invites_t(_Host, Inviter) ->
@@ -88,7 +96,7 @@ init(_Host, _Opts) ->
                            invite_token,
                            [{disc_copies, [node()]},
                             {attributes, record_info(fields, invite_token)},
-                            {index, [inviter, invitee]}]).
+                            {index, [inviter, invitee, account_name]}]).
 
 is_reserved(_Host, Token, User) ->
     lists:filter(fun(T) ->

--- a/src/mod_invites_sql.erl
+++ b/src/mod_invites_sql.erl
@@ -46,7 +46,34 @@ init(Host, _Opts) ->
     ejabberd_sql_schema:update_schema(Host, ?MODULE, sql_schemas()).
 
 sql_schemas() ->
-    [#sql_schema{version = 2,
+    [#sql_schema{version = 3,
+                 tables =
+                     [#sql_table{name = <<"invite_token">>,
+                                 columns =
+                                     [#sql_column{name = <<"token">>, type = text},
+                                      #sql_column{name = <<"username">>, type = text},
+                                      #sql_column{name = <<"server_host">>, type = text},
+                                      #sql_column{name = <<"invitee">>,
+                                                  type = {text, 191},
+                                                  default = true},
+                                      #sql_column{name = <<"created_at">>,
+                                                  type = timestamp,
+                                                  default = true},
+                                      #sql_column{name = <<"expires">>,
+                                                  type = timestamp,
+                                                  default = true},
+                                      #sql_column{name = <<"type">>, type = {char, 1}},
+                                      #sql_column{name = <<"account_name">>, type = text}],
+                                 indices =
+                                     [#sql_index{columns = [<<"token">>], unique = true},
+                                      #sql_index{columns = [<<"username">>, <<"server_host">>]},
+                                      #sql_index{columns = [<<"type">>]},
+                                      #sql_index{columns = [<<"account_name">>]},
+                                      #sql_index{columns = [<<"invitee">>]}]}],
+                 update = [{create_index, <<"invite_token">>, [<<"type">>]},
+                           {create_index, <<"invite_token">>, [<<"account_name">>]}
+                          ]},
+     #sql_schema{version = 2,
                  tables =
                      [#sql_table{name = <<"invite_token">>,
                                  columns =
@@ -149,18 +176,21 @@ get_invite(Host, Token) ->
             {error, not_found}
     end.
 
--spec get_invite_by_invitee_t(binary(), binary()) ->
+-spec get_invite_by_invitee_t(binary(), {binary(), binary()}) ->
                                  mod_invites:invite_token() | {error, not_found}.
-get_invite_by_invitee_t(Host, InviteeJid) ->
+get_invite_by_invitee_t(Host, {User, Server}) ->
+    Invitee = jid:encode(jid:make(User, Server)),
     case ejabberd_sql:sql_query(Host,
                                 ?SQL("SELECT @(token)s, @(username)s, @(invitee)s, @(type)s, "
                                      "@(account_name)s, @(expires)t, @(created_at)t FROM "
-                                     "invite_token WHERE invitee = %(InviteeJid)s AND %(Host)H"))
+                                     "invite_token WHERE %(Host)H AND "
+                                     "(type != 'R' AND invitee = %(Invitee)s) OR "
+                                     "(type = 'R' AND account_name = %(User)s)"))
     of
-        {selected, [{Token, User, Invitee, Type, AccountName, Expires, CreatedAt}]} ->
+        {selected, [{Token, Inviter, IInvitee, Type, AccountName, Expires, CreatedAt}]} ->
             #invite_token{token = Token,
-                          inviter = {User, Host},
-                          invitee = Invitee,
+                          inviter = {Inviter, Host},
+                          invitee = IInvitee,
                           type = dec_type(Type),
                           account_name = AccountName,
                           expires = Expires,

--- a/test/invites_tests.erl
+++ b/test/invites_tests.erl
@@ -49,11 +49,11 @@ find_invites_tree_root_t_test_() ->
         meck:new(db, [non_strict]),
         meck:expect(db,
                     get_invite_by_invitee_t,
-                    fun (_, <<"4@host">>) ->
+                    fun (_, {<<"4">>, <<"host">>}) ->
                             #invite_token{inviter = {<<"3">>, <<"host">>}};
-                        (_, <<"3@host">>) ->
+                        (_, {<<"3">>, <<"host">>}) ->
                             #invite_token{inviter = {<<"2">>, <<"host">>}};
-                        (_, <<"2@host">>) ->
+                        (_, {<<"2">>, <<"host">>}) ->
                             #invite_token{inviter = {<<"1">>, <<"host">>}};
                         (_, _) ->
                             {error, not_found}
@@ -138,6 +138,7 @@ single_cases() ->
       single_test(remove_user),
       single_test(expire_tokens),
       single_test(max_invites),
+      single_test(overuse),
       single_test(presence_with_preauth_token),
       single_test(is_reserved),
       single_test(stream_feature),
@@ -425,6 +426,53 @@ max_invites(Config0) ->
     ?match(4, mod_invites:cleanup_expired()),
     disconnect(Config).
 
+overuse(Config0) ->
+    Server = ?config(server, Config0),
+    User = ?config(user, Config0),
+    Inviter = {User, Server},
+    InviteeJID = jid:make(User, Server),
+    OldOpts = gen_mod:get_module_opts(Server, mod_invites),
+    NewOpts =
+        gen_mod_set_opts(OldOpts,
+                         [{access_create_account, account_invite},
+                          {allow_modules, [mod_invites]}]),
+    update_module_opts(Server, mod_invites, NewOpts),
+
+    Config1 = reconnect(Config0),
+    update_module_opts(Server, mod_invites, OldOpts),
+
+    %% We only test we're not causing any crashes - these are test from reported bugs. We're not
+    %% testing the actual overuse scenario.
+
+    #invite_token{token = AToken} = create_account_invite(Server, {<<>>, Server}),
+    mod_invites:set_invitee(Server, AToken, InviteeJID),
+
+    #invite_token{token = RToken} = mod_invites:create_roster_invite(Server, {<<"foo">>, Server}),
+    mod_invites:set_invitee(Server, RToken, InviteeJID),
+
+    #invite_token{} = create_account_invite(Server, Inviter),
+
+    mod_invites:expire_tokens(<<>>, Server),
+    ?match(1, mod_invites:cleanup_expired()),
+    mod_invites:remove_user(User, Server),
+
+    #invite_token{token = RToken2} = mod_invites:create_roster_invite(Server, {<<"foo">>, Server}),
+
+    ?match(#iq{type = result}, send_pars(Config1, RToken2)),
+    ?match(#iq{type = result}, send_iq_register(Config1, <<"overuser">>)),
+
+    _Config2 =
+        open_session(bind(auth(set_opt(password,
+                                       <<"mySecret">>,
+                                       set_opt(user, <<"overuser">>, Config1))))),
+
+    #invite_token{token = RToken3} = mod_invites:create_roster_invite(Server, {<<"foo">>, Server}),
+    mod_invites:set_invitee(Server, RToken3, jid:make(<<"overuser">>, Server)),
+
+    #invite_token{} = create_account_invite(Server, {<<"overuser">>, Server}),
+    ejabberd_auth:remove_user(<<"overuser">>, Server).
+
+
 presence_with_preauth_token(Config) ->
     Server = ?config(server, Config),
     User = ?config(user, Config),
@@ -580,6 +628,7 @@ ibr(Config0) ->
                         SubEls)),
     ?match(#iq{type = result}, send_iq_register(Config4, <<"yet_another_self_chosen_name">>)),
 
+    ejabberd_auth:remove_user(<<"roster_invite_user">>, Server),
     ejabberd_auth:remove_user(AccountName, Server),
     ejabberd_auth:remove_user(<<"yet_another_self_chosen_name">>, Server),
     ejabberd_auth:remove_user(<<"some_self_chosen_name">>, Server),


### PR DESCRIPTION
There was a missing where clause for the type of the invite.

Furthermore we need to check roster_only invites if they have been used for creating the account - here it can happen invitee is not being set (yet).

Fixes #4565