### PR TITLE
Erlang29 catch odbc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       with:
         packages: libexpat1-dev libgd-dev libpam0g-dev
                   libsqlite3-dev libwebp-dev libyaml-dev
+                  unixodbc-dev
 
     - name: Cache rebar3
       uses: actions/cache@v5

--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -52,7 +52,8 @@ jobs:
       run: |
         apt-get -qq update
         apt-get -q -y install libexpat1-dev libgd-dev libpam0g-dev \
-                              libsqlite3-dev libwebp-dev libyaml-dev
+                              libsqlite3-dev libwebp-dev libyaml-dev \
+                              unixodbc-dev
 
     - name: Cache rebar3
       if: matrix.rebar == 'rebar3'

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         packages: libexpat1-dev libgd-dev libpam0g-dev
                   libsqlite3-dev libwebp-dev libyaml-dev
+                  unixodbc-dev
 
     - name: Get recent compatible Rebar binaries
       if: matrix.otp < 26

--- a/include/ejabberd_catch.hrl
+++ b/include/ejabberd_catch.hrl
@@ -1,0 +1,123 @@
+%%%----------------------------------------------------------------------
+%%%
+%%% ejabberd, Copyright (C) 2002-2026   ProcessOne
+%%%
+%%% This program is free software; you can redistribute it and/or
+%%% modify it under the terms of the GNU General Public License as
+%%% published by the Free Software Foundation; either version 2 of the
+%%% License, or (at your option) any later version.
+%%%
+%%% This program is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+%%% General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License along
+%%% with this program; if not, write to the Free Software Foundation, Inc.,
+%%% 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+%%%
+%%%----------------------------------------------------------------------
+
+%% This uses Macros Overloading, see
+%% https://www.erlang.org/doc/system/macros.html#macros-overloading
+
+%% @format-begin
+
+-define(CATCH_MFA(Module, Function, Arguments),
+        try apply(Module, Function, Arguments)
+        catch
+            TCX:TCY ->
+                ?WARNING_MSG("Catched exception~n  in: ~p:~p/~p (line ~p)~n"
+                             "  calling: ~p:~p~p~n  catched: ~p:~p",
+                               [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE,
+                                Module, Function, Arguments, TCX, TCY]),
+                {TCX, TCY}
+        end).
+
+-define(CATCH_TRY(Function, A1),
+        try Function(A1)
+        catch
+            TCX:TCY ->
+                ?WARNING_MSG("Catched exception~n  in: ~p:~p/~p (line ~p)~n"
+                             "  calling: ~p(~p)~n  catched: ~p:~p",
+                               [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE,
+                                Function, A1, TCX, TCY]),
+                {TCX, TCY}
+        end).
+
+-define(CATCH_TRY(Function, A1, A2),
+        try Function(A1, A2)
+        catch
+            TCX:TCY ->
+                ?WARNING_MSG("Catched exception~n  in: ~p:~p/~p (line ~p)~n"
+                             "  calling: ~p(~p, ~p)~n  catched: ~p:~p",
+                               [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE,
+                                Function, A1, A2, TCX, TCY]),
+                {TCX, TCY}
+        end).
+
+-define(CATCH_TRY(Function, A1, A2, A3),
+        try Function(A1, A2, A3)
+        catch
+            TCX:TCY ->
+                ?WARNING_MSG("Catched exception~n  in: ~p:~p/~p (line ~p)~n"
+                             "  calling: ~p(~p, ~p, ~p)~n  catched: ~p:~p",
+                               [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE,
+                                Function, A1, A2, A3, TCX, TCY]),
+                {TCX, TCY}
+        end).
+
+-define(CATCH_TRY(Function, A1, A2, A3, A4),
+        try Function(A1, A2, A3, A4)
+        catch
+            TCX:TCY ->
+                ?WARNING_MSG("Catched exception~n  in: ~p:~p/~p (line ~p)~n"
+                             "  calling: ~p(~p, ~p, ~p, ~p)~n  catched: ~p:~p",
+                               [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE,
+                                Function, A1, A2, A3, A4, TCX, TCY]),
+                {TCX, TCY}
+        end).
+
+-define(CATCH_TRY(Function, A1, A2, A3, A4, A5),
+        try Function(A1, A2, A3, A4, A5)
+        catch
+            TCX:TCY ->
+                ?WARNING_MSG("Catched exception~n  in: ~p:~p/~p (line ~p)~n"
+                             "  calling: ~p(~p, ~p, ~p, ~p, ~p)~n  catched: ~p:~p",
+                               [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE,
+                                Function, A1, A2, A3, A4, A5, TCX, TCY]),
+                {TCX, TCY}
+        end).
+
+-define(CATCH_TRY(Function, A1, A2, A3, A4, A5, A6),
+        try Function(A1, A2, A3, A4, A5, A6)
+        catch
+            TCX:TCY ->
+                ?WARNING_MSG("Catched exception~n  in: ~p:~p/~p (line ~p)~n"
+                             "  calling: ~p(~p, ~p, ~p, ~p, ~p, ~p)~n  catched: ~p:~p",
+                               [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE,
+                                Function, A1, A2, A3, A4, A5, A6, TCX, TCY]),
+                {TCX, TCY}
+        end).
+
+-define(CATCH_TRY(Function, A1, A2, A3, A4, A5, A6, A7),
+        try Function(A1, A2, A3, A4, A5, A6, A7)
+        catch
+            TCX:TCY ->
+                ?WARNING_MSG("Catched exception~n  in: ~p:~p/~p (line ~p)~n"
+                             "  calling: ~p(~p, ~p, ~p, ~p, ~p, ~p, ~p)~n  catched: ~p:~p",
+                               [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE,
+                                Function, A1, A2, A3, A4, A5, A6, A7, TCX, TCY]),
+                {TCX, TCY}
+        end).
+
+-define(CATCH_TRY(Function, A1, A2, A3, A4, A5, A6, A7, A8),
+        try Function(A1, A2, A3, A4, A5, A6, A7, A8)
+        catch
+            TCX:TCY ->
+                ?WARNING_MSG("Catched exception~n  in: ~p:~p/~p (line ~p)~n"
+                             "  calling: ~p(~p, ~p, ~p, ~p, ~p, ~p, ~p, ~p)~n  catched: ~p:~p",
+                               [?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY, ?LINE,
+                                Function, A1, A2, A3, A4, A5, A6, A7, A8, TCX, TCY]),
+                {TCX, TCY}
+        end).

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,11 @@ defmodule Ejabberd.MixProject do
     if :erlang.system_info(:otp_release) > ver do
       okResult
     else
-      []
+      if :erlang.is_boolean(okResult) do
+        not okResult
+      else
+        []
+      end
     end
   end
 
@@ -75,7 +79,11 @@ defmodule Ejabberd.MixProject do
     if :erlang.system_info(:otp_release) < ver do
       okResult
     else
-      []
+      if :erlang.is_boolean(okResult) do
+        not okResult
+      else
+        []
+      end
     end
   end
 
@@ -151,6 +159,9 @@ defmodule Ejabberd.MixProject do
                          {if_version_above(~c"25", true), {:jose, "~> 1.11.12"}},
                          {config(:lua), {:luerl, "~> 1.2.0"}},
                          {config(:mysql), {:p1_mysql, ">= 1.0.28"}},
+                         {if_version_above(~c"28", true) and config(:odbc),
+                          {:odbc, "~> 2.17.1", hex: :erlang_otp_odbc}
+                         },
                          {config(:pgsql), {:p1_pgsql, ">= 1.1.38"}},
                          {config(:sqlite), {:sqlite3, "~> 1.1"}},
                          {config(:stun), {:stun, "~> 1.0"}}], do:

--- a/rebar.config
+++ b/rebar.config
@@ -119,7 +119,6 @@
             {if_version_below, "27", {d, 'OTP_BELOW_27'}},
             {if_version_below, "27", {feature, maybe_expr, enable}},
             {if_version_below, "28", {d, 'OTP_BELOW_28'}},
-            {if_version_above, "28", nowarn_deprecated_catch},
             {if_var_false, debug, no_debug_info},
             {if_var_true, debug, debug_info},
             {if_var_true, elixir, {d, 'ELIXIR_ENABLED'}},

--- a/rebar.config
+++ b/rebar.config
@@ -54,6 +54,11 @@
          {luerl, "~> 1.2.0", {git, "https://github.com/rvirding/luerl", {tag, "1.2"}}}
         },
         {mqtree, "~> 1.0.19", {git, "https://github.com/processone/mqtree", {tag, "1.0.20"}}},
+        {if_version_above, "28",
+         {if_var_true, odbc,
+          {if_rebar3,
+           {odbc, {package, erlang_otp_odbc, "~> 2.17.1"}, {git, "https://github.com/rnowak/erlang-otp-odbc", {tag, "v2.17.1"}}}
+        }}},
         {p1_acme, "~> 1.0.30", {git, "https://github.com/processone/p1_acme", {tag, "1.0.31"}}},
         {if_var_true, mysql,
          {p1_mysql, "~> 1.0.28", {git, "https://github.com/processone/p1_mysql", {tag, "1.0.28"}}}},

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -223,7 +223,7 @@ AppendList2 = fun(Append) ->
 % https://github.com/rebar/rebar/wiki/Dependency-management
 Rebar2DepsFilter =
 fun(DepsList, GitOnlyDeps) ->
-	lists:map(fun({DepName, _HexVersion, Source}) ->
+	lists:map(fun({DepName, _HexPackage, Source}) ->
 	              {DepName, ".*", Source}
 		  end, DepsList)
 end,
@@ -233,14 +233,22 @@ end,
 % https://hexdocs.pm/elixir/Version.html
 Rebar3DepsFilter =
 fun(DepsList, GitOnlyDeps) ->
-	lists:map(fun({DepName, HexVersion, {git, _, {tag, GitVersion}} = Source}) ->
-			  case {lists:member(DepName, GitOnlyDeps), HexVersion == ".*"} of
-                              {true, _} ->
+	lists:map(fun({DepName, HexPackageVersion, {git, _, {tag, GitVersion}} = Source}) ->
+                          {HexPackage, HexVersion} = case HexPackageVersion of
+                                           HV when is_list(HV) -> {false, HV};
+                                           {package, HP, HV} -> {HP, HV}
+                                       end,
+			  case {lists:member(DepName, GitOnlyDeps),
+                                HexPackage,
+                                HexVersion == ".*"} of
+                              {true, _, _} ->
                                   {DepName, ".*", Source};
-                              {false, true} ->
+                              {false, _, true} ->
                                   {DepName, GitVersion};
-                              {false, false} ->
-                                  {DepName, HexVersion}
+                              {false, false, false} ->
+                                  {DepName, HexVersion};
+                              {false, PkgName, false} ->
+                                  {DepName, HexVersion, {pkg, PkgName}}
                           end;
 		     ({DepName, _HexVersion, Source}) ->
 	              {DepName, ".*", Source}

--- a/src/ELDAPv3.erl
+++ b/src/ELDAPv3.erl
@@ -129,25 +129,27 @@ encoding_rule() -> ber.
 bit_string_format() -> bitstring.
 
 encode(Type,Data) ->
-case catch encode_disp(Type,Data) of
-  {'EXIT',{error,Reason}} ->
-    {error,Reason};
-  {'EXIT',Reason} ->
-    {error,{asn1,Reason}};
+try encode_disp(Type,Data) of
   {Bytes,_Len} ->
     {ok,iolist_to_binary(Bytes)};
   Bytes ->
     {ok,iolist_to_binary(Bytes)}
+catch
+  _:{error,Reason} ->
+    {error,Reason};
+  _:Reason ->
+    {error,{asn1,Reason}}
 end.
 
 decode(Type,Data) ->
-case catch decode_disp(Type,element(1, ber_decode_nif(Data))) of
-  {'EXIT',{error,Reason}} ->
-    {error,Reason};
-  {'EXIT',Reason} ->
-    {error,{asn1,Reason}};
+try decode_disp(Type,element(1, ber_decode_nif(Data))) of
   Result ->
     {ok,Result}
+catch
+  _:{error,Reason} ->
+    {error,Reason};
+  _:Reason ->
+    {error,{asn1,Reason}}
 end.
 
 encode_disp('LDAPMessage',Data) -> 'enc_LDAPMessage'(Data);

--- a/src/ejabberd_admin.erl
+++ b/src/ejabberd_admin.erl
@@ -83,6 +83,7 @@
          web_menu_node/3, web_page_node/3]).
 
 -include_lib("xmpp/include/xmpp.hrl").
+-include("ejabberd_catch.hrl").
 -include("ejabberd_commands.hrl").
 -include("ejabberd_http.hrl").
 -include("ejabberd_web_admin.hrl").
@@ -839,7 +840,7 @@ perform_kindly(DelaySeconds, AnnouncementTextString, Action) ->
                    io:format("~s[~p/~p ~ps]~s ~ts...~s ",
                              [?CLEAD ++ ?CINFO, NumberThis, NumberLast, SecondsDiff,
                               ?CMID ++ ?CINFO, Desc, ?CCLEAN]),
-                   Result = (catch apply(Mod, Func, Args)),
+                   Result = ?CATCH_TRY(apply, Mod, Func, Args),
                    io:format("~p~n", [Result]),
                    NumberThis + 1
                 end,

--- a/src/ejabberd_app.erl
+++ b/src/ejabberd_app.erl
@@ -240,9 +240,11 @@ print_distribution_listening() ->
     end,
     {Addr, Port} = lists:foldl(
           fun(Link, Acc) ->
-                  case catch inet:sockname(Link) of
+                  try inet:sockname(Link) of
                       {ok, {A1, P1}} -> {misc:ip_to_list(A1), P1};
                       _ -> Acc
+                  catch
+                      _:_ -> Acc
                   end
           end, {"UnknownAddress", "UnknownPort"}, Links),
     ?INFO_MSG("Start accepting TCP connections at ~ts:~p for erlang distribution", [Addr, Port]).

--- a/src/ejabberd_auth_ldap.erl
+++ b/src/ejabberd_auth_ldap.erl
@@ -124,9 +124,10 @@ check_password(User, AuthzId, Server, Password) ->
        Password == <<"">> ->
 	    {nocache, false};
        true ->
-	    case catch check_password_ldap(User, Server, Password) of
-		{'EXIT', _} -> {nocache, false};
+	    try check_password_ldap(User, Server, Password) of
 		Result -> {cache, Result}
+            catch
+		_:_ -> {nocache, false}
 	    end
     end.
 
@@ -143,18 +144,19 @@ set_password(User, Server, Password) ->
     end.
 
 get_users(Server, []) ->
-    case catch get_users_ldap(Server) of
-      {'EXIT', _} -> [];
-      Result -> Result
+    try get_users_ldap(Server)
+    catch
+      _:_ -> []
     end.
 
 count_users(Server, Opts) ->
     length(get_users(Server, Opts)).
 
 user_exists(User, Server) ->
-    case catch user_exists_ldap(User, Server) of
-	{'EXIT', _Error} -> {nocache, {error, db_failure}};
+    try user_exists_ldap(User, Server) of
 	Result -> {cache, Result}
+    catch
+	_:_Error -> {nocache, {error, db_failure}}
     end.
 
 %%%----------------------------------------------------------------------

--- a/src/ejabberd_auth_pam.erl
+++ b/src/ejabberd_auth_pam.erl
@@ -46,10 +46,11 @@ check_password(User, AuthzId, Host, Password) ->
 			   username -> User;
 			   jid -> <<User/binary, "@", Host/binary>>
 		       end,
-	    case catch epam:authenticate(Service, UserInfo, Password) of
+	    try epam:authenticate(Service, UserInfo, Password) of
 		true -> {cache, true};
-		false -> {cache, false};
-		_ -> {nocache, false}
+		false -> {cache, false}
+            catch
+		_:_ -> {nocache, false}
 	    end
     end.
 
@@ -59,10 +60,11 @@ user_exists(User, Host) ->
 		 username -> User;
 		 jid -> <<User/binary, "@", Host/binary>>
 	       end,
-    case catch epam:acct_mgmt(Service, UserInfo) of
+    try epam:acct_mgmt(Service, UserInfo) of
 	true -> {cache, true};
-	false -> {cache, false};
-	_Err -> {nocache, {error, db_failure}}
+	false -> {cache, false}
+    catch
+	_:_Err -> {nocache, {error, db_failure}}
     end.
 
 plain_password_required(_) -> true.

--- a/src/ejabberd_bosh.erl
+++ b/src/ejabberd_bosh.erl
@@ -635,12 +635,13 @@ reply(State, Body, RID, From) ->
     Receivers = gb_trees:delete_any(RID,
 				    State1#state.receivers),
     State2 = do_reply(State1, From, Body, RID),
-    case catch gb_trees:take_smallest(Receivers) of
+    try gb_trees:take_smallest(Receivers) of
       {NextRID, {From1, Req}, Receivers1}
 	  when NextRID == RID + 1 ->
 	  p1_fsm:send_event(self(), {Req, From1}),
-	  State2#state{receivers = Receivers1};
-      _ -> State2#state{receivers = Receivers}
+	  State2#state{receivers = Receivers1}
+    catch
+      _:_ -> State2#state{receivers = Receivers}
     end.
 
 reply_next_state(State, Body, RID, From) ->
@@ -648,12 +649,13 @@ reply_next_state(State, Body, RID, From) ->
     Receivers = gb_trees:delete_any(RID,
 				    State1#state.receivers),
     State2 = do_reply(State1, From, Body, RID),
-    case catch gb_trees:take_smallest(Receivers) of
+    try gb_trees:take_smallest(Receivers) of
       {NextRID, {From1, Req}, Receivers1}
 	  when NextRID == RID + 1 ->
 	  active(Req, From1,
-		 State2#state{receivers = Receivers1});
-      _ ->
+		 State2#state{receivers = Receivers1})
+    catch
+      _:_ ->
 	  {next_state, active,
 	   State2#state{receivers = Receivers}}
     end.

--- a/src/ejabberd_bosh.erl
+++ b/src/ejabberd_bosh.erl
@@ -112,16 +112,17 @@
 start(#body{attrs = Attrs} = Body, IP, SID) ->
     XMPPDomain = get_attr(to, Attrs),
     SupervisorProc = gen_mod:get_module_proc(XMPPDomain, mod_bosh),
-    case catch supervisor:start_child(SupervisorProc,
+    try supervisor:start_child(SupervisorProc,
 				      [Body, IP, SID])
 	of
       {ok, Pid} -> {ok, Pid};
-      {'EXIT', {noproc, _}} ->
-	  check_bosh_module(XMPPDomain),
-	  {error, module_not_loaded};
-      Err ->
+      {error, Err} ->
 	  ?ERROR_MSG("Failed to start BOSH session: ~p", [Err]),
 	  {error, Err}
+    catch
+      exit:{noproc, _} ->
+	  check_bosh_module(XMPPDomain),
+	  {error, module_not_loaded}
     end.
 
 start(StateName, State) ->
@@ -136,13 +137,12 @@ send({http_bind, FsmRef, IP}, Packet) ->
     send_xml({http_bind, FsmRef, IP}, Packet).
 
 send_xml({http_bind, FsmRef, _IP}, Packet) ->
-    case catch p1_fsm:sync_send_all_state_event(FsmRef,
+    try p1_fsm:sync_send_all_state_event(FsmRef,
 						    {send_xml, Packet},
 						    ?SEND_TIMEOUT)
-	of
-      {'EXIT', {timeout, _}} -> {error, timeout};
-      {'EXIT', _} -> {error, einval};
-      Res -> Res
+    catch
+        exit:{timeout, _} -> {error, timeout};
+        exit:_ -> {error, einval}
     end.
 
 setopts({http_bind, FsmRef, _IP}, Opts) ->
@@ -153,11 +153,9 @@ setopts({http_bind, FsmRef, _IP}, Opts) ->
       _ ->
 	  case lists:member({active, false}, Opts) of
 	    true ->
-		case catch p1_fsm:sync_send_all_state_event(FsmRef,
-								deactivate_socket)
-		    of
-		  {'EXIT', _} -> {error, einval};
-		  Res -> Res
+		try p1_fsm:sync_send_all_state_event(FsmRef, deactivate_socket)
+                catch
+		  exit:_ -> {error, einval}
 		end;
 	    _ -> ok
 	  end
@@ -172,8 +170,9 @@ change_shaper({http_bind, FsmRef, _IP}, Shaper) ->
     p1_fsm:send_all_state_event(FsmRef, {change_shaper, Shaper}).
 
 close({http_bind, FsmRef, _IP}) ->
-    catch p1_fsm:sync_send_all_state_event(FsmRef,
-					       close).
+    try p1_fsm:sync_send_all_state_event(FsmRef, close)
+    catch X:Y -> {X, Y}
+    end.
 
 sockname(_Socket) -> {ok, {{0, 0, 0, 0}, 0}}.
 
@@ -245,11 +244,10 @@ process_request(Data, IP, Type) ->
     end.
 
 process_request(Pid, Req, _IP, Type) ->
-    case catch p1_fsm:sync_send_event(Pid, Req,
-					  infinity)
-	of
-      #body{} = Resp -> bosh_response(Resp, Type);
-      {'EXIT', {Reason, _}}
+    try p1_fsm:sync_send_event(Pid, Req, infinity) of
+      #body{} = Resp -> bosh_response(Resp, Type)
+    catch
+      exit:{Reason, _}
 	  when Reason == noproc; Reason == normal ->
 	  bosh_response(#body{http_reason =
 				  <<"BOSH session not found">>,
@@ -257,7 +255,7 @@ process_request(Pid, Req, _IP, Type) ->
 				  [{type, <<"terminate">>},
 				   {condition, <<"item-not-found">>}]},
                         Type);
-      {'EXIT', _} ->
+      exit:_ ->
 	  bosh_response(#body{http_reason =
 				  <<"Unexpected error">>,
 			      attrs =

--- a/src/ejabberd_captcha.erl
+++ b/src/ejabberd_captcha.erl
@@ -546,12 +546,13 @@ is_limited(Limiter) ->
     case ejabberd_option:captcha_limit() of
       infinity -> false;
       Int ->
-	  case catch gen_server:call(?MODULE,
+	  try gen_server:call(?MODULE,
 				     {is_limited, Limiter, Int}, 5000)
 	      of
 	    true -> true;
-	    false -> false;
-	    Err -> ?ERROR_MSG("Call failed: ~p", [Err]), false
+	    false -> false
+          catch
+	    _:Err -> ?ERROR_MSG("Call failed: ~p", [Err]), false
 	  end
     end.
 
@@ -587,7 +588,9 @@ recv_data(Port, TRef, Buf) ->
 		    {ok, binary()} | {error, image_error()}.
 return(Port, TRef, Result) ->
     misc:cancel_timer(TRef),
-    catch port_close(Port),
+    try port_close(Port)
+    catch _:_ -> error
+    end,
     Result.
 
 is_feature_available() ->

--- a/src/ejabberd_ctl.erl
+++ b/src/ejabberd_ctl.erl
@@ -347,7 +347,7 @@ call_command([CmdString | Args], Auth, _AccessCommands, Version) ->
                    list_to_binary(CmdString), <<"-">>, <<"_">>),
     Command = list_to_atom(binary_to_list(CmdStringU)),
     {ArgsFormat, _, ResultFormat} = ejabberd_commands:get_command_format(Command, Auth, Version),
-    case (catch format_args(Args, ArgsFormat)) of
+    try format_args(Args, ArgsFormat) of
 	ArgsFormatted when is_list(ArgsFormatted) ->
 	    CI = case Auth of
 		     {U, S, _, _} -> #{usr => {U, S, <<"">>}, caller_host => S};
@@ -358,8 +358,10 @@ call_command([CmdString | Args], Auth, _AccessCommands, Version) ->
 							ArgsFormatted,
 							CI2,
 							Version),
-	    format_result_preliminary(Result, ResultFormat, Version);
-	{'EXIT', {function_clause,[{lists,zip,[A1,A2|_], _} | _]}} ->
+	    format_result_preliminary(Result, ResultFormat, Version)
+    catch
+	error:function_clause:Stacktrace ->
+            [{lists, zip, [A1,A2|_], _} | _] = Stacktrace,
 	    {NumCompa, TextCompa} =
 		case {length(A1), length(A2)} of
 		    {L1, L2} when L1 < L2 -> {L2-L1, "less argument"};

--- a/src/ejabberd_http.erl
+++ b/src/ejabberd_http.erl
@@ -266,11 +266,12 @@ process_header(State, Data) ->
 		      request_headers = add_header(Name, Auth, State)};
       {ok,
        {http_header, _, 'Content-Length' = Name, _, SLen}} ->
-	  case catch binary_to_integer(SLen) of
+	  try binary_to_integer(SLen) of
 	    Len when is_integer(Len) ->
 		State#state{request_content_length = Len,
-			    request_headers = add_header(Name, SLen, State)};
-	    _ -> State
+			    request_headers = add_header(Name, SLen, State)}
+          catch
+             _:_ -> State
 	  end;
       {ok,
        {http_header, _, 'Accept-Language' = Name, _, Langs}} ->

--- a/src/ejabberd_http_ws.erl
+++ b/src/ejabberd_http_ws.erl
@@ -74,13 +74,12 @@ start_link(WS) ->
     p1_fsm:start_link(?MODULE, [WS], ?FSMOPTS).
 
 send_xml({http_ws, FsmRef, _IP}, Packet) ->
-    case catch p1_fsm:sync_send_all_state_event(FsmRef,
+    try p1_fsm:sync_send_all_state_event(FsmRef,
 						    {send_xml, Packet},
 						    15000)
-    of
-	{'EXIT', {timeout, _}} -> {error, timeout};
-	{'EXIT', _} -> {error, einval};
-	Res -> Res
+    catch
+        exit:{timeout, _} -> {error, timeout};
+        exit:_ -> {error, einval}
     end.
 
 setopts({http_ws, FsmRef, _IP}, Opts) ->

--- a/src/ejabberd_http_ws.erl
+++ b/src/ejabberd_http_ws.erl
@@ -98,7 +98,9 @@ peername({http_ws, _FsmRef, IP}) -> {ok, IP}.
 controlling_process(_Socket, _Pid) -> ok.
 
 close({http_ws, FsmRef, _IP}) ->
-    catch p1_fsm:sync_send_all_state_event(FsmRef, close).
+    try p1_fsm:sync_send_all_state_event(FsmRef, close)
+    catch A:B -> {A, B}
+    end.
 
 reset_stream({http_ws, _FsmRef, _IP} = Socket) ->
     Socket.

--- a/src/ejabberd_listener.erl
+++ b/src/ejabberd_listener.erl
@@ -417,15 +417,16 @@ is_ctl_over_http(State) ->
 udp_recv(Socket, Module, State) ->
     case gen_udp:recv(Socket, 0) of
 	{ok, {Addr, Port, Packet}} ->
-	    case catch Module:udp_recv(Socket, Addr, Port, Packet, State) of
-		{'EXIT', Reason} ->
+	    try Module:udp_recv(Socket, Addr, Port, Packet, State) of
+		NewState ->
+		    udp_recv(Socket, Module, NewState)
+            catch
+		_:Reason ->
 		    ?ERROR_MSG("Failed to process UDP packet:~n"
 			       "** Source: {~p, ~p}~n"
 			       "** Reason: ~p~n** Packet: ~p",
 			       [Addr, Port, Reason, Packet]),
-		    udp_recv(Socket, Module, State);
-		NewState ->
-		    udp_recv(Socket, Module, NewState)
+		    udp_recv(Socket, Module, State)
 	    end;
 	{error, Reason} ->
 	    ?ERROR_MSG("Unexpected UDP error: ~ts", [format_error(Reason)]),

--- a/src/ejabberd_local.erl
+++ b/src/ejabberd_local.erl
@@ -151,7 +151,9 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 -spec update_table() -> ok.
 update_table() ->
-    catch mnesia:delete_table(iq_response),
+    try mnesia:delete_table(iq_response)
+    catch _:_ -> error
+    end,
     ok.
 
 host_up(Host) ->

--- a/src/ejabberd_mnesia.erl
+++ b/src/ejabberd_mnesia.erl
@@ -119,9 +119,7 @@ do_create(Module, Name, TabDef, TabDefs) ->
     code:ensure_loaded(Module),
     Schema = schema(Name, TabDef, TabDefs),
     {attributes, Attrs} = lists:keyfind(attributes, 1, Schema),
-    case catch mnesia:table_info(Name, attributes) of
-	{'EXIT', _} ->
-	    create(Name, TabDef);
+    try mnesia:table_info(Name, attributes) of
 	Attrs ->
 	    case need_reset(Name, Schema) of
 		true ->
@@ -136,6 +134,9 @@ do_create(Module, Name, TabDef, TabDefs) ->
 	    end;
 	OldAttrs ->
 	    transform(Module, Name, OldAttrs, Attrs)
+    catch
+	_:_ ->
+	    create(Name, TabDef)
     end.
 
 reset(Name, TabDef) ->

--- a/src/ejabberd_oauth_mnesia.erl
+++ b/src/ejabberd_oauth_mnesia.erl
@@ -61,10 +61,11 @@ store(R) ->
     mnesia:dirty_write(R).
 
 lookup(Token) ->
-    case catch mnesia:dirty_read(oauth_token, Token) of
+    try mnesia:dirty_read(oauth_token, Token) of
         [R] ->
-            {ok, R};
-        _ ->
+            {ok, R}
+    catch
+        _:_ ->
             error
     end.
 
@@ -85,10 +86,11 @@ clean(TS) ->
     mnesia:async_dirty(F).
 
 lookup_client(ClientID) ->
-    case catch mnesia:dirty_read(oauth_client, ClientID) of
+    try mnesia:dirty_read(oauth_client, ClientID) of
         [R] ->
-            {ok, R};
-        _ ->
+            {ok, R}
+    catch
+        _:_ ->
             error
     end.
 

--- a/src/ejabberd_router_multicast.erl
+++ b/src/ejabberd_router_multicast.erl
@@ -62,12 +62,13 @@ start_link() ->
 route_multicast(From0, Domain0, Destinations0, Packet0, Wrapped0) ->
     {From, Domain, Destinations, Packet, Wrapped} =
     ejabberd_hooks:run_fold(multicast_route, Domain0, {From0, Domain0, Destinations0, Packet0, Wrapped0}, []),
-    case catch do_route(Domain, Destinations, xmpp:set_from(Packet, From), Wrapped) of
-	{'EXIT', Reason} ->
-	    ?ERROR_MSG("~p~nwhen processing: ~p",
-		       [Reason, {From, Domain, Destinations, Packet}]);
+    try do_route(Domain, Destinations, xmpp:set_from(Packet, From), Wrapped) of
 	_ ->
 	    ok
+    catch
+        _:Reason ->
+            ?ERROR_MSG("~p~nwhen processing: ~p",
+                       [Reason, {From, Domain, Destinations, Packet}])
     end.
 
 -spec register_route(binary()) -> any().
@@ -159,12 +160,13 @@ handle_cast(Msg, State) ->
 %% Description: Handling all non call/cast messages
 %%--------------------------------------------------------------------
 handle_info({route_multicast, Domain, Destinations, Packet}, State) ->
-    case catch do_route(Domain, Destinations, Packet, false) of
-	{'EXIT', Reason} ->
-	    ?ERROR_MSG("~p~nwhen processing: ~p",
-		       [Reason, {Domain, Destinations, Packet}]);
+    try do_route(Domain, Destinations, Packet, false) of
 	_ ->
 	    ok
+    catch
+        _:Reason ->
+            ?ERROR_MSG("~p~nwhen processing: ~p",
+                       [Reason, {Domain, Destinations, Packet}])
     end,
     {noreply, State};
 handle_info({mnesia_table_event, {write, #route_multicast{pid = Pid}, _ActivityId}},

--- a/src/ejabberd_s2s.erl
+++ b/src/ejabberd_s2s.erl
@@ -49,6 +49,7 @@
 
 -export([get_info_s2s_connections/1]).
 
+-include("ejabberd_catch.hrl").
 -include("logger.hrl").
 -include_lib("xmpp/include/xmpp.hrl").
 -include("ejabberd_commands.hrl").
@@ -112,20 +113,24 @@ is_temporarly_blocked(Host) ->
 
 -spec have_connection({binary(), binary()}) -> boolean().
 have_connection(FromTo) ->
-    case catch mnesia:dirty_read(s2s, FromTo) of
+    try mnesia:dirty_read(s2s, FromTo) of
 	[_] ->
             true;
         _ ->
+            false
+    catch
+        _:_ ->
             false
     end.
 
 -spec get_connections_pids({binary(), binary()}) -> [pid()].
 get_connections_pids(FromTo) ->
-    case catch mnesia:dirty_read(s2s, FromTo) of
+    try mnesia:dirty_read(s2s, FromTo) of
 	L when is_list(L) ->
-	    [Connection#s2s.pid || Connection <- L];
-	_ ->
-	    []
+	    [Connection#s2s.pid || Connection <- L]
+    catch
+        _:_ ->
+            []
     end.
 
 -spec register_connection(FromTo :: {binary(), binary()}) -> ok.

--- a/src/ejabberd_sm.erl
+++ b/src/ejabberd_sm.erl
@@ -794,7 +794,7 @@ route_message(#message{to = To, type = Type} = Packet) ->
     LUser = To#jid.luser,
     LServer = To#jid.lserver,
     PrioRes = get_user_present_resources(LUser, LServer),
-    case catch lists:max(PrioRes) of
+    try lists:max(PrioRes) of
       {MaxPrio, MaxRes}
 	  when is_integer(MaxPrio), MaxPrio >= 0 ->
 	  lists:foreach(fun ({P, R}) when P == MaxPrio;
@@ -819,8 +819,9 @@ route_message(#message{to = To, type = Type} = Packet) ->
 			    %% Ignore other priority:
 			    ({_Prio, _Res}) -> ok
 			end,
-			PrioRes);
-      _ ->
+			PrioRes)
+    catch
+      _:_ ->
 	    case ejabberd_auth:user_exists(LUser, LServer) andalso
 		is_privacy_allow(Packet) of
 		true ->

--- a/src/ejabberd_sm_mnesia.erl
+++ b/src/ejabberd_sm_mnesia.erl
@@ -140,15 +140,16 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Internal functions
 %%%===================================================================
 update_tables() ->
-    case catch mnesia:table_info(session, attributes) of
+    try mnesia:table_info(session, attributes) of
       [ur, user, node] -> mnesia:delete_table(session);
       [ur, user, pid] -> mnesia:delete_table(session);
       [usr, us, pid] -> mnesia:delete_table(session);
       [usr, us, sid, priority, info] -> mnesia:delete_table(session);
       [sid, usr, us, priority] ->
 	  mnesia:delete_table(session);
-      [sid, usr, us, priority, info] -> ok;
-      {'EXIT', _} -> ok
+      [sid, usr, us, priority, info] -> ok
+    catch
+      exit:_ -> ok
     end,
     case lists:member(presence, mnesia:system_info(tables))
 	of

--- a/src/ejabberd_sm_sql.erl
+++ b/src/ejabberd_sm_sql.erl
@@ -173,11 +173,10 @@ timestamp_to_now(I) ->
     {MSec, Sec, USec}.
 
 dec_priority(Prio) ->
-    case catch binary_to_integer(Prio) of
-	{'EXIT', _} ->
-	    undefined;
-	Int ->
-	    Int
+    try binary_to_integer(Prio)
+    catch
+        error:_ ->
+            undefined
     end.
 
 enc_priority(undefined) ->

--- a/src/ejabberd_sql.erl
+++ b/src/ejabberd_sql.erl
@@ -515,8 +515,14 @@ handle_info(Info, StateName, State) ->
 
 terminate(_Reason, _StateName, State) ->
     case State#state.db_type of
-        mysql -> catch p1_mysql_conn:stop(State#state.db_ref);
-        sqlite -> catch sqlite3:close(sqlite_db(State#state.host));
+        mysql ->
+            try p1_mysql_conn:stop(State#state.db_ref)
+            catch X:Y -> {X, Y}
+            end;
+        sqlite ->
+            try sqlite3:close(sqlite_db(State#state.host))
+            catch R:S -> {R, S}
+            end;
         _ -> ok
     end,
     ok.
@@ -543,9 +549,18 @@ handle_reconnect(Reason, #state{host = Host, reconnect_count = RC} = State) ->
 		 [State#state.db_type, Reason,
 		  StartInterval div 1000]),
     case State#state.db_type of
-	mysql -> catch p1_mysql_conn:stop(State#state.db_ref);
-	sqlite -> catch sqlite3:close(sqlite_db(State#state.host));
-	pgsql -> catch pgsql:terminate(State#state.db_ref);
+	mysql ->
+           try p1_mysql_conn:stop(State#state.db_ref)
+           catch M1:M2 -> {M1, M2}
+           end;
+	sqlite ->
+           try sqlite3:close(sqlite_db(State#state.host))
+           catch S1:S2 -> {S1, S2}
+           end;
+	pgsql ->
+           try pgsql:terminate(State#state.db_ref)
+           catch P1:P2 -> {P1, P2}
+           end;
 	_ -> ok
     end,
     p1_fsm:send_event_after(StartInterval, connect),
@@ -606,11 +621,14 @@ inner_transaction(F) ->
       _N -> ok
     end,
     put(?NESTING_KEY, PreviousNestingLevel + 1),
-    Result = (catch F()),
+    Result = try F()
+             catch F1:F2 -> {F1, F2}
+             end,
     put(?NESTING_KEY, PreviousNestingLevel),
     case Result of
       {aborted, Reason} -> {aborted, Reason};
-      {'EXIT', Reason} -> {'EXIT', Reason};
+      {exit, Reason} -> {'EXIT', Reason};
+      {error, Reason} -> {'EXIT', Reason};
       {atomic, Res} -> {atomic, Res};
       Res -> {atomic, Res}
     end.
@@ -687,10 +705,11 @@ maybe_restart_transaction(F, NRestarts, Reason, DoRollback) ->
     end.
 
 execute_bloc(F) ->
-    case catch F() of
+    try F() of
       {aborted, Reason} -> {aborted, Reason};
-      {'EXIT', Reason} -> {aborted, Reason};
       Res -> {atomic, Res}
+    catch
+        _:Reason -> {aborted, Reason}
     end.
 
 execute_fun(F) when is_function(F, 0) ->
@@ -774,10 +793,11 @@ sql_query_internal(#sql_query{} = Query) ->
         end,
     check_error(Res, Query);
 sql_query_internal(F) when is_function(F) ->
-    case catch execute_fun(F) of
+    try execute_fun(F) of
         {aborted, Reason} -> {error, Reason};
-        {'EXIT', Reason} -> {error, Reason};
         Res -> Res
+    catch
+        _:Reason -> {error, Reason}
     end;
 sql_query_internal(Query) ->
     State = get(?STATE_KEY),
@@ -1253,10 +1273,11 @@ get_db_version(#state{db_type = pgsql} = State) ->
     case pgsql:squery(State#state.db_ref,
                       <<"select current_setting('server_version_num')">>) of
         {ok, [{_, _, [[SVersion]]}]} ->
-            case catch binary_to_integer(SVersion) of
+            try binary_to_integer(SVersion) of
                 Version when is_integer(Version) ->
-                    State#state{db_version = Version};
-                Error ->
+                    State#state{db_version = Version}
+            catch
+                _:Error ->
                     ?WARNING_MSG("Error getting pgsql version: ~p", [Error]),
                     State
             end;
@@ -1474,10 +1495,11 @@ check_error({error, Why}, #sql_query{} = Query) ->
     {error, Err};
 check_error({error, Why}, Query) ->
     Err = extended_error(Why),
-    case catch iolist_to_binary(Query) of
+    try iolist_to_binary(Query) of
         SQuery when is_binary(SQuery) ->
-            ?ERROR_MSG("SQL query '~ts' failed: ~p", [SQuery, Err]);
-        _ ->
+            ?ERROR_MSG("SQL query '~ts' failed: ~p", [SQuery, Err])
+    catch
+        _:_ ->
             ?ERROR_MSG("SQL query ~p failed: ~p", [Query, Err])
     end,
     {error, Err};

--- a/src/ejabberd_sql.erl
+++ b/src/ejabberd_sql.erl
@@ -91,6 +91,10 @@
 -dialyzer([no_opaque_union]).
 -endif.
 
+-ifndef(OTP_BELOW_28).
+-compile({nowarn_deprecated_function, [{odbc, connect, 2}, {odbc, sql_query, 3}]}).
+-endif.
+
 -include("logger.hrl").
 -include("ejabberd_sql_pt.hrl").
 

--- a/src/ejabberd_web_admin.erl
+++ b/src/ejabberd_web_admin.erl
@@ -1899,8 +1899,13 @@ make_command_allowed(Name, Request, BaseArguments, Options, Cmd) ->
                 false
         end,
     ArgumentsUsed =
-        (catch lists:zip(
-                   lists:map(fun({A, _}) -> A end, ArgumentsFormat), ArgumentsUsed1)),
+        try
+            lists:zip(
+                lists:map(fun({A, _}) -> A end, ArgumentsFormat), ArgumentsUsed1)
+        catch
+            _:_ ->
+                error
+        end,
     ResultEls =
         make_command_result(filter_results(get_filters_from_query(Query,
                                                                   get_result_fields(ResultFormatApi)),

--- a/src/ejabberd_web_admin.erl
+++ b/src/ejabberd_web_admin.erl
@@ -41,6 +41,7 @@
          webadmin_node_db_table_page/3]).
 
 -include_lib("xmpp/include/xmpp.hrl").
+-include("ejabberd_catch.hrl").
 -include("ejabberd_commands.hrl").
 -include("ejabberd_http.hrl").
 -include("ejabberd_web_admin.hrl").
@@ -1069,13 +1070,12 @@ list_last_activity(Host, Lang, Integral, Period) ->
       <<"year">> -> TS = TimeStamp - 366 * 86400, Days = 366;
       _ -> TS = TimeStamp - 31 * 86400, Days = 31
     end,
-    case catch mnesia:dirty_select(last_activity,
+    try mnesia:dirty_select(last_activity,
 				   [{{last_activity, {'_', Host}, '$1', '_'},
 				     [{'>', '$1', TS}],
 				     [{trunc,
 				       {'/', {'-', TimeStamp, '$1'}, 86400}}]}])
 	of
-      {'EXIT', _Reason} -> [];
       Vals ->
 	  Hist = histogram(Vals, Integral),
 	  if Hist == [] -> [?CT(?T("No Data"))];
@@ -1099,6 +1099,8 @@ list_last_activity(Host, Lang, Integral, Period) ->
 			     [{xmlcdata, pretty_string_int(V)}])
 			|| V <- Hist ++ Tail])]
 	  end
+    catch
+      exit:_Reason -> []
     end.
 
 histogram(Values, Integral) ->

--- a/src/ejabberd_web_admin.erl
+++ b/src/ejabberd_web_admin.erl
@@ -2254,7 +2254,7 @@ execute_command2(Name,
         end,
     case LetsExecute of
         true ->
-            catch ejabberd_commands:execute_command2(Name, Arguments, CallerInfo);
+            ?CATCH_MFA(ejabberd_commands, execute_command2, [Name, Arguments, CallerInfo]);
         false ->
             not_executed
     end.

--- a/src/ejd2sql.erl
+++ b/src/ejd2sql.erl
@@ -267,10 +267,11 @@ flatten1([], Acc) ->
 import_rows(LServer, FromType, ToType, Tab, Mod, Dump, FieldsNumber) ->
     case read_row_from_sql_dump(Dump, FieldsNumber) of
         {ok, Fields} ->
-            case catch Mod:import(LServer, FromType, ToType, Tab, Fields) of
+            try Mod:import(LServer, FromType, ToType, Tab, Fields) of
                 ok ->
-                    ok;
-                Err ->
+                    ok
+            catch
+                _:Err ->
                     ?ERROR_MSG("Failed to import fields ~p for tab ~p: ~p",
                                [Fields, Tab, Err])
             end,

--- a/src/eldap.erl
+++ b/src/eldap.erl
@@ -200,9 +200,9 @@ add_attrs(Attrs) ->
     F = fun ({Type, Vals}) ->
 		{'AddRequest_attributes', Type, Vals}
 	end,
-    case catch lists:map(F, Attrs) of
-      {'EXIT', _} -> throw({error, attribute_values});
-      Else -> Else
+    try lists:map(F, Attrs)
+    catch
+      _:_ -> throw({error, attribute_values})
     end.
 
 %%% --------------------------------------------------------------------
@@ -347,11 +347,11 @@ optional(Value) -> Value.
 search(Handle, A) when is_record(A, eldap_search) ->
     call_search(Handle, A);
 search(Handle, L) when is_list(L) ->
-    case catch parse_search_args(L) of
-      {error, Emsg} -> {error, Emsg};
-      {'EXIT', Emsg} -> {error, Emsg};
+    try parse_search_args(L) of
       A when is_record(A, eldap_search) ->
 	  call_search(Handle, A)
+    catch
+        throw:{error, Emsg} -> {error, Emsg}
     end.
 
 call_search(Handle, A) ->
@@ -643,7 +643,9 @@ active(Event, From, S) ->
 %%          {stop, Reason, NewStateData}
 %%----------------------------------------------------------------------
 handle_event(close, _StateName, S) ->
-    catch (S#eldap.sockmod):close(S#eldap.fd),
+    try (S#eldap.sockmod):close(S#eldap.fd)
+    catch _:_ -> error
+    end,
     {stop, normal, S};
 handle_event(_Event, StateName, S) ->
     {next_state, StateName, S}.
@@ -661,23 +663,24 @@ handle_info({Tag, _Socket, Data}, connecting, S)
 handle_info({Tag, _Socket, Data}, wait_bind_response, S)
     when Tag == tcp; Tag == ssl ->
     misc:cancel_timer(S#eldap.bind_timer),
-    case catch recvd_wait_bind_response(Data, S) of
+    try recvd_wait_bind_response(Data, S) of
       bound -> dequeue_commands(S);
       {fail_bind, Reason} ->
 	  report_bind_failure(S#eldap.host, S#eldap.port, Reason),
 	  {next_state, connecting,
-	   close_and_retry(S, ?GRACEFUL_RETRY_TIMEOUT)};
-      {'EXIT', Reason} ->
+	   close_and_retry(S, ?GRACEFUL_RETRY_TIMEOUT)}
+    catch
+      throw:{error, Reason} ->
 	  report_bind_failure(S#eldap.host, S#eldap.port, Reason),
 	  {next_state, connecting, close_and_retry(S)};
-      {error, Reason} ->
+      _:Reason ->
 	  report_bind_failure(S#eldap.host, S#eldap.port, Reason),
 	  {next_state, connecting, close_and_retry(S)}
     end;
 handle_info({Tag, _Socket, Data}, StateName, S)
     when (StateName == active orelse StateName == active_bind)
 	   andalso (Tag == tcp orelse Tag == ssl) ->
-    case catch recvd_packet(Data, S) of
+    try recvd_packet(Data, S) of
       {response, Response, RequestType} ->
 	  NewS = case Response of
 		   {reply, Reply, To, S1} -> p1_fsm:reply(To, Reply), S1;
@@ -690,6 +693,8 @@ handle_info({Tag, _Socket, Data}, StateName, S)
 	     true -> {next_state, StateName, NewS}
 	  end;
       _ -> {next_state, StateName, S}
+    catch
+      _:_ -> {next_state, StateName, S}
     end;
 handle_info({Tag, _Socket}, Fsm_state, S)
     when Tag == tcp_closed; Tag == ssl_closed ->
@@ -970,7 +975,9 @@ check_id(_, _) -> throw({error, wrong_bind_id}).
 %%-----------------------------------------------------------------------
 
 close_and_retry(S, Timeout) ->
-    catch (S#eldap.sockmod):close(S#eldap.fd),
+    try (S#eldap.sockmod):close(S#eldap.fd)
+    catch _:_ -> error
+    end,
     Queue = dict:fold(fun (_Id,
 			   [{Timer, Command, From, _Name} | _], Q) ->
 			      misc:cancel_timer(Timer),

--- a/src/eldap_filter.erl
+++ b/src/eldap_filter.erl
@@ -84,15 +84,14 @@ parse(L) ->
                    {error, any()} | {ok, eldap:filter()}.
 
 parse(L, SList) ->
-    case catch eldap_filter_yecc:parse(scan(binary_to_list(L), SList)) of
-        {'EXIT', _} = Err ->
-            {error, Err};
+    try eldap_filter_yecc:parse(scan(binary_to_list(L), SList)) of
 	{error, {_, _, Msg}} ->
 	    {error, Msg};
 	{ok, Result} ->
-	    {ok, Result};
-	{regexp, Err} ->
-	    {error, Err}
+	    {ok, Result}
+    catch
+        _:Err ->
+            {error, {'EXIT', Err}}
     end.
 
 %%====================================================================

--- a/src/eldap_pool.erl
+++ b/src/eldap_pool.erl
@@ -51,12 +51,13 @@ start_link(Name, Hosts, Backups, Port, Rootdn, Passwd,
     pg:start_link(),
     lists:foreach(fun (Host) ->
 			  ID = list_to_binary(erlang:ref_to_list(make_ref())),
-			  case catch eldap:start_link(ID, [Host | Backups],
+			  try eldap:start_link(ID, [Host | Backups],
 						      Port, Rootdn, Passwd,
 						      Opts)
 			      of
-			    {ok, Pid} -> pg:join(PoolName, Pid);
-			    Err ->
+			    {ok, Pid} -> pg:join(PoolName, Pid)
+                          catch
+                             _:Err ->
                                   ?ERROR_MSG("Err = ~p", [Err]),
                                   error
 			  end
@@ -69,14 +70,14 @@ start_link(Name, Hosts, Backups, Port, Rootdn, Passwd,
 do_request(Name, {F, Args}) ->
     case pg_get_closest_pid(make_id(Name)) of
       Pid when is_pid(Pid) ->
-	  case catch apply(eldap, F, [Pid | Args]) of
-	    {'EXIT', {timeout, _}} ->
-		?ERROR_MSG("LDAP request failed: timed out", []);
-	    {'EXIT', Reason} ->
+	  try apply(eldap, F, [Pid | Args])
+          catch
+              _:timeout ->
+                  ?ERROR_MSG("LDAP request failed: timed out", []);
+              _:Reason ->
 		?ERROR_MSG("LDAP request failed: eldap:~p(~p)~nReason: ~p",
 			   [F, Args, Reason]),
-		{error, Reason};
-	    Reply -> Reply
+		{error, Reason}
 	  end;
       Err -> Err
     end.

--- a/src/eldap_utils.erl
+++ b/src/eldap_utils.erl
@@ -88,13 +88,9 @@ get_user_part(String, Pattern) ->
 		TailLength = byte_size(P) - (First+1),
 		str:sub_string(S, First, byte_size(S) - TailLength)
 	end,
-    case catch F(String, Pattern) of
-	{'EXIT', _} ->
-	    {error, badmatch};
+    try F(String, Pattern) of
 	Result ->
-            case catch ejabberd_regexp:replace(Pattern, <<"%u">>, Result) of
-                {'EXIT', _} ->
-                    {error, badmatch};
+            try ejabberd_regexp:replace(Pattern, <<"%u">>, Result) of
 		StringRes ->
                     case case_insensitive_match(StringRes, String) of
                         true ->
@@ -102,7 +98,13 @@ get_user_part(String, Pattern) ->
                         false ->
                             {error, badmatch}
                     end
+            catch
+               _:_ ->
+                    {error, badmatch}
             end
+    catch
+        _:_ ->
+            {error, badmatch}
     end.
 
 -spec make_filter([{binary(), [binary()]}], [{binary(), binary()}]) -> any().

--- a/src/ext_mod.erl
+++ b/src/ext_mod.erl
@@ -43,6 +43,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
 	 terminate/2, code_change/3]).
 
+-include("ejabberd_catch.hrl").
 -include("ejabberd_commands.hrl").
 -include("ejabberd_http.hrl").
 -include("ejabberd_web_admin.hrl").
@@ -1338,9 +1339,9 @@ get_commit_link(CommitHtmlUrl, TitleEl, CommitSha) ->
 
 get_content(Node, Query, Lang) ->
     {{_CommandCtl}, _Res} =
-        case catch parse_and_execute(Query, Node) of
-            {'EXIT', _} -> {{""}, <<"">>};
-            Result_tuple -> Result_tuple
+        try parse_and_execute(Query, Node)
+        catch
+            _:_ -> {{""}, <<"">>}
         end,
 
     AvailableModulesEls = get_available_modules_table(Lang),

--- a/src/extauth.erl
+++ b/src/extauth.erl
@@ -160,7 +160,9 @@ handle_info(Info, State) ->
     {noreply, State}.
 
 terminate(_Reason, State) ->
-    catch port_close(State#state.port),
+    try port_close(State#state.port)
+    catch _:_ -> error
+    end,
     ok.
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/gen_iq_handler.erl
+++ b/src/gen_iq_handler.erl
@@ -46,9 +46,11 @@
 %%====================================================================
 -spec start(component()) -> ok.
 start(Component) ->
-    catch ets:new(Component, [named_table, public, ordered_set,
+    try ets:new(Component, [named_table, public, ordered_set,
 			      {read_concurrency, true},
-			      {heir, erlang:group_leader(), none}]),
+			      {heir, erlang:group_leader(), none}])
+    catch _:_ -> error
+    end,
     ok.
 
 -spec add_iq_handler(component(), binary(), binary(), module(), atom()) -> ok.

--- a/src/jd2ejd.erl
+++ b/src/jd2ejd.erl
@@ -30,6 +30,7 @@
 %% External exports
 -export([import_file/1, import_dir/1]).
 
+-include("ejabberd_catch.hrl").
 -include("logger.hrl").
 -include_lib("xmpp/include/xmpp.hrl").
 
@@ -119,17 +120,17 @@ xdb_data(User, Server, #xmlel{attrs = Attrs} = El) ->
 	  ejabberd_auth:set_password(User, Server, Password),
 	  ok;
       ?NS_ROSTER ->
-	  catch mod_roster:set_items(User, Server, xmpp:decode(El)),
+	  ?CATCH_MFA(mod_roster, set_items, [User, Server, xmpp:decode(El)]),
 	  ok;
       ?NS_LAST ->
 	  TimeStamp = fxml:get_attr_s(<<"last">>, Attrs),
 	  Status = fxml:get_tag_cdata(El),
-	  catch mod_last:store_last_info(User, Server,
+	  ?CATCH_MFA(mod_last, store_last_info, [User, Server,
 					 binary_to_integer(TimeStamp),
-					 Status),
+					 Status]),
 	  ok;
       ?NS_VCARD ->
-	  catch mod_vcard:set_vcard(User, LServer, El),
+	  ?CATCH_MFA(mod_vcard, set_vcard, [User, LServer, El]),
 	  ok;
       <<"jabber:x:offline">> ->
 	  process_offline(Server, From, El), ok;
@@ -141,9 +142,9 @@ xdb_data(User, Server, #xmlel{attrs = Attrs} = El) ->
 				({<<"xdbns">>, _}) -> false;
 				(_) -> true
 			     end, Attrs),
-		catch mod_private:set_data(
+	  ?CATCH_MFA(mod_private, set_data, [
 			From,
-			[{XMLNS, El#xmlel{attrs = NewAttrs}}]);
+			[{XMLNS, El#xmlel{attrs = NewAttrs}}]]);
 	    _ ->
 		?DEBUG("Unknown namespace \"~ts\"~n", [XMLNS])
 	  end,

--- a/src/jd2ejd.erl
+++ b/src/jd2ejd.erl
@@ -48,13 +48,14 @@ import_file(File) ->
 	    {ok, Text} ->
 		case fxml_stream:parse_element(Text) of
 		  El when is_record(El, xmlel) ->
-		      case catch process_xdb(User, Server, El) of
-			{'EXIT', Reason} ->
+		      try process_xdb(User, Server, El) of
+			_ -> ok
+                      catch
+			_:Reason ->
 			    ?ERROR_MSG("Error while processing file \"~ts\": "
 				       "~p~n",
 				       [File, Reason]),
-			    {error, Reason};
-			_ -> ok
+			    {error, Reason}
 		      end;
 		  {error, Reason} ->
 		      ?ERROR_MSG("Can't parse file \"~ts\": ~p~n",

--- a/src/mod_admin_extra.erl
+++ b/src/mod_admin_extra.erl
@@ -1148,12 +1148,15 @@ delete_old_users(Days, Users) ->
     TimeStamp_now = erlang:system_time(second),
     TimeStamp_oldest = TimeStamp_now - SecOlder,
     F = fun({LUser, LServer}) ->
-	    case catch delete_or_not(LUser, LServer, TimeStamp_oldest) of
+	    try delete_or_not(LUser, LServer, TimeStamp_oldest) of
 		true ->
 		    ejabberd_auth:remove_user(LUser, LServer),
 		    true;
 		_ ->
 		    false
+            catch
+                _:_ ->
+                    false
 	    end
 	end,
     Users_removed = lists:filter(F, Users),
@@ -1385,7 +1388,7 @@ get_status_list(Host, Status_required) ->
 	    end,
     Sessions3 = [ {Pid, Server, Priority} || {{_User, Server, _Resource}, {_, Pid}, Priority} <- Sessions2, apply(Fhost, [Server, Host])],
     %% For each Pid, get its presence
-    Sessions4 = [ {catch get_presence(Pid), Server, Priority} || {Pid, Server, Priority} <- Sessions3],
+    Sessions4 = [ {get_presence(Pid), Server, Priority} || {Pid, Server, Priority} <- Sessions3],
     %% Filter by status
     Fstatus = case Status_required of
 		  <<"all">> ->
@@ -2161,12 +2164,14 @@ stats(Name, Host) ->
 user_action(User, Server, Fun, OK) ->
     case ejabberd_auth:user_exists(User, Server) of
         true ->
-            case catch Fun() of
+            try Fun() of
                 OK -> ok;
                 {error, Error} -> throw(Error);
                 Error ->
                     ?ERROR_MSG("Command returned: ~p", [Error]),
                     1
+            catch
+                _:Error -> throw(Error)
             end;
         false ->
             throw({not_found, "unknown_user"})

--- a/src/mod_announce_sql.erl
+++ b/src/mod_announce_sql.erl
@@ -93,28 +93,30 @@ delete_motd(LServer) ->
     transaction(LServer, F).
 
 get_motd(LServer) ->
-    case catch ejabberd_sql:sql_query(
+    try ejabberd_sql:sql_query(
                  LServer,
                  ?SQL("select @(xml)s from motd"
                       " where username='' and %(LServer)H")) of
         {selected, [{XML}]} ->
 	    parse_element(XML);
 	{selected, []} ->
-	    error;
-	_ ->
+	    error
+    catch
+        _:_ ->
 	    {error, db_failure}
     end.
 
 is_motd_user(LUser, LServer) ->
-    case catch ejabberd_sql:sql_query(
+    try ejabberd_sql:sql_query(
                  LServer,
                  ?SQL("select @(username)s from motd"
                       " where username=%(LUser)s and %(LServer)H")) of
         {selected, [_|_]} ->
 	    {ok, true};
 	{selected, []} ->
-	    {ok, false};
-	_ ->
+	    {ok, false}
+    catch
+        _:_ ->
 	    {error, db_failure}
     end.
 

--- a/src/mod_bosh_mnesia.erl
+++ b/src/mod_bosh_mnesia.erl
@@ -227,10 +227,13 @@ multicast(Msg) ->
       end, ejabberd_cluster:get_nodes()).
 
 setup_database() ->
-    case catch mnesia:table_info(bosh, attributes) of
+    try mnesia:table_info(bosh, attributes) of
         [sid, pid] ->
             mnesia:delete_table(bosh);
         _ ->
+            ok
+    catch
+        _:_ ->
             ok
     end,
     ejabberd_mnesia:create(?MODULE, bosh,

--- a/src/mod_caps.erl
+++ b/src/mod_caps.erl
@@ -563,9 +563,11 @@ import_start(LServer, DBType) ->
 
 import(_LServer, {sql, _}, _DBType, <<"caps_features">>,
        [Node, SubNode, Feature, _TimeStamp]) ->
-    Feature1 = case catch binary_to_integer(Feature) of
+    Feature1 = try binary_to_integer(Feature) of
                    I when is_integer(I), I>0 -> I;
                    _ -> Feature
+               catch
+                   _:_ -> Feature
                end,
     ets:insert(caps_features_tmp, {{Node, SubNode}, Feature1}),
     ok.

--- a/src/mod_caps_sql.erl
+++ b/src/mod_caps_sql.erl
@@ -63,10 +63,11 @@ caps_read(LServer, {Node, SubNode}) ->
            ?SQL("select @(feature)s from caps_features where"
                 " node=%(Node)s and subnode=%(SubNode)s")) of
         {selected, [{H}|_] = Fs} ->
-            case catch binary_to_integer(H) of
+            try binary_to_integer(H) of
                 Int when is_integer(Int), Int>=0 ->
-                    {ok, Int};
-                _ ->
+                    {ok, Int}
+            catch
+                _:_ ->
                     {ok, [F || {F} <- Fs]}
             end;
         _ ->

--- a/src/mod_carboncopy.erl
+++ b/src/mod_carboncopy.erl
@@ -42,6 +42,7 @@
 %% For debugging purposes
 -export([list/2]).
 
+-include("ejabberd_catch.hrl").
 -include("logger.hrl").
 -include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
@@ -187,9 +188,11 @@ send_copies(JID, To, Msg, Direction)->
     {U, S, R} = jid:tolower(JID),
     PrioRes = ejabberd_sm:get_user_present_resources(U, S),
     {_, AvailRs} = lists:unzip(PrioRes),
-    {MaxPrio, _MaxRes} = case catch lists:max(PrioRes) of
-	{Prio, Res} -> {Prio, Res};
+    {MaxPrio, _MaxRes} = try lists:max(PrioRes) of
+	{Prio, Res} when is_integer(Prio) -> {Prio, Res};
 	_ -> {0, undefined}
+    catch
+        error:function_clause -> {0, undefined}
     end,
 
     %% unavailable resources are handled like bare JIDs

--- a/src/mod_delegation.erl
+++ b/src/mod_delegation.erl
@@ -191,9 +191,11 @@ disco_sm_identity(Acc, From, To, Node, Lang) ->
 %%%===================================================================
 init([Host|_]) ->
     process_flag(trap_exit, true),
-    catch ets:new(?MODULE,
+    try ets:new(?MODULE,
                   [named_table, public,
-                   {heir, erlang:group_leader(), none}]),
+                   {heir, erlang:group_leader(), none}])
+    catch _:_ -> error
+    end,
     ejabberd_hooks:add(component_connected, ?MODULE,
 		       component_connected, 50),
     ejabberd_hooks:add(component_disconnected, ?MODULE,

--- a/src/mod_disco.erl
+++ b/src/mod_disco.erl
@@ -51,9 +51,11 @@
 -export_type([features_acc/0, items_acc/0]).
 
 start(Host, Opts) ->
-    catch ets:new(disco_extra_domains,
+    try ets:new(disco_extra_domains,
 		  [named_table, ordered_set, public,
-		   {heir, erlang:group_leader(), none}]),
+		   {heir, erlang:group_leader(), none}])
+    catch _:_ -> error
+    end,
     ExtraDomains = mod_disco_opt:extra_domains(Opts),
     lists:foreach(fun (Domain) ->
 			  register_extra_domain(Host, Domain)
@@ -72,8 +74,10 @@ start(Host, Opts) ->
           {hook, disco_info, get_info, 100}]}.
 
 stop(Host) ->
-    catch ets:match_delete(disco_extra_domains,
-			   {{'_', Host}}),
+    try ets:match_delete(disco_extra_domains,
+			   {{'_', Host}})
+    catch _:_ -> error
+    end,
     ok.
 
 reload(Host, NewOpts, OldOpts) ->

--- a/src/mod_fail2ban.erl
+++ b/src/mod_fail2ban.erl
@@ -105,8 +105,10 @@ c2s_stream_started(#{ip := {Addr, _}} = State, _) ->
 %% gen_mod callbacks
 %%====================================================================
 start(Host, Opts) ->
-    catch ets:new(failed_auth, [named_table, public,
-				{heir, erlang:group_leader(), none}]),
+    try ets:new(failed_auth, [named_table, public,
+				{heir, erlang:group_leader(), none}])
+    catch _:_ -> error
+    end,
     ejabberd_commands:register_commands(Host, ?MODULE, get_commands_spec()),
     gen_mod:start_child(?MODULE, Host, Opts).
 

--- a/src/mod_http_api.erl
+++ b/src/mod_http_api.erl
@@ -178,7 +178,7 @@ process(_Path, Request) ->
     json_error(400, 40, <<"Missing command name.">>).
 
 perform_call(Command, Args, Req, Version) ->
-    case catch binary_to_existing_atom(Command, utf8) of
+    try binary_to_existing_atom(Command, utf8) of
 	Call when is_atom(Call) ->
 	    case extract_auth(Req) of
 		{error, expired} -> invalid_token_response();
@@ -187,8 +187,9 @@ perform_call(Command, Args, Req, Version) ->
 		Auth when is_map(Auth) ->
 		    Result = handle(Call, Auth, Args, Version),
 		    json_format(Result)
-	    end;
-	_ ->
+	    end
+    catch
+        _:_ ->
 	    json_error(404, 40, <<"Endpoint not found.">>)
     end.
 
@@ -203,10 +204,9 @@ get_api_version(#request{path = Path, host = Host}) ->
     get_api_version(lists:reverse(Path), Host).
 
 get_api_version([<<"v", String/binary>> | Tail], Host) ->
-    case catch binary_to_integer(String) of
-	N when is_integer(N) ->
-	    N;
-	_ ->
+    try binary_to_integer(String)
+    catch
+        _:_ ->
 	    get_api_version(Tail, Host)
     end;
 get_api_version([_Head | Tail], Host) ->

--- a/src/mod_mam.erl
+++ b/src/mod_mam.erl
@@ -1596,10 +1596,14 @@ match_interval(Now, Start, End) ->
     (Now >= Start) and (Now =< End).
 
 match_rsm(Now, #rsm_set{'after' = ID}) when is_binary(ID), ID /= <<"">> ->
-    Now1 = (catch misc:usec_to_now(binary_to_integer(ID))),
+    Now1 = try misc:usec_to_now(binary_to_integer(ID))
+           catch _:_ -> error
+           end,
     Now > Now1;
 match_rsm(Now, #rsm_set{before = ID}) when is_binary(ID), ID /= <<"">> ->
-    Now1 = (catch misc:usec_to_now(binary_to_integer(ID))),
+    Now1 = try misc:usec_to_now(binary_to_integer(ID))
+           catch _:_ -> error
+           end,
     Now < Now1;
 match_rsm(_Now, _) ->
     true.

--- a/src/mod_mam_sql.erl
+++ b/src/mod_mam_sql.erl
@@ -639,17 +639,18 @@ make_sql_query(User, LServer, MAMQuery, RSM, ExtraUsernames) ->
 			true ->
 			     []
 		     end,
-    WithClause = case catch jid:tolower(With) of
+    WithClause = try jid:tolower(With) of
 		     {_, _, <<>>} ->
 			 [<<" and bare_peer=">>,
 			  ToString(jid:encode(With))];
 		     {_, _, _} ->
 			 [<<" and peer=">>,
-			  ToString(jid:encode(With))];
-		     _ ->
-			 []
+			  ToString(jid:encode(With))]
+                 catch
+                     _:_ ->
+                         []
 		 end,
-    PageClause = case catch binary_to_integer(ID) of
+    PageClause = try binary_to_integer(ID) of
 		     I when is_integer(I), I >= 0 ->
 			 case Direction of
 			     before ->
@@ -658,9 +659,10 @@ make_sql_query(User, LServer, MAMQuery, RSM, ExtraUsernames) ->
 				 [<<" AND timestamp > ">>, ID];
 			     _ ->
 				 []
-			 end;
-		     _ ->
-			 []
+			 end
+                 catch
+                     _:_ ->
+                         []
 		 end,
     StartClause = case Start of
 		      {_, _, _} ->

--- a/src/mod_matrix_gw.erl
+++ b/src/mod_matrix_gw.erl
@@ -237,7 +237,7 @@ process([<<"federation">>, <<"v1">>, <<"get_missing_events">>, RoomID],
     end;
 process([<<"federation">>, <<"v1">>, <<"backfill">>, RoomID],
         #request{method = 'GET', host = _Host} = Request) ->
-    case catch binary_to_integer(proplists:get_value(<<"limit">>, Request#request.q)) of
+    try binary_to_integer(proplists:get_value(<<"limit">>, Request#request.q)) of
         Limit when is_integer(Limit) ->
             case preprocess_federation_request(Request, false) of
                 {ok, _JSON, Origin} ->
@@ -265,8 +265,9 @@ process([<<"federation">>, <<"v1">>, <<"backfill">>, RoomID],
                      misc:json_encode(Res)};
                 {result, HTTPResult} ->
                     HTTPResult
-            end;
-        _ ->
+            end
+    catch
+        _:_ ->
             {400, [], <<"400 Bad Request: bad 'limit' parameter">>}
     end;
 process([<<"federation">>, <<"v1">>, <<"state_ids">>, RoomID],

--- a/src/mod_matrix_gw_s2s.erl
+++ b/src/mod_matrix_gw_s2s.erl
@@ -147,7 +147,7 @@ check_auth(Host, MatrixServer, AuthParams, Content, Request) ->
     case get_connection(Host, MatrixServer) of
         {ok, S2SPid} ->
             #{<<"key">> := KeyID} = AuthParams,
-            case catch gen_statem:call(S2SPid, {get_key, KeyID}) of
+            try gen_statem:call(S2SPid, {get_key, KeyID}) of
                 {ok, VerifyKey, _ValidUntil} ->
                     %% TODO: check ValidUntil
                     Destination = mod_matrix_gw_opt:matrix_domain(Host),
@@ -175,6 +175,9 @@ check_auth(Host, MatrixServer, AuthParams, Content, Request) ->
                     end;
                 _ ->
                     false
+            catch
+                _:_ ->
+                    false
             end;
         {error, _} = _Error ->
             false
@@ -190,7 +193,7 @@ check_signature(Host, JSON, RoomVersion) ->
                 #{MatrixServer := #{} = KeySig} ->
                     case maps:next(maps:iterator(KeySig)) of
                         {KeyID, _Sig, _} ->
-                            case catch get_key(Host, MatrixServer, KeyID) of
+                            try get_key(Host, MatrixServer, KeyID) of
                                 {ok, VerifyKey, ValidUntil} ->
                                     if
                                         not RoomVersion#room_version.enforce_key_validity or
@@ -206,6 +209,9 @@ check_signature(Host, JSON, RoomVersion) ->
                                             false
                                     end;
                                 _ ->
+                                    false
+                            catch
+                                _:_ ->
                                     false
                             end;
                         _ ->
@@ -324,9 +330,10 @@ handle_event(cast, {key_reply, RequestID, HTTPResult}, State,
                     VerifyKey = mod_matrix_gw:base64_decode(SKey),
                     ?DEBUG("key ~p~n", [VerifyKey]),
                     ?DEBUG("check ~p~n",
-                           [catch check_signature(
+                           [try check_signature(
                                     JSON, Data#data.matrix_server,
-                                    KeyID, VerifyKey)]),
+                                    KeyID, VerifyKey)
+                            catch _:_ -> error_checking_signature end]),
                     true = check_signature(
                              JSON, Data#data.matrix_server,
                              KeyID, VerifyKey),
@@ -506,10 +513,11 @@ do_get_matrix_host_port(MatrixServer) ->
                     end
             end;
         [Addr, SPort] ->
-            case catch binary_to_integer(SPort) of
+            try binary_to_integer(SPort) of
                 Port when is_integer(Port) ->
-                    {Addr, Port};
-                _ ->
+                    {Addr, Port}
+            catch
+                _:_ ->
                     error
             end
     end.

--- a/src/mod_mqtt.erl
+++ b/src/mod_mqtt.erl
@@ -642,9 +642,11 @@ init_cache(Mod, Host, Opts) ->
 
 -spec init_topic_cache(module(), binary()) -> ok | {error, db_failure}.
 init_topic_cache(Mod, Host) ->
-    catch ets:new(?MQTT_TOPIC_CACHE,
+    try ets:new(?MQTT_TOPIC_CACHE,
                   [named_table, ordered_set, public,
-                   {heir, erlang:group_leader(), none}]),
+                   {heir, erlang:group_leader(), none}])
+    catch _:_ -> error
+    end,
     ?INFO_MSG("Building MQTT cache for ~ts, this may take a while", [Host]),
     case Mod:list_topics(Host) of
         {ok, Topics} ->

--- a/src/mod_muc.erl
+++ b/src/mod_muc.erl
@@ -1242,7 +1242,9 @@ remove_user(User, Server) ->
     JID = jid:make(User, Server),
     lists:foreach(
       fun(HostI) ->
-              catch set_nick(HostI, JID, <<"">>)
+              try set_nick(HostI, JID, <<"">>)
+              catch _:_ -> error
+              end
       end,
       ejabberd_option:hosts()),
     lists:foreach(

--- a/src/mod_muc_admin.erl
+++ b/src/mod_muc_admin.erl
@@ -1138,10 +1138,11 @@ make_breadcrumb(Elements) ->
 
 %% Returns: {normal | reverse, Integer}
 get_sort_query(Q) ->
-    case catch get_sort_query2(Q) of
+    try get_sort_query2(Q) of
         {ok, Res} ->
-            Res;
-        _ ->
+            Res
+    catch
+        _:_ ->
             {normal, 1}
     end.
 

--- a/src/mod_muc_log.erl
+++ b/src/mod_muc_log.erl
@@ -85,11 +85,11 @@ add_to_log(Host, Type, Data, Room, Opts) ->
 check_access_log(allow, _Host, _From) ->
     allow;
 check_access_log(_Acc, Host, From) ->
-    case catch gen_server:call(get_proc_name(Host),
+    try gen_server:call(get_proc_name(Host),
 			       {check_access_log, Host, From})
-	of
-      {'EXIT', _Error} -> deny;
-      Res -> Res
+    catch
+        _:_ ->
+            deny
     end.
 
 -spec get_url(any(), #state{}) -> {ok, binary()} | error.
@@ -133,9 +133,10 @@ handle_call(stop, _From, State) ->
 handle_cast({reload, Opts}, #logstate{host = Host}) ->
     {noreply, init_state(Host, Opts)};
 handle_cast({add_to_log, Type, Data, Room, Opts}, State) ->
-    case catch add_to_log2(Type, Data, Room, Opts, State) of
-      {'EXIT', Reason} -> ?ERROR_MSG("~p", [Reason]);
-      _ -> ok
+    try add_to_log2(Type, Data, Room, Opts, State) of
+        _ -> ok
+    catch
+        _:Reason -> ?ERROR_MSG("~p", [Reason])
     end,
     {noreply, State};
 handle_cast(Msg, State) ->
@@ -342,7 +343,9 @@ add_message_to_log(Nick1, Message, RoomJID, Opts,
       {error, enoent} ->
 	  make_dir_rec(Fd),
 	  {ok, F} = file:open(Fn, [append]),
-	  catch set_filemode(Fn, FilePermissions),
+	  try set_filemode(Fn, FilePermissions)
+          catch _:_ -> error
+          end,
 	  Datestring = get_dateweek(Date, Lang),
 	  TimeStampYesterday = get_timestamp_daydiff(TimeStamp,
 						     -1),

--- a/src/mod_muc_mnesia.erl
+++ b/src/mod_muc_mnesia.erl
@@ -51,6 +51,7 @@
 -include_lib("xmpp/include/xmpp.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 
+-include("ejabberd_catch.hrl").
 -include("ejabberd_db_serialize.hrl").
 
 -record(state, {}).
@@ -103,15 +104,16 @@ can_use_nick(_LServer, ServiceOrRoom, JID, Nick) ->
                     {'==', {element, 2, '$1'}, Service},
                     {'==', {element, 2, '$1'}, ServiceOrRoom} }]
                 end,
-    case catch mnesia:dirty_select(muc_registered,
+    try mnesia:dirty_select(muc_registered,
 				   [{#muc_registered{us_host = '$1',
 						     nick = Nick, _ = '_'},
 				     MatchSpec,
 				     ['$_']}])
 	of
-      {'EXIT', _Reason} -> true;
       [] -> true;
       [#muc_registered{us_host = {U, _Host}}] -> U == LUS
+    catch
+        exit:_Reason -> true
     end.
 
 get_rooms(_LServer, Host) ->
@@ -373,7 +375,9 @@ init([_Host, Opts]) ->
 				   [{ram_copies, [node()]},
 				    {type, ordered_set},
 				    {attributes, record_info(fields, muc_online_room)}]),
-	    catch ets:new(muc_online_users, [bag, named_table, public, {keypos, 2}]),
+	    try ets:new(muc_online_users, [bag, named_table, public, {keypos, 2}])
+            catch _:_ -> ok
+            end,
 	    lists:foreach(
 	      fun(MyHost) ->
 		      clean_table_from_bad_node(node(), MyHost)

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -70,11 +70,11 @@
 	 terminate/3,
 	 code_change/4]).
 
+-include("ejabberd_catch.hrl").
 -include("logger.hrl").
 -include_lib("xmpp/include/xmpp.hrl").
 -include("translate.hrl").
 -include("mod_muc_room.hrl").
-
 
 -define(MAX_USERS_DEFAULT_LIST,
 	[5, 10, 20, 30, 50, 100, 200, 500, 1000, 2000, 5000]).
@@ -1296,8 +1296,7 @@ process_voice_approval(From, Pkt, VoiceApproval, StateData) ->
 			true when Allow ->
 			    Reason = <<>>,
 			    NSD = set_role(TargetJid, participant, StateData),
-			    catch send_new_presence(
-				    TargetJid, Reason, NSD, StateData),
+			    ?CATCH_TRY(send_new_presence, TargetJid, Reason, NSD, StateData),
 			    NSD;
 			_ ->
 			    StateData
@@ -4103,7 +4102,7 @@ remove_nonmembers(StateData) ->
 	      Affiliation = get_affiliation(JID, SD),
 	      case Affiliation of
 		  none ->
-		      catch send_kickban_presence(undefined, JID, <<"">>, 322, SD),
+		      ?CATCH_TRY(send_kickban_presence, undefined, JID, <<"">>, 322, SD),
 		      set_role(JID, none, SD);
 		  _ -> SD
 	      end

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -2182,9 +2182,11 @@ filter_presence(Presence) ->
     Els = lists:filter(
 	    fun(El) ->
 		    XMLNS = xmpp:get_ns(El),
-		    case catch binary:part(XMLNS, 0, size(?NS_MUC)) of
+		    try binary:part(XMLNS, 0, size(?NS_MUC)) of
 			?NS_MUC -> false;
 			_ -> XMLNS /= ?NS_HATS
+		    catch
+			_:_ -> XMLNS /= ?NS_HATS
 		    end
 	    end, xmpp:get_els(Presence)),
     xmpp:set_els(Presence, Els).

--- a/src/mod_muc_room.erl
+++ b/src/mod_muc_room.erl
@@ -3208,7 +3208,7 @@ search_affiliation_fallback(Affiliation, StateData) ->
 process_admin_items_set(UJID, Items, Lang, StateData) ->
     UAffiliation = get_affiliation(UJID, StateData),
     URole = get_role(UJID, StateData),
-    case catch find_changed_items(UJID, UAffiliation, URole,
+    try find_changed_items(UJID, UAffiliation, URole,
 				  Items, Lang, StateData, [])
 	of
       {result, Res} ->
@@ -3223,8 +3223,9 @@ process_admin_items_set(UJID, Items, Lang, StateData) ->
 	      NSD ->
 		  store_room(NSD),
 		  {result, undefined, NSD}
-	  end;
-	{error, Err} -> {error, Err}
+	  end
+    catch
+	throw:{error, Err} -> {error, Err}
     end.
 
 -spec process_item_change(jid()) -> fun((admin_action(), state() | {error, stanza_error()}) ->

--- a/src/mod_muc_sql.erl
+++ b/src/mod_muc_sql.erl
@@ -49,6 +49,7 @@
 -include_lib("xmpp/include/jid.hrl").
 -include("mod_muc.hrl").
 -include("logger.hrl").
+-include("ejabberd_catch.hrl").
 -include("ejabberd_sql_pt.hrl").
 -include("ejabberd_db_serialize.hrl").
 
@@ -196,13 +197,13 @@ change_room(Host, Room, Change) ->
     ?ERROR_MSG("Unsupported change on room ~ts@~ts: ~p", [Room, Host, Change]).
 
 restore_room(LServer, Host, Name) ->
-    case catch ejabberd_sql:sql_query(
+    case try_sql_query(
                  LServer,
                  ?SQL("select @(opts)s from muc_room where name=%(Name)s"
                       " and host=%(Host)s")) of
 	{selected, [{Opts}]} ->
 	    OptsD = ejabberd_sql:decode_term(Opts),
-	    case catch ejabberd_sql:sql_query(
+	    case try_sql_query(
 		LServer,
 		?SQL("select @(jid)s, @(nick)s, @(nodes)s from muc_room_subscribers where room=%(Name)s"
 		     " and host=%(Host)s")) of
@@ -254,13 +255,13 @@ can_use_nick(LServer, ServiceOrRoom, JID, Nick) ->
                             "where nick=%(Nick)s"
                             " and (host=%(ServiceOrRoom)s or host=%(Service)s)")
                end,
-    case catch ejabberd_sql:sql_query(LServer, SqlQuery) of
+    case try_sql_query(LServer, SqlQuery) of
 	{selected, [{SJID1}]} -> SJID == SJID1;
 	_ -> true
     end.
 
 get_rooms_without_subscribers(LServer, Host) ->
-    case catch ejabberd_sql:sql_query(
+    case try_sql_query(
 	LServer,
 	?SQL("select @(name)s, @(opts)s from muc_room"
 	     " where host=%(Host)s")) of
@@ -277,7 +278,7 @@ get_rooms_without_subscribers(LServer, Host) ->
 
 get_hibernated_rooms_older_than(LServer, Host, Timestamp) ->
     TimestampS = usec_to_sql_timestamp(Timestamp),
-    case catch ejabberd_sql:sql_query(
+    case try_sql_query(
 	LServer,
 	?SQL("select @(name)s, @(opts)s from muc_room"
 	     " where host=%(Host)s and created_at < %(TimestampS)t and created_at > '1970-01-02 00:00:00'")) of
@@ -293,12 +294,12 @@ get_hibernated_rooms_older_than(LServer, Host, Timestamp) ->
     end.
 
 get_rooms(LServer, Host) ->
-    case catch ejabberd_sql:sql_query(
+    case try_sql_query(
                  LServer,
                  ?SQL("select @(name)s, @(opts)s from muc_room"
                       " where host=%(Host)s")) of
 	{selected, RoomOpts} ->
-	    case catch ejabberd_sql:sql_query(
+            case try_sql_query(
 		LServer,
 		?SQL("select @(room)s, @(jid)s, @(nick)s, @(nodes)s from muc_room_subscribers"
 		     " where host=%(Host)s")) of
@@ -339,7 +340,7 @@ get_rooms(LServer, Host) ->
 
 get_nick(LServer, Host, From) ->
     SJID = jid:encode(jid:tolower(jid:remove_resource(From))),
-    case catch ejabberd_sql:sql_query(
+    case try_sql_query(
                  LServer,
                  ?SQL("select @(nick)s from muc_registered where"
                       " jid=%(SJID)s and host=%(Host)s")) of
@@ -348,7 +349,7 @@ get_nick(LServer, Host, From) ->
     end.
 
 get_nicks(LServer, Host) ->
-    case catch ejabberd_sql:sql_query(LServer,
+    case try_sql_query(LServer,
                                       ?SQL("select @(jid)s, @(nick)s from muc_registered where"
                                            " host=%(Host)s"))
     of
@@ -760,3 +761,6 @@ clean_tables(ServerHost) ->
 usec_to_sql_timestamp(Timestamp) ->
     TS = misc:usec_to_now(Timestamp),
     calendar:now_to_universal_time(TS).
+
+try_sql_query(LServer, Query) ->
+    ?CATCH_MFA(ejabberd_sql, sql_query, [LServer, Query]).

--- a/src/mod_multicast.erl
+++ b/src/mod_multicast.erl
@@ -178,11 +178,12 @@ handle_cast(Msg, State) ->
 %%--------------------------------------------------------------------
 
 handle_info({route, #iq{} = Packet}, State) ->
-    case catch handle_iq(Packet, State) of
-        {'EXIT', Reason} ->
-            ?ERROR_MSG("Error when processing IQ stanza: ~p",
-                       [Reason]);
+    try handle_iq(Packet, State) of
         _ -> ok
+    catch
+        _:Reason ->
+            ?ERROR_MSG("Error when processing IQ stanza: ~p",
+                       [Reason])
     end,
     {noreply, State};
 %% XEP33 allows only 'message' and 'presence' stanza type
@@ -197,11 +198,12 @@ handle_info({route_trusted, Destinations, Packet},
 	    #state{lservice = LServiceS, lserver = LServerS} =
 		State) ->
     From = xmpp:get_from(Packet),
-    case catch route_trusted(LServiceS, LServerS, From, Destinations,
+    try route_trusted(LServiceS, LServerS, From, Destinations,
                              Packet) of
-        {'EXIT', Reason} ->
-            ?ERROR_MSG("Error in route_trusted: ~p", [Reason]);
         _ -> ok
+    catch
+        _:Reason ->
+            ?ERROR_MSG("Error in route_trusted: ~p", [Reason])
     end,
     {noreply, State};
 handle_info({get_host, Pid}, State) ->

--- a/src/mod_offline.erl
+++ b/src/mod_offline.erl
@@ -413,7 +413,7 @@ handle_offline_fetch(#jid{luser = U, lserver = S} = JID) ->
 
 -spec fetch_msg_by_node(jid(), binary()) -> error | {ok, #offline_msg{}}.
 fetch_msg_by_node(To, Seq) ->
-    case catch binary_to_integer(Seq) of
+    try binary_to_integer(Seq) of
 	I when is_integer(I), I >= 0 ->
 	    LUser = To#jid.luser,
 	    LServer = To#jid.lserver,
@@ -421,11 +421,14 @@ fetch_msg_by_node(To, Seq) ->
 	    Mod:read_message(LUser, LServer, I);
 	_ ->
 	    error
+    catch
+        _:_ ->
+            error
     end.
 
 -spec remove_msg_by_node(jid(), binary()) -> boolean().
 remove_msg_by_node(To, Seq) ->
-    case catch binary_to_integer(Seq) of
+    try binary_to_integer(Seq) of
 	I when is_integer(I), I>= 0 ->
 	    LUser = To#jid.luser,
 	    LServer = To#jid.lserver,
@@ -435,6 +438,9 @@ remove_msg_by_node(To, Seq) ->
 	    true;
 	_ ->
 	    false
+    catch
+        _:_ ->
+            false
     end.
 
 -spec need_to_store(binary(), message()) -> boolean().

--- a/src/mod_offline_sql.erl
+++ b/src/mod_offline_sql.erl
@@ -234,7 +234,7 @@ remove_all_messages(LUser, LServer) ->
     {atomic, ok}.
 
 count_messages(LUser, LServer) ->
-    case catch ejabberd_sql:sql_query(
+    try ejabberd_sql:sql_query(
                  LServer,
                  ?SQL("select @(count(*))d from spool "
                       "where username=%(LUser)s and %(LServer)H")) of
@@ -244,6 +244,9 @@ count_messages(LUser, LServer) ->
 	    {cache, 0};
         _ ->
 	    {nocache, 0}
+    catch
+        _:_ ->
+            {nocache, 0}
     end.
 
 export(_Server) ->

--- a/src/mod_privacy.erl
+++ b/src/mod_privacy.erl
@@ -330,10 +330,7 @@ process_lists_set(#iq{from = #jid{luser = LUser, lserver = LServer},
     end;
 process_lists_set(#iq{from = #jid{luser = LUser, lserver = LServer} = From,
 		      lang = Lang} = IQ, Name, Items) ->
-    case catch lists:map(fun decode_item/1, Items) of
-	{error, Why} ->
-	    Txt = xmpp:io_format_error(Why),
-	    xmpp:make_error(IQ, xmpp:err_bad_request(Txt, Lang));
+    try lists:map(fun decode_item/1, Items) of
 	List ->
 	    case set_list(LUser, LServer, Name, List) of
 		ok ->
@@ -343,6 +340,10 @@ process_lists_set(#iq{from = #jid{luser = LUser, lserver = LServer} = From,
 		    Txt = ?T("Database failure"),
 		    xmpp:make_error(IQ, xmpp:err_internal_server_error(Txt, Lang))
 	    end
+    catch
+        throw:{error, Why} ->
+	    Txt = xmpp:io_format_error(Why),
+	    xmpp:make_error(IQ, xmpp:err_bad_request(Txt, Lang))
     end.
 
 -spec push_list_update(jid(), binary()) -> ok.

--- a/src/mod_privacy_sql.erl
+++ b/src/mod_privacy_sql.erl
@@ -241,12 +241,15 @@ remove_lists(LUser, LServer) ->
 
 export(Server) ->
     SqlType = ejabberd_option:sql_type(Server),
-    case catch ejabberd_sql:sql_query(jid:nameprep(Server),
+    try ejabberd_sql:sql_query(jid:nameprep(Server),
 				 [<<"select id from privacy_list order by "
 				    "id desc limit 1;">>]) of
         {selected, [<<"id">>], [[I]]} ->
             put(id, binary_to_integer(I));
         _ ->
+            put(id, 0)
+    catch
+        _:_ ->
             put(id, 0)
     end,
     [{privacy,

--- a/src/mod_privilege.erl
+++ b/src/mod_privilege.erl
@@ -404,9 +404,11 @@ process_presence_in(Acc) ->
 %%%===================================================================
 init([Host|_]) ->
     process_flag(trap_exit, true),
-    catch ets:new(?MODULE,
+    try ets:new(?MODULE,
                   [named_table, public,
-                   {heir, erlang:group_leader(), none}]),
+                   {heir, erlang:group_leader(), none}])
+    catch _:_ -> error
+    end,
     ejabberd_hooks:add(component_connected, ?MODULE,
                        component_connected, 50),
     ejabberd_hooks:add(component_disconnected, ?MODULE,

--- a/src/mod_proxy65_stream.erl
+++ b/src/mod_proxy65_stream.erl
@@ -101,8 +101,7 @@ accept(StreamPid) ->
 stop(StreamPid) -> StreamPid ! stop.
 
 activate({P1, J1}, {P2, J2}) ->
-    case catch {p1_fsm:sync_send_all_state_event(P1,
-						  get_socket),
+    try {p1_fsm:sync_send_all_state_event(P1, get_socket),
 		p1_fsm:sync_send_all_state_event(P2, get_socket)}
 	of
       {S1, S2} when is_port(S1), is_port(S2) ->
@@ -113,8 +112,9 @@ activate({P1, J1}, {P2, J2}) ->
 	  ?INFO_MSG("(~w:~w) Activated bytestream for ~ts "
 		    "-> ~ts",
 		    [P1, P2, JID1, JID2]),
-	  ok;
-      _ -> error
+	  ok
+    catch
+       _:_ -> error
     end.
 
 %%%-----------------------

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -3375,7 +3375,10 @@ node_options(Host, Type) ->
 -spec node_plugin_options(host(), binary()) -> [{atom(), any()}].
 node_plugin_options(Host, Type) ->
     Module = plugin(Host, Type),
-    case {lists:member(Type, config(Host, plugins)), catch Module:options()} of
+    Options = try Module:options()
+              catch _:_ -> error
+              end,
+    case {lists:member(Type, config(Host, plugins)), Options} of
 	{true, Opts} when is_list(Opts) ->
 	    Opts;
 	{_, _} ->
@@ -3716,9 +3719,11 @@ config(ServerHost, Key) ->
 config({_User, Host, _Resource}, Key, Default) ->
     config(Host, Key, Default);
 config(ServerHost, Key, Default) ->
-    case catch ets:lookup(gen_mod:get_module_proc(ServerHost, config), Key) of
+    try ets:lookup(gen_mod:get_module_proc(ServerHost, config), Key) of
 	[{Key, Value}] -> Value;
 	_ -> Default
+    catch
+        _:_ -> Default
     end.
 
 -spec select_type(binary(), host(), binary(), binary()) -> binary().

--- a/src/mod_pubsub.erl
+++ b/src/mod_pubsub.erl
@@ -3780,9 +3780,8 @@ features() ->
 -spec plugin_features(host(), binary()) -> [binary()].
 plugin_features(Host, Type) ->
     Module = plugin(Host, Type),
-    case catch Module:features() of
-	{'EXIT', {undef, _}} -> [];
-	Result -> Result
+    try Module:features()
+    catch error:undef -> []
     end.
 
 -spec features(binary(), binary()) -> [binary()].

--- a/src/mod_register_web.erl
+++ b/src/mod_register_web.erl
@@ -306,7 +306,7 @@ form_new_get2(Host, Lang, CaptchaEls) ->
 %%%----------------------------------------------------------------------
 
 form_new_post(Q, Ip) ->
-    case catch get_register_parameters(Q) of
+    try get_register_parameters(Q) of
       [Username, Host, Password, Password, Id, Key] ->
 	  form_new_post(Username, Host, Password, {Id, Key}, Ip);
       [_Username, _Host, _Password, _Password2, false, false] ->
@@ -315,6 +315,8 @@ form_new_post(Q, Ip) ->
 	  ejabberd_captcha:check_captcha(Id, Key),
 	  {error, passwords_not_identical};
       _ -> {error, wrong_parameters}
+    catch
+        _:_ -> {error, wrong_parameters}
     end.
 
 get_register_parameters(Q) ->
@@ -418,13 +420,15 @@ form_changepass_get(Host, Lang) ->
 %%%----------------------------------------------------------------------
 
 form_changepass_post(Q) ->
-    case catch get_changepass_parameters(Q) of
+    try get_changepass_parameters(Q) of
       [Username, Host, PasswordOld, Password, Password] ->
 	  try_change_password(Username, Host, PasswordOld,
 			      Password);
       [_Username, _Host, _PasswordOld, _Password, _Password2] ->
 	  {error, passwords_not_identical};
       _ -> {error, wrong_parameters}
+    catch
+        _:_ -> {error, wrong_parameters}
     end.
 
 get_changepass_parameters(Q) ->
@@ -548,23 +552,24 @@ register_account2(Username, Host, Password, Ip) ->
 %%%----------------------------------------------------------------------
 
 form_del_post(Q) ->
-    case catch get_unregister_parameters(Q) of
+    try get_unregister_parameters(Q) of
       [Username, Host, Password] ->
-	  try_unregister_account(Username, Host, Password);
-      _ -> {error, wrong_parameters}
+            try_unregister_account(Username, Host, Password)
+    catch
+        _:_ -> {error, wrong_parameters}
     end.
 
 get_unregister_parameters(Q) ->
-%% @spec(Username, Host, Password) -> {atomic, ok} |
-%%                                    {error, account_doesnt_exist} |
-%%                                    {error, account_exists} |
-%%                                    {error, password_incorrect}
     lists:map(fun (Key) ->
 		      {value, {_Key, Value}} = lists:keysearch(Key, 1, Q),
 		      Value
 	      end,
 	      [<<"username">>, <<"host">>, <<"password">>]).
 
+%% @spec(Username, Host, Password) -> {atomic, ok} |
+%%                                    {error, account_doesnt_exist} |
+%%                                    {error, account_exists} |
+%%                                    {error, password_incorrect}
 try_unregister_account(Username, Host, Password) ->
     try unregister_account(Username, Host, Password) of
       {atomic, ok} -> {atomic, ok}

--- a/src/mod_roster_mnesia.erl
+++ b/src/mod_roster_mnesia.erl
@@ -253,13 +253,16 @@ print_progress_line({Pr, NT, NV, ND}) ->
     Pr2.
 
 decide_rip(Key, {_Action, Subs, Asks, User, Contact}) ->
-    case catch mnesia:dirty_read(roster, Key) of
+    try mnesia:dirty_read(roster, Key) of
         [RI] ->
             lists:member(RI#roster.subscription, Subs)
                 andalso lists:member(RI#roster.ask, Asks)
                 andalso decide_rip_jid(RI#roster.us, User)
                 andalso decide_rip_jid(RI#roster.jid, Contact);
         _ ->
+            false
+    catch
+        _:_ ->
             false
     end.
 

--- a/src/mod_shared_roster_ldap.erl
+++ b/src/mod_shared_roster_ldap.erl
@@ -356,13 +356,17 @@ search_group_info(State, Group) ->
     Extractor = case State#state.uid_format_re of
 		  undefined ->
 		      fun (UID) ->
-			      catch eldap_utils:get_user_part(UID,
+			      try eldap_utils:get_user_part(UID,
 							      State#state.uid_format)
+                              catch _:_ -> error
+                              end
 		      end;
 		  _ ->
 		      fun (UID) ->
-			      catch get_user_part_re(UID,
+			      try get_user_part_re(UID,
 						     State#state.uid_format_re)
+                              catch _:_ -> error
+                              end
 		      end
 		end,
     AuthChecker = case State#state.auth_check of
@@ -451,12 +455,14 @@ search_user_name(State, User) ->
 
 %% Getting User ID part by regex pattern
 get_user_part_re(String, Pattern) ->
-    case catch re:run(String, Pattern) of
+    try re:run(String, Pattern) of
       {match, Captured} ->
 	  {First, Len} = lists:nth(2, Captured),
 	  Result = str:sub_string(String, First + 1, First + Len),
 	  {ok, Result};
       _ -> {error, badmatch}
+    catch
+       _:_ -> {error, badmatch}
     end.
 
 parse_options(Host, Opts) ->

--- a/src/mod_shared_roster_mnesia.erl
+++ b/src/mod_shared_roster_mnesia.erl
@@ -86,9 +86,10 @@ delete_group(Host, Group) ->
     mnesia:transaction(F).
 
 get_group_opts(Host, Group) ->
-    case catch mnesia:dirty_read(sr_group, {Group, Host}) of
-	[#sr_group{opts = Opts}] -> {ok, Opts};
-	_ -> error
+    try mnesia:dirty_read(sr_group, {Group, Host}) of
+	[#sr_group{opts = Opts}] -> {ok, Opts}
+    catch
+       _:_ -> error
     end.
 
 set_group_opts(Host, Group, Opts) ->
@@ -97,29 +98,30 @@ set_group_opts(Host, Group, Opts) ->
     mnesia:transaction(F).
 
 get_user_groups(US, Host) ->
-    case catch mnesia:dirty_read(sr_user, US) of
+    try mnesia:dirty_read(sr_user, US) of
 	Rs when is_list(Rs) ->
-	    [Group || #sr_user{group_host = {Group, H}} <- Rs, H == Host];
-	_ ->
-	    []
+	    [Group || #sr_user{group_host = {Group, H}} <- Rs, H == Host]
+    catch
+        _:_ ->
+            []
     end.
 
 get_group_explicit_users(Host, Group) ->
-    Read = (catch mnesia:dirty_index_read(sr_user,
-					  {Group, Host}, #sr_user.group_host)),
-    case Read of
-	Rs when is_list(Rs) -> [R#sr_user.us || R <- Rs];
-	_ -> []
+    try mnesia:dirty_index_read(sr_user, {Group, Host}, #sr_user.group_host) of
+        Rs when is_list(Rs) -> [R#sr_user.us || R <- Rs]
+    catch
+        _:_ -> []
     end.
 
 get_user_displayed_groups(LUser, LServer, GroupsOpts) ->
-    case catch mnesia:dirty_read(sr_user, {LUser, LServer}) of
+    try mnesia:dirty_read(sr_user, {LUser, LServer}) of
 	Rs when is_list(Rs) ->
 	    [{Group, proplists:get_value(Group, GroupsOpts, [])}
 	     || #sr_user{group_host = {Group, H}} <- Rs,
-		H == LServer];
-	_ ->
-	    []
+		H == LServer]
+    catch
+        _:_ ->
+            []
     end.
 
 is_user_in_group(US, Group, Host) ->

--- a/src/mod_shared_roster_sql.erl
+++ b/src/mod_shared_roster_sql.erl
@@ -121,13 +121,14 @@ delete_group(Host, Group) ->
     end.
 
 get_group_opts(Host, Group) ->
-    case catch ejabberd_sql:sql_query(
+    try ejabberd_sql:sql_query(
 		 Host,
 		 ?SQL("select @(opts)s from sr_group"
                       " where name=%(Group)s and %(Host)H")) of
 	{selected, [{SOpts}]} ->
             {ok, mod_shared_roster:opts_to_binary(ejabberd_sql:decode_term(SOpts))};
 	_ -> error
+    catch _:_ -> error
     end.
 
 set_group_opts(Host, Group, Opts) ->
@@ -143,16 +144,17 @@ set_group_opts(Host, Group, Opts) ->
 
 get_user_groups(US, Host) ->
     SJID = make_jid_s(US),
-    case catch ejabberd_sql:sql_query(
+    try ejabberd_sql:sql_query(
 		 Host,
 		 ?SQL("select @(grp)s from sr_user"
                       " where jid=%(SJID)s and %(Host)H")) of
 	{selected, Rs} -> [G || {G} <- Rs];
 	_ -> []
+    catch _:_ -> []
     end.
 
 get_group_explicit_users(Host, Group) ->
-    case catch ejabberd_sql:sql_query(
+    try ejabberd_sql:sql_query(
 		 Host,
 		 ?SQL("select @(jid)s from sr_user"
                       " where grp=%(Group)s and %(Host)H")) of
@@ -164,11 +166,12 @@ get_group_explicit_users(Host, Group) ->
 	      end, Rs);
 	_ ->
 	    []
+    catch _:_ -> []
     end.
 
 get_user_displayed_groups(LUser, LServer, GroupsOpts) ->
     SJID = make_jid_s(LUser, LServer),
-    case catch ejabberd_sql:sql_query(
+    try ejabberd_sql:sql_query(
 		 LServer,
 		 ?SQL("select @(grp)s from sr_user"
                       " where jid=%(SJID)s and %(LServer)H")) of
@@ -176,16 +179,18 @@ get_user_displayed_groups(LUser, LServer, GroupsOpts) ->
 	    [{Group, proplists:get_value(Group, GroupsOpts, [])}
 	     || {Group} <- Rs];
 	_ -> []
+    catch _:_ -> []
     end.
 
 is_user_in_group(US, Group, Host) ->
     SJID = make_jid_s(US),
-    case catch ejabberd_sql:sql_query(
+    try ejabberd_sql:sql_query(
                  Host,
                  ?SQL("select @(jid)s from sr_user where jid=%(SJID)s"
                       " and %(Host)H and grp=%(Group)s")) of
 	{selected, []} -> false;
 	_ -> true
+    catch _:_ -> []
     end.
 
 add_user_to_group(Host, US, Group) ->

--- a/src/mod_sip_registrar.erl
+++ b/src/mod_sip_registrar.erl
@@ -357,21 +357,23 @@ min_expires() ->
     60.
 
 to_integer(Bin, Min, Max) ->
-    case catch (binary_to_integer(Bin)) of
+    try (binary_to_integer(Bin)) of
         N when N >= Min, N =< Max ->
             {ok, N};
         _ ->
             error
+    catch
+        _:_ ->
+            error
     end.
 
 call(Msg) ->
-    case catch ?GEN_SERVER:call(?MODULE, Msg, ?CALL_TIMEOUT) of
-	{'EXIT', {timeout, _}} ->
-	    {error, timeout};
-	{'EXIT', Why} ->
-	    {error, Why};
-	Reply ->
-	    Reply
+    try ?GEN_SERVER:call(?MODULE, Msg, ?CALL_TIMEOUT)
+    catch
+        _:{timeout, _} ->
+            {error, timeout};
+        _:Why ->
+            {error, Why}
     end.
 
 make_contacts_with_expires(Contacts, Expires) ->
@@ -501,12 +503,13 @@ get_flow_timeout(LServer, #sip_socket{type = Type}) ->
 
 update_table() ->
     Fields = record_info(fields, sip_session),
-    case catch mnesia:table_info(sip_session, attributes) of
+    try mnesia:table_info(sip_session, attributes) of
 	Fields ->
 	    ok;
 	[_|_] ->
-	    mnesia:delete_table(sip_session);
-	{'EXIT', _} ->
+	    mnesia:delete_table(sip_session)
+    catch
+        _:_ ->
 	    ok
     end.
 
@@ -551,7 +554,9 @@ delete_session(#sip_session{reg_tref = RegTRef,
 			    conn_mref = MRef} = Session) ->
     misc:cancel_timer(RegTRef),
     misc:cancel_timer(FlowTRef),
-    catch erlang:demonitor(MRef, [flush]),
+    try erlang:demonitor(MRef, [flush])
+    catch _:_ -> error
+    end,
     mnesia:dirty_delete_object(Session).
 
 process_ping(SIPSocket) ->

--- a/src/mod_stats.erl
+++ b/src/mod_stats.erl
@@ -108,23 +108,23 @@ get_local_stats(_Server, _, _, Lang) ->
 
 get_local_stat(Server, [], Name)
     when Name == <<"users/online">> ->
-    case catch ejabberd_sm:get_vh_session_list(Server) of
-      {'EXIT', _Reason} ->
-	  ?STATERR(500, <<"Internal Server Error">>);
+    try ejabberd_sm:get_vh_session_list(Server) of
       Users ->
 	  ?STATVAL((integer_to_binary(length(Users))),
 		   <<"users">>)
+    catch
+        _:_Reason ->
+            ?STATERR(500, <<"Internal Server Error">>)
     end;
 get_local_stat(Server, [], Name)
     when Name == <<"users/total">> ->
-    case catch
-	   ejabberd_auth:count_users(Server)
-	of
-      {'EXIT', _Reason} ->
-	  ?STATERR(500, <<"Internal Server Error">>);
+    try ejabberd_auth:count_users(Server) of
       NUsers ->
 	  ?STATVAL((integer_to_binary(NUsers)),
 		   <<"users">>)
+    catch
+       _:_Reason ->
+            ?STATERR(500, <<"Internal Server Error">>)
     end;
 get_local_stat(_Server, [], Name)
     when Name == <<"users/all-hosts/online">> ->

--- a/src/mod_stats.erl
+++ b/src/mod_stats.erl
@@ -144,79 +144,73 @@ get_local_stat(_Server, _, Name) ->
 
 get_node_stat(Node, Name)
     when Name == <<"time/uptime">> ->
-    case catch ejabberd_cluster:call(Node, erlang, statistics,
-			[wall_clock])
-	of
-      {badrpc, _Reason} ->
-	  ?STATERR(500, <<"Internal Server Error">>);
+    try ejabberd_cluster:call(Node, erlang, statistics, [wall_clock]) of
       CPUTime ->
 	    ?STATVAL(str:format("~.3f",	[element(1, CPUTime) / 1000]),
 		   <<"seconds">>)
+    catch
+        badrpc:_Reason ->
+            ?STATERR(500, <<"Internal Server Error">>)
     end;
 get_node_stat(Node, Name)
     when Name == <<"time/cputime">> ->
-    case catch ejabberd_cluster:call(Node, erlang, statistics, [runtime])
-	of
-      {badrpc, _Reason} ->
-	  ?STATERR(500, <<"Internal Server Error">>);
+    try ejabberd_cluster:call(Node, erlang, statistics, [runtime]) of
       RunTime ->
 	  ?STATVAL(str:format("~.3f", [element(1, RunTime) / 1000]),
 		   <<"seconds">>)
+    catch
+        badrpc:_Reason ->
+	  ?STATERR(500, <<"Internal Server Error">>)
     end;
 get_node_stat(Node, Name)
     when Name == <<"users/online">> ->
-    case catch ejabberd_cluster:call(Node, ejabberd_sm,
-			dirty_get_my_sessions_list, [])
-	of
-      {badrpc, _Reason} ->
-	  ?STATERR(500, <<"Internal Server Error">>);
+    try ejabberd_cluster:call(Node, ejabberd_sm, dirty_get_my_sessions_list, []) of
       Users ->
 	  ?STATVAL((integer_to_binary(length(Users))),
 		   <<"users">>)
+    catch
+        badrpc:_Reason ->
+            ?STATERR(500, <<"Internal Server Error">>)
     end;
 get_node_stat(Node, Name)
     when Name == <<"transactions/committed">> ->
-    case catch ejabberd_cluster:call(Node, mnesia, system_info,
-			[transaction_commits])
-	of
-      {badrpc, _Reason} ->
-	  ?STATERR(500, <<"Internal Server Error">>);
+    try ejabberd_cluster:call(Node, mnesia, system_info, [transaction_commits]) of
       Transactions ->
 	  ?STATVAL((integer_to_binary(Transactions)),
 		   <<"transactions">>)
+    catch
+        badrpc:_Reason ->
+            ?STATERR(500, <<"Internal Server Error">>)
     end;
 get_node_stat(Node, Name)
     when Name == <<"transactions/aborted">> ->
-    case catch ejabberd_cluster:call(Node, mnesia, system_info,
-			[transaction_failures])
-	of
-      {badrpc, _Reason} ->
-	  ?STATERR(500, <<"Internal Server Error">>);
+    try ejabberd_cluster:call(Node, mnesia, system_info, [transaction_failures]) of
       Transactions ->
 	  ?STATVAL((integer_to_binary(Transactions)),
 		   <<"transactions">>)
+    catch
+        badrpc:_Reason ->
+            ?STATERR(500, <<"Internal Server Error">>)
     end;
 get_node_stat(Node, Name)
     when Name == <<"transactions/restarted">> ->
-    case catch ejabberd_cluster:call(Node, mnesia, system_info,
-			[transaction_restarts])
-	of
-      {badrpc, _Reason} ->
-	  ?STATERR(500, <<"Internal Server Error">>);
+    try ejabberd_cluster:call(Node, mnesia, system_info, [transaction_restarts]) of
       Transactions ->
 	  ?STATVAL((integer_to_binary(Transactions)),
 		   <<"transactions">>)
+    catch
+        badrpc:_Reason ->
+            ?STATERR(500, <<"Internal Server Error">>)
     end;
 get_node_stat(Node, Name)
     when Name == <<"transactions/logged">> ->
-    case catch ejabberd_cluster:call(Node, mnesia, system_info,
-			[transaction_log_writes])
-	of
-      {badrpc, _Reason} ->
-	  ?STATERR(500, <<"Internal Server Error">>);
+    try ejabberd_cluster:call(Node, mnesia, system_info, [transaction_log_writes]) of
       Transactions ->
 	  ?STATVAL((integer_to_binary(Transactions)),
 		   <<"transactions">>)
+    catch
+        badrpc:_Reason ->
+	  ?STATERR(500, <<"Internal Server Error">>)
     end;
 get_node_stat(_, Name) ->
     ?STATERR(404, <<"Not Found">>).

--- a/src/mod_vcard_mnesia.erl
+++ b/src/mod_vcard_mnesia.erl
@@ -80,10 +80,8 @@ search(LServer, Data, AllowReturnAll, MaxMatch) ->
        not AllowReturnAll ->
 	    [];
        true ->
-	    case catch mnesia:dirty_select(vcard_search,
+	    try mnesia:dirty_select(vcard_search,
 					   [{MatchSpec, [], ['$_']}]) of
-		{'EXIT', Reason} ->
-		    ?ERROR_MSG("~p", [Reason]), [];
 		Rs ->
 		    Fields = lists:map(fun record_to_item/1, Rs),
 		    case MaxMatch of
@@ -92,6 +90,10 @@ search(LServer, Data, AllowReturnAll, MaxMatch) ->
 			Val ->
 			    lists:sublist(Fields, Val)
 		    end
+            catch
+               _:Reason ->
+                    ?ERROR_MSG("~p", [Reason]),
+                    []
 	    end
     end.
 

--- a/src/mod_vcard_sql.erl
+++ b/src/mod_vcard_sql.erl
@@ -205,7 +205,7 @@ search(LServer, Data, AllowReturnAll, MaxMatch) ->
 			Val ->
 			    [<<" LIMIT ">>, integer_to_binary(Val)]
 		    end,
-	   case catch ejabberd_sql:sql_query(
+	   try ejabberd_sql:sql_query(
 			LServer,
 			[<<"select username, fn, family, given, "
 			   "middle,        nickname, bday, ctry, "
@@ -220,6 +220,10 @@ search(LServer, Data, AllowReturnAll, MaxMatch) ->
 		   [row_to_item(LServer, R) || R <- Rs];
 	       Error ->
 		   ?ERROR_MSG("~p", [Error]), []
+           catch
+               _:Error ->
+                   ?ERROR_MSG("~p", [Error]),
+                   []
 	   end
     end.
 

--- a/src/node_flat.erl
+++ b/src/node_flat.erl
@@ -724,18 +724,21 @@ get_nodes_helper(NodeTree, #pubsub_state{stateid = {_, N}, subscriptions = Subs}
 %% ```get_states(Nidx) ->
 %%           node_default:get_states(Nidx).'''</p>
 get_states(Nidx) ->
-    States = case catch mnesia:index_read(pubsub_state, Nidx, #pubsub_state.nodeidx) of
-	List when is_list(List) -> List;
-	_ -> []
+    States = try mnesia:index_read(pubsub_state, Nidx, #pubsub_state.nodeidx) of
+                 List when is_list(List) -> List
+             catch
+                 _:_ -> []
     end,
     {result, States}.
 
 %% @doc <p>Returns a state (one state list), given its reference.</p>
 get_state(Nidx, Key) ->
     StateId = {Key, Nidx},
-    case catch mnesia:read({pubsub_state, StateId}) of
+    try mnesia:read({pubsub_state, StateId}) of
 	[State] when is_record(State, pubsub_state) -> State;
 	_ -> #pubsub_state{stateid = StateId, nodeidx = Nidx}
+    catch
+       _:_ -> #pubsub_state{stateid = StateId, nodeidx = Nidx}
     end.
 
 %% @doc <p>Write a state into database.</p>

--- a/src/node_flat_sql.erl
+++ b/src/node_flat_sql.erl
@@ -658,9 +658,12 @@ set_state(Nidx, State) ->
 
 del_state(Nidx, JID) ->
     J = encode_jid(JID),
-    catch ejabberd_sql:sql_query_t(
+    try ejabberd_sql:sql_query_t(
             ?SQL("delete from pubsub_state"
-                 " where jid=%(J)s and nodeid=%(Nidx)d")),
+                 " where jid=%(J)s and nodeid=%(Nidx)d"))
+    catch
+        _:_ -> error
+    end,
     ok.
 
 get_items(Nidx, _From, undefined) ->
@@ -676,11 +679,13 @@ get_items(Nidx, _From, undefined) ->
     end;
 get_items(Nidx, _From, #rsm_set{max = Max, index = IncIndex,
 				'after' = After, before = Before}) ->
-    Count = case catch ejabberd_sql:sql_query_t(
+    Count = try ejabberd_sql:sql_query_t(
 		    ?SQL("select @(count(itemid))d from pubsub_item"
 		         " where nodeid=%(Nidx)d")) of
 		{selected, [{C}]} -> C;
 		_ -> 0
+            catch
+                _:_ -> 0
 	    end,
     Offset = case {IncIndex, Before, After} of
 		{I, undefined, undefined} when is_integer(I) -> I;
@@ -763,11 +768,14 @@ get_last_items(Nidx, _From, Limit) ->
 			 "' order by modification desc ",
 			 " limit ", (integer_to_binary(Limit))/binary>>])
 	    end,
-    case catch ejabberd_sql:sql_query_t(Query) of
+    try ejabberd_sql:sql_query_t(Query) of
 	{selected, [<<"itemid">>, <<"publisher">>, <<"creation">>,
 		    <<"modification">>, <<"payload">>], RItems} ->
 	    {result, [raw_to_item(Nidx, RItem) || RItem <- RItems]};
 	_ ->
+	    {result, []}
+    catch
+        _:_ ->
 	    {result, []}
     end.
 
@@ -782,16 +790,19 @@ get_only_item(Nidx, _From) ->
 		       [<<"select itemid, publisher, creation, modification, payload",
 			  " from pubsub_item where nodeid='", SNidx/binary, "'">>])
 	    end,
-    case catch ejabberd_sql:sql_query_t(Query) of
+    try ejabberd_sql:sql_query_t(Query) of
 	{selected, [<<"itemid">>, <<"publisher">>, <<"creation">>,
 		    <<"modification">>, <<"payload">>], RItems} ->
 	    {result, [raw_to_item(Nidx, RItem) || RItem <- RItems]};
 	_ ->
 	    {result, []}
+    catch
+       _:_ ->
+            {result, []}
     end.
 
 get_item(Nidx, ItemId) ->
-    case catch ejabberd_sql:sql_query_t(
+    try ejabberd_sql:sql_query_t(
 		 ?SQL("select @(itemid)s, @(publisher)s, @(creation)s,"
 		      " @(modification)s, @(payload)s from pubsub_item"
 		      " where nodeid=%(Nidx)d and itemid=%(ItemId)s"))
@@ -799,8 +810,9 @@ get_item(Nidx, ItemId) ->
 	{selected, [RItem]} ->
 	    {result, raw_to_item(Nidx, RItem)};
 	{selected, []} ->
-	    {error, xmpp:err_item_not_found()};
-	{'EXIT', _} ->
+	    {error, xmpp:err_item_not_found()}
+    catch
+        _:_ ->
 	    {error, xmpp:err_internal_server_error(?T("Database failure"), ejabberd_option:language())}
     end.
 
@@ -858,9 +870,11 @@ set_item(Item) ->
     ok.
 
 del_item(Nidx, ItemId) ->
-    catch ejabberd_sql:sql_query_t(
+    try ejabberd_sql:sql_query_t(
             ?SQL("delete from pubsub_item where itemid=%(ItemId)s"
-                 " and nodeid=%(Nidx)d")).
+                 " and nodeid=%(Nidx)d"))
+    catch _:_ -> error
+    end.
 
 del_items(_, []) ->
     ok;
@@ -869,9 +883,11 @@ del_items(Nidx, [ItemId]) ->
 del_items(Nidx, ItemIds) ->
     I = str:join([ejabberd_sql:to_string_literal_t(X) || X <- ItemIds], <<",">>),
     SNidx = misc:i2l(Nidx),
-    catch
+    try
     ejabberd_sql:sql_query_t([<<"delete from pubsub_item where itemid in (">>,
-	    I, <<") and nodeid='">>, SNidx, <<"';">>]).
+	    I, <<") and nodeid='">>, SNidx, <<"';">>])
+    catch _:_ -> error
+    end.
 
 get_item_name(_Host, _Node, Id) ->
     {result, Id}.
@@ -892,7 +908,7 @@ first_in_list(Pred, [H | T]) ->
     end.
 
 itemids(Nidx) ->
-    case catch
+    try
 	ejabberd_sql:sql_query_t(
 	  ?SQL("select @(itemid)s from pubsub_item where "
 	       "nodeid=%(Nidx)d order by modification desc"))
@@ -901,12 +917,15 @@ itemids(Nidx) ->
 	    [ItemId || {ItemId} <- RItems];
 	_ ->
 	    []
+    catch
+        _:_ ->
+            []
     end.
 
 itemids(Nidx, {_U, _S, _R} = JID) ->
     SJID = encode_jid(JID),
     SJIDLike = <<(encode_jid_like(JID))/binary, "/%">>,
-    case catch
+    try
 	ejabberd_sql:sql_query_t(
           ?SQL("select @(itemid)s from pubsub_item where "
                "nodeid=%(Nidx)d and (publisher=%(SJID)s"
@@ -917,11 +936,14 @@ itemids(Nidx, {_U, _S, _R} = JID) ->
 	    [ItemId || {ItemId} <- RItems];
 	_ ->
 	    []
+    catch
+        _:_ ->
+            []
     end.
 
 select_affiliation_subscriptions(Nidx, JID) ->
     J = encode_jid(JID),
-    case catch
+    try
 	ejabberd_sql:sql_query_t(
           ?SQL("select @(affiliation)s, @(subscriptions)s from "
                " pubsub_state where nodeid=%(Nidx)d and jid=%(J)s"))
@@ -930,6 +952,9 @@ select_affiliation_subscriptions(Nidx, JID) ->
 	    {decode_affiliation(A), decode_subscriptions(S)};
 	_ ->
 	    {none, []}
+    catch
+        _:_ ->
+            {none, []}
     end.
 
 select_affiliation_subscriptions(Nidx, JID, JID) ->
@@ -937,7 +962,7 @@ select_affiliation_subscriptions(Nidx, JID, JID) ->
 select_affiliation_subscriptions(Nidx, GenKey, SubKey) ->
     GJ = encode_jid(GenKey),
     SJ = encode_jid(SubKey),
-    case catch ejabberd_sql:sql_query_t(
+    try ejabberd_sql:sql_query_t(
 	?SQL("select @(jid)s, @(affiliation)s, @(subscriptions)s from "
 	     " pubsub_state where nodeid=%(Nidx)d and jid in (%(GJ)s, %(SJ)s)"))
     of
@@ -950,6 +975,9 @@ select_affiliation_subscriptions(Nidx, GenKey, SubKey) ->
 		end, {none, []}, Res);
 	_ ->
 	    {none, []}
+    catch
+        _:_ ->
+            {none, []}
     end.
 
 update_affiliation(Nidx, JID, Affiliation) ->

--- a/src/nodetree_tree.erl
+++ b/src/nodetree_tree.erl
@@ -111,17 +111,20 @@ get_all_nodes(Host) ->
     [fixup_node(N) || N <- Nodes].
 
 get_parentnodes(Host, Node, _From) ->
-    case catch mnesia:read({pubsub_node, {Host, Node}}) of
+    try mnesia:read({pubsub_node, {Host, Node}}) of
 	[Record] when is_record(Record, pubsub_node) ->
 	    Record#pubsub_node.parents;
 	_ ->
 	    []
+    catch
+       _:_ ->
+            []
     end.
 
 get_parentnodes_tree(Host, Node, _From) ->
     get_parentnodes_tree(Host, Node, 0, []).
 get_parentnodes_tree(Host, Node, Level, Acc) ->
-    case catch mnesia:read({pubsub_node, {Host, Node}}) of
+    try mnesia:read({pubsub_node, {Host, Node}}) of
 	[#pubsub_node{} = Record0] ->
 	    Record = fixup_node(Record0),
 	    Tree = [{Level, [Record]}|Acc],
@@ -131,6 +134,9 @@ get_parentnodes_tree(Host, Node, Level, Acc) ->
 	    end;
 	_ ->
 	    Acc
+    catch
+       _:_ ->
+            []
     end.
 
 get_subnodes(Host, <<>>, infinity) ->
@@ -209,13 +215,16 @@ create_node(Host, Node, Type, Owner, Options, Parents) ->
 			[] ->
 			    true;
 			[Parent | _] ->
-			    case catch mnesia:read({pubsub_node, {Host, Parent}}) of
+			    try mnesia:read({pubsub_node, {Host, Parent}}) of
 				[#pubsub_node{owners = [{<<>>, Host, <<>>}]}] ->
 				    true;
 				[#pubsub_node{owners = Owners}] ->
 				    lists:member(BJID, Owners);
 				_ ->
 				    false
+                            catch
+                                _:_ ->
+                                    false
 			    end;
 			_ ->
 			    false

--- a/src/nodetree_tree_sql.erl
+++ b/src/nodetree_tree_sql.erl
@@ -142,17 +142,18 @@ get_node(Host, Node) ->
     end.
 
 get_node(Nidx) ->
-    case catch
+    try
 	ejabberd_sql:sql_query_t(
 	  ?SQL("select @(host)s, @(node)s, @(parent)s, @(plugin)s from pubsub_node "
 	       "where nodeid=%(Nidx)d"))
     of
 	{selected, [{Host, Node, Parent, Type}]} ->
 	    raw_to_node(Host, {Node, Parent, Type, Nidx});
-	{'EXIT', _Reason} ->
-	    {error, xmpp:err_internal_server_error(?T("Database failure"), ejabberd_option:language())};
 	_ ->
 	    {error, xmpp:err_item_not_found(?T("Node not found"), ejabberd_option:language())}
+    catch
+        exit:_Reason ->
+            {error, xmpp:err_internal_server_error(?T("Database failure"), ejabberd_option:language())}
     end.
 
 get_nodes(Host) ->

--- a/src/nodetree_tree_sql.erl
+++ b/src/nodetree_tree_sql.erl
@@ -71,22 +71,28 @@ set_node(Record) when is_record(Record, pubsub_node) ->
     H = node_flat_sql:encode_host(Host),
     Nidx = case nodeidx(Host, Node) of
 	{result, OldNidx} ->
-	    catch
+	    try
 	    ejabberd_sql:sql_query_t(
 	      ?SQL("delete from pubsub_node_option "
-		   "where nodeid=%(OldNidx)d")),
-	    catch
+		   "where nodeid=%(OldNidx)d"))
+            catch _:_ -> error
+            end,
+	    try
 	    ejabberd_sql:sql_query_t(
 	      ?SQL("update pubsub_node set"
 		   " host=%(H)s, node=%(Node)s,"
 		   " parent=%(Parent)s, plugin=%(Type)s "
-		   "where nodeid=%(OldNidx)d")),
+		   "where nodeid=%(OldNidx)d"))
+            catch _:_ -> error
+            end,
 	    OldNidx;
 	{error, not_found} ->
-	    catch
+	    try
 	    ejabberd_sql:sql_query_t(
 	      ?SQL("insert into pubsub_node(host, node, parent, plugin) "
-		   "values(%(H)s, %(Node)s, %(Parent)s, %(Type)s)")),
+		   "values(%(H)s, %(Node)s, %(Parent)s, %(Type)s)"))
+            catch _:_ -> error
+            end,
 	    case nodeidx(Host, Node) of
 		{result, NewNidx} -> NewNidx;
 		{error, not_found} -> none;  % this should not happen
@@ -105,10 +111,12 @@ set_node(Record) when is_record(Record, pubsub_node) ->
 	    lists:foreach(fun ({Key, Value}) ->
 			SKey = iolist_to_binary(atom_to_list(Key)),
 			SValue = misc:term_to_expr(Value),
-			catch
+			try
 			ejabberd_sql:sql_query_t(
 			  ?SQL("insert into pubsub_node_option(nodeid, name, val) "
 			       "values (%(Nidx)d, %(SKey)s, %(SValue)s)"))
+                        catch _:_ -> error
+                        end
 		end,
 		Record#pubsub_node.options),
 	    {result, Nidx}
@@ -119,17 +127,18 @@ get_node(Host, Node, _From) ->
 
 get_node(Host, Node) ->
     H = node_flat_sql:encode_host(Host),
-    case catch
+    try
 	ejabberd_sql:sql_query_t(
 	  ?SQL("select @(node)s, @(parent)s, @(plugin)s, @(nodeid)d from pubsub_node "
 	       "where host=%(H)s and node=%(Node)s"))
     of
 	{selected, [RItem]} ->
 	    raw_to_node(Host, RItem);
-	{'EXIT', _Reason} ->
-	    {error, xmpp:err_internal_server_error(?T("Database failure"), ejabberd_option:language())};
 	_ ->
 	    {error, xmpp:err_item_not_found(?T("Node not found"), ejabberd_option:language())}
+    catch
+        _:_Reason ->
+	    {error, xmpp:err_internal_server_error(?T("Database failure"), ejabberd_option:language())}
     end.
 
 get_node(Nidx) ->
@@ -255,16 +264,15 @@ get_subnodes_tree(Host, Node) ->
 	    Type = Rec#pubsub_node.type,
 	    H = node_flat_sql:encode_host(Host),
 	    N = <<(ejabberd_sql:escape_like_arg(Node))/binary, "/%">>,
-	    Sub = case catch
+	    Sub = try
 		ejabberd_sql:sql_query_t(
 		?SQL("select @(node)s, @(parent)s, @(plugin)s, @(nodeid)d from pubsub_node "
 		     "where host=%(H)s and plugin=%(Type)s and"
 		     " (parent=%(Node)s or parent like %(N)s %ESCAPE)"))
 	    of
 		{selected, RItems} ->
-		    [raw_to_node(Host, Item) || Item <- RItems];
-		_ ->
-		    []
+		    [raw_to_node(Host, Item) || Item <- RItems]
+                  catch _:_ -> []
 	    end,
 	    [Rec|Sub]
     end.
@@ -318,8 +326,10 @@ delete_node(Host, Node) ->
     lists:map(
 	fun(Rec) ->
 	    Nidx = Rec#pubsub_node.id,
-	    catch ejabberd_sql:sql_query_t(
-		    ?SQL("delete from pubsub_node where nodeid=%(Nidx)d")),
+	    try ejabberd_sql:sql_query_t(
+		    ?SQL("delete from pubsub_node where nodeid=%(Nidx)d"))
+            catch _:_ -> error
+            end,
 	    Rec
 	end, get_subnodes_tree(Host, Node)).
 
@@ -327,7 +337,7 @@ delete_node(Host, Node) ->
 raw_to_node(Host, [Node, Parent, Type, Nidx]) ->
     raw_to_node(Host, {Node, Parent, Type, binary_to_integer(Nidx)});
 raw_to_node(Host, {Node, Parent, Type, Nidx}) ->
-    Options = case catch
+    Options = try
 	ejabberd_sql:sql_query_t(
 	  ?SQL("select @(name)s, @(val)s from pubsub_node_option "
 	       "where nodeid=%(Nidx)d"))
@@ -348,9 +358,10 @@ raw_to_node(Host, {Node, Parent, Type, Nidx}) ->
 	    lists:foldl(fun ({Key, Value}, Acc) ->
 			lists:keystore(Key, 1, Acc, {Key, Value})
 		end,
-		StdOpts, DbOpts);
-	_ ->
-	    []
+		StdOpts, DbOpts)
+    catch
+        _:_ ->
+            []
     end,
     Parents = case Parent of
 	<<>> -> [];
@@ -361,17 +372,18 @@ raw_to_node(Host, {Node, Parent, Type, Nidx}) ->
 
 nodeidx(Host, Node) ->
     H = node_flat_sql:encode_host(Host),
-    case catch
+    try
 	ejabberd_sql:sql_query_t(
 	  ?SQL("select @(nodeid)d from pubsub_node "
 	       "where host=%(H)s and node=%(Node)s"))
     of
 	{selected, [{Nidx}]} ->
 	    {result, Nidx};
-	{'EXIT', _Reason} ->
-	    {error, db_fail};
 	_ ->
 	    {error, not_found}
+    catch
+        _:_Reason ->
+            {error, db_fail}
     end.
 
 nodeowners(Nidx) ->

--- a/src/pubsub_migrate.erl
+++ b/src/pubsub_migrate.erl
@@ -37,7 +37,7 @@ update_item_database(_Host, _ServerHost) ->
 update_node_database(Host, ServerHost) ->
     mnesia:del_table_index(pubsub_node, type),
     mnesia:del_table_index(pubsub_node, parentid),
-    case catch mnesia:table_info(pubsub_node, attributes) of
+    try mnesia:table_info(pubsub_node, attributes) of
       [host_node, host_parent, info] ->
 	    ?INFO_MSG("Upgrading pubsub nodes table...", []),
 	  F = fun () ->
@@ -287,6 +287,8 @@ update_node_database(Host, ServerHost) ->
 				 [nodeid, id, parents, type, owners, options]),
 	  rename_default_nodeplugin();
       _ -> ok
+    catch
+        _:_ -> error
     end,
     convert_list_nodes().
 
@@ -452,7 +454,8 @@ convert_table_to_binary(Tab, Fields, Type, DetectFun, ConvertFun) ->
         true ->
             ?INFO_MSG("Converting '~ts' table from strings to binaries.", [Tab]),
             TmpTab = list_to_atom(atom_to_list(Tab) ++ "_tmp_table"),
-            catch mnesia:delete_table(TmpTab),
+            try mnesia:delete_table(TmpTab)
+            catch _:_ -> error end,
             case ejabberd_mnesia:create(?MODULE, TmpTab,
                                      [{disc_only_copies, [node()]},
                                       {type, Type},

--- a/src/pubsub_subscription.erl
+++ b/src/pubsub_subscription.erl
@@ -76,35 +76,39 @@
 init(_Host, _ServerHost, _Opts) -> ok = create_table().
 
 subscribe_node(JID, NodeId, Options) ->
-    case catch mnesia:sync_dirty(fun add_subscription/3, [JID, NodeId, Options])
+    try mnesia:sync_dirty(fun add_subscription/3, [JID, NodeId, Options])
     of
-	{'EXIT', {aborted, Error}} -> Error;
 	{error, Error} -> {error, Error};
 	Result -> {result, Result}
+    catch
+       _:{aborted, Error} -> Error
     end.
 
 unsubscribe_node(JID, NodeId, SubID) ->
-    case catch mnesia:sync_dirty(fun delete_subscription/3, [JID, NodeId, SubID])
+    try mnesia:sync_dirty(fun delete_subscription/3, [JID, NodeId, SubID])
     of
-	{'EXIT', {aborted, Error}} -> Error;
 	{error, Error} -> {error, Error};
 	Result -> {result, Result}
+    catch
+        _:{aborted, Error} -> Error
     end.
 
 get_subscription(JID, NodeId, SubID) ->
-    case catch mnesia:sync_dirty(fun read_subscription/3, [JID, NodeId, SubID])
+    try mnesia:sync_dirty(fun read_subscription/3, [JID, NodeId, SubID])
     of
-	{'EXIT', {aborted, Error}} -> Error;
 	{error, Error} -> {error, Error};
 	Result -> {result, Result}
+    catch
+        _:{aborted, Error} -> Error
     end.
 
 set_subscription(JID, NodeId, SubID, Options) ->
-    case catch mnesia:sync_dirty(fun write_subscription/4, [JID, NodeId, SubID, Options])
+    try mnesia:sync_dirty(fun write_subscription/4, [JID, NodeId, SubID, Options])
     of
-	{'EXIT', {aborted, Error}} -> Error;
 	{error, Error} -> {error, Error};
 	Result -> {result, Result}
+    catch
+        _:{aborted, Error} -> Error
     end.
 
 
@@ -203,9 +207,9 @@ var_xfield(_) -> {error, badarg}.
 val_xfield(deliver = Opt, [Val]) -> xopt_to_bool(Opt, Val);
 val_xfield(digest = Opt, [Val]) -> xopt_to_bool(Opt, Val);
 val_xfield(digest_frequency = Opt, [Val]) ->
-    case catch binary_to_integer(Val) of
-	N when is_integer(N) -> N;
-	_ ->
+    try binary_to_integer(Val)
+    catch
+        _:_ ->
 	    Txt = {?T("Value of '~s' should be integer"), [Opt]},
 	    {error, xmpp:err_not_acceptable(Txt, ejabberd_option:language())}
     end;
@@ -221,9 +225,9 @@ val_xfield(subscription_type, [<<"items">>]) -> items;
 val_xfield(subscription_type, [<<"nodes">>]) -> nodes;
 val_xfield(subscription_depth, [<<"all">>]) -> all;
 val_xfield(subscription_depth = Opt, [Depth]) ->
-    case catch binary_to_integer(Depth) of
-	N when is_integer(N) -> N;
-	_ ->
+    try binary_to_integer(Depth)
+    catch
+       _:_ ->
 	    Txt = {?T("Value of '~s' should be integer"), [Opt]},
 	    {error, xmpp:err_not_acceptable(Txt, ejabberd_option:language())}
     end.

--- a/src/pubsub_subscription_sql.erl
+++ b/src/pubsub_subscription_sql.erl
@@ -168,9 +168,9 @@ var_xfield(_) -> {error, badarg}.
 val_xfield(deliver = Opt, [Val]) -> xopt_to_bool(Opt, Val);
 val_xfield(digest = Opt, [Val]) -> xopt_to_bool(Opt, Val);
 val_xfield(digest_frequency = Opt, [Val]) ->
-    case catch binary_to_integer(Val) of
-	N when is_integer(N) -> N;
-	_ ->
+    try binary_to_integer(Val)
+    catch
+        _:_ ->
 	    Txt = {?T("Value of '~s' should be integer"), [Opt]},
 	    {error, xmpp:err_not_acceptable(Txt, ejabberd_option:language())}
     end;
@@ -186,9 +186,9 @@ val_xfield(subscription_type, [<<"items">>]) -> items;
 val_xfield(subscription_type, [<<"nodes">>]) -> nodes;
 val_xfield(subscription_depth, [<<"all">>]) -> all;
 val_xfield(subscription_depth = Opt, [Depth]) ->
-    case catch binary_to_integer(Depth) of
-	N when is_integer(N) -> N;
-	_ ->
+    try binary_to_integer(Depth)
+    catch
+        _:_ ->
 	    Txt = {?T("Value of '~s' should be integer"), [Opt]},
 	    {error, xmpp:err_not_acceptable(Txt, ejabberd_option:language())}
     end.

--- a/src/rest.erl
+++ b/src/rest.erl
@@ -166,11 +166,10 @@ to_list(V) when is_list(V) ->
     V.
 
 encode_json(Content) ->
-    case catch misc:json_encode(Content) of
-        {'EXIT', Reason} ->
-            {error, {invalid_payload, Content, Reason}};
-        Encoded ->
-            Encoded
+    try misc:json_encode(Content)
+    catch
+       _:Reason ->
+            {error, {invalid_payload, Content, Reason}}
     end.
 
 decode_json(<<>>) -> [];

--- a/test/ejabberd_SUITE.erl
+++ b/test/ejabberd_SUITE.erl
@@ -107,41 +107,45 @@ do_init_per_group(redis, Config) ->
     mod_muc:shutdown_rooms(?REDIS_VHOST),
     set_opt(server, ?REDIS_VHOST, Config);
 do_init_per_group(mysql, Config) ->
-    case catch ejabberd_sql:sql_query(?MYSQL_VHOST, [<<"select 1;">>]) of
+    try ejabberd_sql:sql_query(?MYSQL_VHOST, [<<"select 1;">>]) of
         {selected, _, _} ->
             mod_muc:shutdown_rooms(?MYSQL_VHOST),
             update_sql(?MYSQL_VHOST, Config),
             stop_temporary_modules(?MYSQL_VHOST),
-            set_opt(server, ?MYSQL_VHOST, Config);
-        Err ->
+            set_opt(server, ?MYSQL_VHOST, Config)
+    catch
+        _:Err ->
             {skip, {mysql_not_available, Err}}
     end;
 do_init_per_group(mssql, Config) ->
-    case catch ejabberd_sql:sql_query(?MSSQL_VHOST, [<<"select 1;">>]) of
+    try ejabberd_sql:sql_query(?MSSQL_VHOST, [<<"select 1;">>]) of
         {selected, _, _} ->
             mod_muc:shutdown_rooms(?MSSQL_VHOST),
             update_sql(?MSSQL_VHOST, Config),
             stop_temporary_modules(?MSSQL_VHOST),
-            set_opt(server, ?MSSQL_VHOST, Config);
-        Err ->
+            set_opt(server, ?MSSQL_VHOST, Config)
+    catch
+        _:Err ->
             {skip, {mssql_not_available, Err}}
     end;
 do_init_per_group(pgsql, Config) ->
-    case catch ejabberd_sql:sql_query(?PGSQL_VHOST, [<<"select 1;">>]) of
+    try ejabberd_sql:sql_query(?PGSQL_VHOST, [<<"select 1;">>]) of
         {selected, _, _} ->
             mod_muc:shutdown_rooms(?PGSQL_VHOST),
             update_sql(?PGSQL_VHOST, Config),
             stop_temporary_modules(?PGSQL_VHOST),
-            set_opt(server, ?PGSQL_VHOST, Config);
-        Err ->
+            set_opt(server, ?PGSQL_VHOST, Config)
+    catch
+        _:Err ->
             {skip, {pgsql_not_available, Err}}
     end;
 do_init_per_group(sqlite, Config) ->
-    case catch ejabberd_sql:sql_query(?SQLITE_VHOST, [<<"select 1;">>]) of
+    try ejabberd_sql:sql_query(?SQLITE_VHOST, [<<"select 1;">>]) of
         {selected, _, _} ->
             mod_muc:shutdown_rooms(?SQLITE_VHOST),
-            set_opt(server, ?SQLITE_VHOST, Config);
-        Err ->
+            set_opt(server, ?SQLITE_VHOST, Config)
+    catch
+        _:Err ->
             {skip, {sqlite_not_available, Err}}
     end;
 do_init_per_group(ldap, Config) ->
@@ -185,32 +189,35 @@ end_per_group(redis, _Config) ->
     ok;
 end_per_group(mysql, Config) ->
     Query = "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'mqtt_pub';",
-    case catch ejabberd_sql:sql_query(?MYSQL_VHOST, [Query]) of
+    try ejabberd_sql:sql_query(?MYSQL_VHOST, [Query]) of
         {selected, _, [[<<"0">>]]} ->
             ok;
         {selected, _, _} ->
-            clear_sql_tables(mysql, Config);
-        Other ->
+            clear_sql_tables(mysql, Config)
+    catch
+        _:Other ->
             ct:fail({failed_to_check_table_existence, mysql, Other})
     end,
     ok;
 end_per_group(mssql, Config) ->
     Query = "SELECT * FROM sys.tables WHERE name = 'mqtt_pub'",
-    case catch ejabberd_sql:sql_query(?MSSQL_VHOST, [Query]) of
+    try ejabberd_sql:sql_query(?MSSQL_VHOST, [Query]) of
         {selected, [t]} ->
-            clear_sql_tables(mssql, Config);
-        Other ->
+            clear_sql_tables(mssql, Config)
+    catch
+        _:Other ->
             ct:fail({failed_to_check_table_existence, mssql, Other})
     end,
     ok;
 end_per_group(pgsql, Config) ->
     Query = "SELECT EXISTS (SELECT 0 FROM information_schema.tables WHERE table_name = 'mqtt_pub');",
-    case catch ejabberd_sql:sql_query(?PGSQL_VHOST, [Query]) of
+    try ejabberd_sql:sql_query(?PGSQL_VHOST, [Query]) of
         {selected, [t]} ->
             clear_sql_tables(pgsql, Config);
 	{selected, _, [[<<"t">>]]} ->
-	    clear_sql_tables(pgsql, Config);
-        Other ->
+	    clear_sql_tables(pgsql, Config)
+    catch
+        _:Other ->
             ct:fail({failed_to_check_table_existence, pgsql, Other})
     end,
     ok;

--- a/test/suite.hrl
+++ b/test/suite.hrl
@@ -22,7 +22,9 @@
 
 -define(recv2(P1, P2),
         (fun() ->
-                 case {R1 = suite:recv(Config), R2 = suite:recv(Config)} of
+                 R1 = suite:recv(Config),
+                 R2 = suite:recv(Config),
+                 case {R1, R2} of
                      {P1, P2} -> {R1, R2};
                      {P2, P1} -> {R2, R1};
                      {P1, V1} -> suite:match_failure([V1], [P2]);
@@ -35,7 +37,8 @@
 
 -define(recv3(P1, P2, P3),
         (fun() ->
-                 case R3 = suite:recv(Config) of
+                 R3 = suite:recv(Config),
+                 case R3 of
                      P1 -> insert(R3, 1, ?recv2(P2, P3));
                      P2 -> insert(R3, 2, ?recv2(P1, P3));
                      P3 -> insert(R3, 3, ?recv2(P1, P2));
@@ -45,7 +48,8 @@
 
 -define(recv4(P1, P2, P3, P4),
         (fun() ->
-                 case R4 = suite:recv(Config) of
+                 R4 = suite:recv(Config),
+                 case R4 of
                      P1 -> insert(R4, 1, ?recv3(P2, P3, P4));
                      P2 -> insert(R4, 2, ?recv3(P1, P3, P4));
                      P3 -> insert(R4, 3, ?recv3(P1, P2, P4));
@@ -56,7 +60,8 @@
 
 -define(recv5(P1, P2, P3, P4, P5),
         (fun() ->
-                 case R5 = suite:recv(Config) of
+                 R5 = suite:recv(Config),
+                 case R5 of
                      P1 -> insert(R5, 1, ?recv4(P2, P3, P4, P5));
                      P2 -> insert(R5, 2, ?recv4(P1, P3, P4, P5));
                      P3 -> insert(R5, 3, ?recv4(P1, P2, P4, P5));

--- a/test/webadmin_tests.erl
+++ b/test/webadmin_tests.erl
@@ -146,14 +146,7 @@ basic_auth_header(Username, Server, Password) ->
 page(Config, Tail) ->
     Server = ?config(server_host, Config),
     Port = ct:get_config(web_port, 5280),
-    Url = "http://" ++ Server ++ ":" ++ integer_to_list(Port) ++ "/admin/" ++ Tail,
-    %% This bypasses a bug introduced in Erlang OTP R21 and fixed in 23.2:
-    case catch uri_string:normalize("/%2525") of
-	"/%25" ->
-	    string:replace(Url, "%25", "%2525", all);
-	_ ->
-	    Url
-    end.
+    "http://" ++ Server ++ ":" ++ integer_to_list(Port) ++ "/admin/" ++ Tail.
 
 mue(Binary) ->
     misc:url_encode(Binary).


### PR DESCRIPTION
This PR includes various fixes to solve compilation warnings in Erlang/OTP 29

```erl
     ┌─ src/jd2ejd.erl:
     │
 143 │ catch mod_private:set_data(
     │ ╰── Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.>
     Compile directive 'nowarn_deprecated_catch' can be used to suppress
     warnings in selected modules.
```

```erl
     ┌─ src/ejabberd_sql.erl:
     │
 788 │ to_odbc(odbc:sql_query(State#state.db_ref, [Query],
     │  ╰── Warning: odbc:sql_query/3 is deprecated and will be removed in OTP 30;
      Legacy protocol support will be dropped in OTP-30, does not really provide backend transparency
       and known usage is low.
```

```erl
test/pubsub_tests.erl:
 283  						  type = Type}}]},
Warning: variable 'R1' exported from tuple (line 277, column 9).
Exporting bindings from subexpressions other than block expressions is
deprecated and may yield an error in a future version of Erlang/OTP.
Please move the binding of 'R1' out of the tuple.
Compile directive 'nowarn_export_var_subexpr' can be used to suppress
warnings in selected modules.
We are open to contributions for ejabberd, as GitHub pull requests (PR).
Here are a few points to consider before submitting your PR. (You can
remove the whole text after reading.)
```