### PR TITLE
fix (webadmin): don't crash in make_table for regular cmd buttons

### DIFF
--- a/src/ejabberd_web_admin.erl
+++ b/src/ejabberd_web_admin.erl
@@ -1986,7 +1986,9 @@ filter_results(_, Result) ->
 
 format_result(presentation, _ExecRes, PresentationEls, _ArgumentsEls, _ResultEls) ->
     ?XAE(<<"p">>, [{<<"class">>, <<"api">>}], PresentationEls);
-format_result(button, _ExecRes, _PresentationEls, [Button], ResultEls) ->
+format_result(button, _ExecRes, _PresentationEls, [Button], _ResultEls) ->
+    Button;
+format_result(action_button, _ExecRes, _PresentationEls, [Button], ResultEls) ->
     {ResultEls, Button};
 format_result(result,
               _ExecRes,
@@ -3009,7 +3011,7 @@ action_button_allowed(Name, Request, BaseArguments, Options, Cmd) ->
                                BaseArguments,
                                []),
     ResultEls = action_button_result_el(ExecRes, Request#request.lang, Name),
-    format_result(button, ExecRes, PresentationEls, ArgumentsEls, ResultEls).
+    format_result(action_button, ExecRes, PresentationEls, ArgumentsEls, ResultEls).
 
 action_button_result_el(not_executed, _L, _N) ->
     [];

--- a/test/webadmin_tests.erl
+++ b/test/webadmin_tests.erl
@@ -31,6 +31,7 @@ send_recv/2, put_event/2, get_event/1]).
 -include("suite.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include("mod_invites.hrl").
+-include("mod_roster.hrl").
 
 %%%===================================================================
 %%% API
@@ -43,6 +44,7 @@ single_cases() ->
      [single_test(login_page),
       single_test(welcome_page),
       single_test(user_page),
+      single_test(user_roster_page),
       single_test(adduser),
       single_test(changepassword),
       single_test(removeuser),
@@ -65,6 +67,17 @@ welcome_page(Config) ->
 user_page(Config) ->
     Server = ?config(server, Config),
     URL = "server/" ++ binary_to_list(Server) ++ "/user/admin/",
+    Body = ?match({ok, {{"HTTP/1.1", 200, _}, _, Body}},
+		  httpc:request(get, {page(Config, URL), [basic_auth_header(Config)]}, [],
+				[{body_format, binary}]),
+		  Body),
+    ?match({_, _}, binary:match(Body, <<"<title>ejabberd Web Admin">>)).
+
+user_roster_page(Config) ->
+    Server = ?config(server, Config),
+    User = ?config(user, Config),
+    mod_roster:set_roster(#roster{us = {User, Server}, jid = {<<"admin">>, Server, <<>>}}),
+    URL = "server/" ++ binary_to_list(Server) ++ "/user/" ++ binary_to_list(misc:url_encode(User)) ++ "/roster/",
     Body = ?match({ok, {{"HTTP/1.1", 200, _}, _, Body}},
 		  httpc:request(get, {page(Config, URL), [basic_auth_header(Config)]}, [],
 				[{body_format, binary}]),


### PR DESCRIPTION
After merging changes for mod_invites adding web-admin capabilities, now web-admin is crashing for roster views of individual users:

```
[error] Hook webadmin_page_hostuser crashed when running mod_roster:webadmin_page_hostuser/4:
** exception error: no function clause matching
                  ejabberd_web_admin:'-make_table/6-fun-0-'({[],
                                                             {xmlel,
                                                              <<"form">>,
                                                              [{<<"action">>,
                                                                <<>>},
                                                               {<<"method">>,
                                                                <<"post">>}],
                                                              [{xmlel,
                                                                <<"input">>,
                                                                [{<<"type">>,
                                                                  <<"submit">>},
                                                                 {<<"name">>,
                                                                  <<"delete_rosteritemg2wAAAAEbQAAAAV6ZWFua20AAAAJbG9jYWxob3N0bQAAAAVhZG1pbm0AAAAJbG9jYWxob3N0ag==">>},
                                                                 {<<"class">>,
                                                                  <<"btn-danger">>},
                                                                 {<<"value">>,
                                                                  <<"Delete Rosteritem">>}],
                                                                []}]}}) (/Users/zeank/src/ejabberd/src/ejabberd_web_admin.erl:2717)
   in function  lists:map_1/2 (lists.erl:2390)
   in call from lists:map_1/2 (lists.erl:2390)
   in call from lists:map/2 (lists.erl:2385)
   in call from ejabberd_web_admin:'-make_table/6-fun-1-'/2 (/Users/zeank/src/ejabberd/src/ejabberd_web_admin.erl:2725)
   in call from lists:map/2 (lists.erl:2385)
   in call from ejabberd_web_admin:make_table/6 (/Users/zeank/src/ejabberd/src/ejabberd_web_admin.erl:2726)
   in call from mod_roster:make_webadmin_roster_table/4 (/Users/zeank/src/ejabberd/src/mod_roster.erl:1187)
```
