### PR TITLE
Use correct namespace for bidi negotiation

### DIFF
--- a/src/mod_s2s_bidi.erl
+++ b/src/mod_s2s_bidi.erl
@@ -82,8 +82,8 @@ s2s_in_packet(State, _) ->
 s2s_out_unauthenticated_features(#{db_verify := _} = State, _) ->
     State;
 s2s_out_unauthenticated_features(State, #stream_features{} = Pkt) ->
-    try xmpp:try_subtag(Pkt, #s2s_bidi{}) of
-	#s2s_bidi{} ->
+    try xmpp:try_subtag(Pkt, #s2s_bidi_feature{}) of
+	#s2s_bidi_feature{} ->
 	    ejabberd_s2s_out:send(State#{bidi_enabled => true}, #s2s_bidi{});
 	_ ->
 	    State


### PR DESCRIPTION
When ejabberd initiates a connection to a server that has bidi enabled, ejabberd looks at the wrong namespace for negotiating bidi (`urn:xmpp:bidi` vs `urn:xmpp:features:bidi`) .

The correct behavior is documented in [XEP-0288](https://xmpp.org/extensions/xep-0288.html#examples):
1. Client connects to Server
2. Server advertises `<bidi xmlns='urn:xmpp:features:bidi'/>`  in `stream:features`
3. Client activates bidi with `<bidi xmlns='urn:xmpp:bidi'/>`

ejabberd uses `urn:xmpp:bidi` as the namespace in step 2 for unauthenticated streams, see [mod_s2s_bidi.erl#L85](https://github.com/processone/ejabberd/blob/84a33db7212ef2e19be7a07c289f0f88a9070007/src/mod_s2s_bidi.erl#L85).

I think a similar issue was fixed in f38f81159d1a46c9de817b67d3ea548d694901fe but this location was overlooked.

This PR fixes this issue by using the correct namespace for outgoing connections. Incoming connections already worked fine.

There is a test for the behavior in the following repo that shows that this patch allows ejabberd and prosody to successfully negotiate bidi (disclaimer: AI generated but with a human in a loop, i.e. I reviewed the behavior): https://github.com/cdroege/ejabberd-wrong-bidi-namespace-reproduction

Here are some relevant logs for a few server combinations: unpatched ejabberd 26.04, patched ejabberd 26.04, prosody

(Search for `<bidi xmlns='urn:xmpp:bidi` to find the relevant parts)
<details>

# unpatched ejabberd initiates the connection:

This never works because ejabberd looks at the wrong namespace.

## to another unpatched ejabberd

```
2026-06-11 18:05:46.950 [info] (#PID<0.800.0>) Accepted connection [::ffff:10.89.1.2]:42028 -> [::ffff:10.89.1.3]:5269
2026-06-11 18:05:46.953 [notice] (tcp|<0.800.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-b.example' from='server-a.example' xmlns='jabber:server'>"
2026-06-11 18:05:46.961 [notice] (tcp|<0.800.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='12935859957906064004' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-a.example' from='server-b.example' xmlns='jabber:server'>"
2026-06-11 18:05:46.961 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:05:46.961 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:05:46.963 [notice] (tcp|<0.800.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:05:46.964 [notice] (tcp|<0.800.0>) Received XML on stream = "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:05:46.964 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:05:46.966 [notice] (tcp|<0.800.0>) Send XML on stream = "<proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:05:46.969 [notice] (tls|<0.800.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-b.example' from='server-a.example' xmlns='jabber:server'>"
2026-06-11 18:05:46.969 [notice] (tls|<0.800.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='4671181608689212727' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-a.example' from='server-b.example' xmlns='jabber:server'>"
2026-06-11 18:05:46.969 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:05:46.969 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:05:46.970 [notice] (tls|<0.800.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>EXTERNAL</mechanism></mechanisms><sasl-channel-binding xmlns='urn:xmpp:sasl-cb:0'><channel-binding type='tls-exporter'/><channel-binding type='tls-server-end-point'/></sasl-channel-binding><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:05:46.971 [notice] (tls|<0.800.0>) Received XML on stream = "<auth mechanism='EXTERNAL' xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>c2VydmVyLWEuZXhhbXBsZQ==</auth>"
2026-06-11 18:05:46.971 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:05:46.972 [info] (tls|<0.800.0>) Accepted inbound s2s EXTERNAL authentication server-a.example -> server-b.example (::ffff:10.89.1.2)
```

## to a patched ejabberd

```
2026-06-11 18:07:45.894 [info] (#PID<0.1586.0>) Accepted connection [::ffff:10.89.1.2]:47332 -> [::ffff:10.89.1.4]:5269
2026-06-11 18:07:45.897 [notice] (tcp|<0.1586.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-c.example' from='server-a.example' xmlns='jabber:server'>"
2026-06-11 18:07:45.906 [notice] (tcp|<0.1586.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='11031891044896086433' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-a.example' from='server-c.example' xmlns='jabber:server'>"
2026-06-11 18:07:45.906 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:07:45.906 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:07:45.908 [notice] (tcp|<0.1586.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:07:45.908 [notice] (tcp|<0.1586.0>) Received XML on stream = "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:07:45.908 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:07:45.910 [notice] (tcp|<0.1586.0>) Send XML on stream = "<proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:07:45.912 [notice] (tls|<0.1586.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-c.example' from='server-a.example' xmlns='jabber:server'>"
2026-06-11 18:07:45.912 [notice] (tls|<0.1586.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='15529245445817397617' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-a.example' from='server-c.example' xmlns='jabber:server'>"
2026-06-11 18:07:45.912 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:07:45.913 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:07:45.913 [notice] (tls|<0.1586.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>EXTERNAL</mechanism></mechanisms><sasl-channel-binding xmlns='urn:xmpp:sasl-cb:0'><channel-binding type='tls-exporter'/><channel-binding type='tls-server-end-point'/></sasl-channel-binding><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:07:45.914 [notice] (tls|<0.1586.0>) Received XML on stream = "<auth mechanism='EXTERNAL' xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>c2VydmVyLWEuZXhhbXBsZQ==</auth>"
2026-06-11 18:07:45.914 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:07:45.914 [info] (tls|<0.1586.0>) Accepted inbound s2s EXTERNAL authentication server-a.example -> server-c.example (::ffff:10.89.1.2)
```

## to prosody

```
connk8fo-TsBtYUe                          debug New connection FD 19 (10.89.1.2, 57950, 10.89.1.5, 5269) on server FD 13 (*, 5269)
connk8fo-TsBtYUe                          debug Connected (FD 19 (10.89.1.2, 57950, 10.89.1.5, 5269))
s2sin56134d6434d0                         debug Incoming s2s connection
runnerFCFcoFGlG1Ww                        debug creating new coroutine
s2sin56134d6434d0                         debug Incoming s2s received <stream:stream to='server-d.example' xml:lang='en' from='server-a.example' version='1.0' xmlns='http://etherx.jabber.org/streams'>
s2sin56134d6434d0                         debug Sending[s2sin_unauthed]: <?xml version='1.0'?>
mod_s2s                                   debug Sending stream features: <stream:features><bidi xmlns='urn:xmpp:features:bidi'/><dialback xmlns='urn:xmpp:features:dialback'/><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/><limits xmlns='urn:xmpp:stream-limits:0'><idle-seconds>3</idle-seconds></limits></stream:features>
s2sin56134d6434d0                         debug Sending[s2sin_unauthed]: <stream:features>
connk8fo-TsBtYUe                          debug Sent 506 out of 506 buffered bytes
s2sin56134d6434d0                         debug Received[s2sin_unauthed]: <starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls' xml:lang='en'>
s2sin56134d6434d0                         debug Sending[s2sin_unauthed]: <proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'>
connk8fo-TsBtYUe                          debug Start TLS after write
s2sin56134d6434d0                         debug TLS negotiation started for s2sin_unauthed...
connk8fo-TsBtYUe                          debug Sent 50 out of 50 buffered bytes
connk8fo-TsBtYUe                          debug Prepared to start TLS
connk8fo-TsBtYUe                          debug Starting TLS now
connk8fo-TsBtYUe                          debug TLS handshake complete (TLSv1.3 with TLS_AES_256_GCM_SHA384)
s2sin56134d6434d0                         info  Stream encrypted (TLSv1.3 with TLS_AES_256_GCM_SHA384)
s2sin56134d6434d0                         debug Incoming s2s received <stream:stream to='server-d.example' xml:lang='en' from='server-a.example' version='1.0' xmlns='http://etherx.jabber.org/streams'>
s2sin56134d6434d0                         debug certificate chain validation result: valid
x509                                      debug Cert dNSName server-a.example matched hostname
s2sin56134d6434d0                         debug certificate identity validation result: valid
s2sin56134d6434d0                         debug Sending[s2sin_unauthed]: <?xml version='1.0'?>
server-d.example:saslauth                 debug Offering SASL EXTERNAL
mod_s2s                                   debug Sending stream features: <stream:features><bidi xmlns='urn:xmpp:features:bidi'/><dialback xmlns='urn:xmpp:features:dialback'/><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>EXTERNAL</mechanism></mechanisms><limits xmlns='urn:xmpp:stream-limits:0'><idle-seconds>3</idle-seconds></limits></stream:features>
s2sin56134d6434d0                         debug Sending[s2sin_unauthed]: <stream:features>
connk8fo-TsBtYUe                          debug Sent 552 out of 552 buffered bytes
s2sin56134d6434d0                         debug Received[s2sin_unauthed]: <auth mechanism='EXTERNAL' xmlns='urn:ietf:params:xml:ns:xmpp-sasl' xml:lang='en'>
s2sin56134d6434d0                         debug Sending[s2sin_unauthed]: <success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>
server-d.example:saslauth                 info  Accepting SASL EXTERNAL identity from server-a.example
s2sin56134d6434d0                         debug connection server-a.example->server-d.example is now authenticated for server-a.example
s2sin56134d6434d0                         info  Incoming s2s connection server-a.example->server-d.example complete
```

# patched versions of ejabberd initiate the connection:

This works in all cases because ejabberd looks at the correct namespace

## to unpatched

```
2026-06-11 18:10:37.297 [info] (#PID<0.824.0>) Accepted connection [::ffff:10.89.1.4]:36838 -> [::ffff:10.89.1.2]:5269
2026-06-11 18:10:37.297 [notice] (tcp|<0.824.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-a.example' from='server-c.example' xmlns='jabber:server'>"
2026-06-11 18:10:37.297 [notice] (tcp|<0.824.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='12820131712988234504' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-c.example' from='server-a.example' xmlns='jabber:server'>"
2026-06-11 18:10:37.297 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:10:37.297 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:10:37.298 [notice] (tcp|<0.824.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:10:37.299 [notice] (tcp|<0.824.0>) Received XML on stream = "<bidi xmlns='urn:xmpp:bidi'/>"
2026-06-11 18:10:37.299 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:10:37.299 [debug] Running hook :s2s_in_unauthenticated_packet: :mod_s2s_bidi::s2s_in_packet/2
2026-06-11 18:10:37.340 [notice] (tcp|<0.824.0>) Received XML on stream = "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:10:37.340 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:10:37.340 [notice] (tcp|<0.824.0>) Send XML on stream = "<proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:10:37.343 [notice] (tls|<0.824.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-a.example' from='server-c.example' xmlns='jabber:server'>"
2026-06-11 18:10:37.344 [notice] (tls|<0.824.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='11421481197767930310' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-c.example' from='server-a.example' xmlns='jabber:server'>"
2026-06-11 18:10:37.344 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:10:37.344 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:10:37.344 [notice] (tls|<0.824.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>EXTERNAL</mechanism></mechanisms><sasl-channel-binding xmlns='urn:xmpp:sasl-cb:0'><channel-binding type='tls-exporter'/><channel-binding type='tls-server-end-point'/></sasl-channel-binding><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:10:37.344 [notice] (tls|<0.824.0>) Received XML on stream = "<bidi xmlns='urn:xmpp:bidi'/>"
2026-06-11 18:10:37.344 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:10:37.344 [debug] Running hook :s2s_in_unauthenticated_packet: :mod_s2s_bidi::s2s_in_packet/2
2026-06-11 18:10:37.385 [notice] (tls|<0.824.0>) Received XML on stream = "<auth mechanism='EXTERNAL' xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>c2VydmVyLWMuZXhhbXBsZQ==</auth>"
2026-06-11 18:10:37.385 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:10:37.386 [info] (tls|<0.824.0>) Accepted inbound s2s EXTERNAL authentication server-c.example -> server-a.example (::ffff:10.89.1.4)
```

## to prosody

```
connpy-6queybio3                          debug New connection FD 19 (10.89.1.4, 42268, 10.89.1.5, 5269) on server FD 13 (*, 5269)
connpy-6queybio3                          debug Connected (FD 19 (10.89.1.4, 42268, 10.89.1.5, 5269))
s2sin56134d885750                         debug Incoming s2s connection
runnerUKpf9ZRr0jUt                        debug creating new coroutine
s2sin56134d885750                         debug Incoming s2s received <stream:stream to='server-d.example' xml:lang='en' from='server-c.example' version='1.0' xmlns='http://etherx.jabber.org/streams'>
s2sin56134d885750                         debug Sending[s2sin_unauthed]: <?xml version='1.0'?>
mod_s2s                                   debug Sending stream features: <stream:features><bidi xmlns='urn:xmpp:features:bidi'/><dialback xmlns='urn:xmpp:features:dialback'/><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/><limits xmlns='urn:xmpp:stream-limits:0'><idle-seconds>3</idle-seconds></limits></stream:features>
s2sin56134d885750                         debug Sending[s2sin_unauthed]: <stream:features>
connpy-6queybio3                          debug Sent 506 out of 506 buffered bytes
s2sin56134d885750                         debug Received[s2sin_unauthed]: <bidi xmlns='urn:xmpp:bidi' xml:lang='en'>
s2sin56134d885750                         debug Requested bidirectional stream
s2sin56134d885750                         debug Received[s2sin_unauthed]: <starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls' xml:lang='en'>
s2sin56134d885750                         debug Sending[s2sin_unauthed]: <proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'>
connpy-6queybio3                          debug Start TLS after write
s2sin56134d885750                         debug TLS negotiation started for s2sin_unauthed...
connpy-6queybio3                          debug Sent 50 out of 50 buffered bytes
connpy-6queybio3                          debug Prepared to start TLS
connpy-6queybio3                          debug Starting TLS now
connpy-6queybio3                          debug TLS handshake complete (TLSv1.3 with TLS_AES_256_GCM_SHA384)
s2sin56134d885750                         info  Stream encrypted (TLSv1.3 with TLS_AES_256_GCM_SHA384)
s2sin56134d885750                         debug Incoming s2s received <stream:stream to='server-d.example' xml:lang='en' from='server-c.example' version='1.0' xmlns='http://etherx.jabber.org/streams'>
s2sin56134d885750                         debug certificate chain validation result: valid
x509                                      debug Cert dNSName server-c.example matched hostname
s2sin56134d885750                         debug certificate identity validation result: valid
s2sin56134d885750                         debug Sending[s2sin_unauthed]: <?xml version='1.0'?>
server-d.example:saslauth                 debug Offering SASL EXTERNAL
mod_s2s                                   debug Sending stream features: <stream:features><bidi xmlns='urn:xmpp:features:bidi'/><dialback xmlns='urn:xmpp:features:dialback'/><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>EXTERNAL</mechanism></mechanisms><limits xmlns='urn:xmpp:stream-limits:0'><idle-seconds>3</idle-seconds></limits></stream:features>
s2sin56134d885750                         debug Sending[s2sin_unauthed]: <stream:features>
connpy-6queybio3                          debug Sent 552 out of 552 buffered bytes
s2sin56134d885750                         debug Received[s2sin_unauthed]: <bidi xmlns='urn:xmpp:bidi' xml:lang='en'>
s2sin56134d885750                         debug Requested bidirectional stream
s2sin56134d885750                         debug Received[s2sin_unauthed]: <auth mechanism='EXTERNAL' xmlns='urn:ietf:params:xml:ns:xmpp-sasl' xml:lang='en'>
s2sin56134d885750                         debug Sending[s2sin_unauthed]: <success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>
server-d.example:saslauth                 info  Accepting SASL EXTERNAL identity from server-c.example
```



# Prosody initiates the connection
## to a patched ejabberd

```
2026-06-11 18:13:29.042 [info] (#PID<0.1605.0>) Accepted connection [::ffff:10.89.1.5]:36512 -> [::ffff:10.89.1.4]:5269
2026-06-11 18:13:29.042 [notice] (tcp|<0.1605.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream xmlns:stream='http://etherx.jabber.org/streams' to='server-c.example' xmlns='jabber:server' xml:lang='en' id='' from='server-d.example' xmlns:db='jabber:server:dialback' version='1.0'>"
2026-06-11 18:13:29.042 [notice] (tcp|<0.1605.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='1345026712530292279' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-d.example' from='server-c.example' xmlns='jabber:server'>"
2026-06-11 18:13:29.042 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:13:29.042 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:13:29.042 [notice] (tcp|<0.1605.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:13:29.042 [notice] (tcp|<0.1605.0>) Received XML on stream = "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:13:29.042 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:13:29.042 [notice] (tcp|<0.1605.0>) Send XML on stream = "<proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:13:29.044 [notice] (tls|<0.1605.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream xmlns:stream='http://etherx.jabber.org/streams' to='server-c.example' xmlns='jabber:server' xml:lang='en' id='' from='server-d.example' xmlns:db='jabber:server:dialback' version='1.0'>"
2026-06-11 18:13:29.045 [notice] (tls|<0.1605.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='1059782440086522106' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-d.example' from='server-c.example' xmlns='jabber:server'>"
2026-06-11 18:13:29.045 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:13:29.045 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:13:29.045 [notice] (tls|<0.1605.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>EXTERNAL</mechanism></mechanisms><sasl-channel-binding xmlns='urn:xmpp:sasl-cb:0'><channel-binding type='tls-exporter'/><channel-binding type='tls-server-end-point'/></sasl-channel-binding><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:13:29.045 [notice] (tls|<0.1605.0>) Received XML on stream = "<bidi xmlns='urn:xmpp:bidi'><limits xmlns='urn:xmpp:stream-limits:0'><max-bytes>10000</max-bytes><idle-seconds>3</idle-seconds></limits></bidi><auth mechanism='EXTERNAL' xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>c2VydmVyLWQuZXhhbXBsZQ==</auth>"
2026-06-11 18:13:29.045 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:13:29.045 [debug] Running hook :s2s_in_unauthenticated_packet: :mod_s2s_bidi::s2s_in_packet/2
2026-06-11 18:13:29.045 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:13:29.045 [info] (tls|<0.1605.0>) Accepted inbound s2s EXTERNAL authentication server-d.example -> server-c.example (::ffff:10.89.1.5)
```

## to unpatched

```
2026-06-11 18:12:24.653 [info] (#PID<0.831.0>) Accepted connection [::ffff:10.89.1.5]:46676 -> [::ffff:10.89.1.2]:5269
2026-06-11 18:12:24.654 [notice] (tcp|<0.831.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream xmlns:stream='http://etherx.jabber.org/streams' to='server-a.example' xmlns='jabber:server' xml:lang='en' id='' from='server-d.example' xmlns:db='jabber:server:dialback' version='1.0'>"
2026-06-11 18:12:24.654 [notice] (tcp|<0.831.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='4613447545769661590' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-d.example' from='server-a.example' xmlns='jabber:server'>"
2026-06-11 18:12:24.654 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:12:24.654 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:12:24.654 [notice] (tcp|<0.831.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/><starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:12:24.654 [notice] (tcp|<0.831.0>) Received XML on stream = "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:12:24.654 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:12:24.654 [notice] (tcp|<0.831.0>) Send XML on stream = "<proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
2026-06-11 18:12:24.656 [notice] (tls|<0.831.0>) Received XML on stream = "<?xml version='1.0'?><stream:stream xmlns:stream='http://etherx.jabber.org/streams' to='server-a.example' xmlns='jabber:server' xml:lang='en' id='' from='server-d.example' xmlns:db='jabber:server:dialback' version='1.0'>"
2026-06-11 18:12:24.656 [notice] (tls|<0.831.0>) Send XML on stream = "<?xml version='1.0'?><stream:stream id='13079327263087803952' version='1.0' xml:lang='en' xmlns:db='jabber:server:dialback' xmlns:stream='http://etherx.jabber.org/streams' to='server-d.example' from='server-a.example' xmlns='jabber:server'>"
2026-06-11 18:12:24.657 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_bidi::s2s_in_features/2
2026-06-11 18:12:24.657 [debug] Running hook :s2s_in_pre_auth_features: :mod_s2s_dialback::s2s_in_features/2
2026-06-11 18:12:24.657 [notice] (tls|<0.831.0>) Send XML on stream = "<stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>EXTERNAL</mechanism></mechanisms><sasl-channel-binding xmlns='urn:xmpp:sasl-cb:0'><channel-binding type='tls-exporter'/><channel-binding type='tls-server-end-point'/></sasl-channel-binding><dialback xmlns='urn:xmpp:features:dialback'><errors/></dialback><bidi xmlns='urn:xmpp:features:bidi'/></stream:features>"
2026-06-11 18:12:24.657 [notice] (tls|<0.831.0>) Received XML on stream = "<bidi xmlns='urn:xmpp:bidi'><limits xmlns='urn:xmpp:stream-limits:0'><max-bytes>10000</max-bytes><idle-seconds>3</idle-seconds></limits></bidi><auth mechanism='EXTERNAL' xmlns='urn:ietf:params:xml:ns:xmpp-sasl'>c2VydmVyLWQuZXhhbXBsZQ==</auth>"
2026-06-11 18:12:24.657 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:12:24.657 [debug] Running hook :s2s_in_unauthenticated_packet: :mod_s2s_bidi::s2s_in_packet/2
2026-06-11 18:12:24.657 [debug] Running hook :s2s_in_handle_recv: :mod_s2s_dialback::s2s_in_recv/3
2026-06-11 18:12:24.657 [info] (tls|<0.831.0>) Accepted inbound s2s EXTERNAL authentication server-d.example -> server-a.example (::ffff:10.89.1.5)
```

</details>