### PR TITLE
Handle duplicate Mnesia push sessions

### DIFF
--- a/src/mod_push.erl
+++ b/src/mod_push.erl
@@ -623,14 +623,16 @@ delete_session(LUser, LServer, ID) ->
 -spec delete_session(binary(), binary(), jid(), binary()) -> ok | {error, err_reason()}.
 delete_session(LUser, LServer, PushJID, Node) ->
     Mod = gen_mod:db_mod(LServer, ?MODULE),
-    case Mod:lookup_session(LUser, LServer, PushJID, Node) of
-	{ok, {ID, _, _, _}} ->
-	    delete_session(LUser, LServer, ID);
-	error ->
-	    {error, notfound};
-	{error, _} = Err ->
-	    Err
-    end.
+    LookupFun = fun() ->
+			case Mod:lookup_sessions(LUser, LServer, PushJID) of
+			    {ok, Sessions} ->
+				{ok, [Session || {_, _, N, _} = Session <- Sessions,
+						 N == Node]};
+			    {error, _} = Err ->
+				Err
+			end
+		end,
+    delete_sessions(LUser, LServer, LookupFun, Mod).
 
 -spec delete_sessions(binary(), binary(), jid()) -> ok | {error, err_reason()}.
 delete_sessions(LUser, LServer, PushJID) ->

--- a/src/mod_push_mnesia.erl
+++ b/src/mod_push_mnesia.erl
@@ -52,6 +52,14 @@ store_session(LUser, LServer, TS, PushJID, Node, XData) ->
     PushLJID = jid:tolower(PushJID),
     MaxSessions = ejabberd_sm:get_max_user_sessions(LUser, LServer),
     F = fun() ->
+		Recs = mnesia:wread({push_session, US}),
+		lists:foreach(
+		  fun(#push_session{service = P, node = N} = Rec)
+			when P == PushLJID, N == Node ->
+			  mnesia:delete_object(Rec);
+		     (_) ->
+			  ok
+		  end, Recs),
 		enforce_max_sessions(US, MaxSessions),
 		mnesia:write(#push_session{us = US,
 					   timestamp = TS,
@@ -78,8 +86,13 @@ lookup_session(LUser, LServer, PushJID, Node) ->
 			     N == Node ->
 			  Rec
 		  end),
-    case mnesia:dirty_select(push_session, MatchSpec) of
-	[#push_session{timestamp = TS, xml = El}] ->
+    Records = mnesia:dirty_select(push_session, MatchSpec),
+    SortedRecords = lists:sort(fun(#push_session{timestamp = TS1},
+				   #push_session{timestamp = TS2}) ->
+				       TS1 >= TS2
+			       end, Records),
+    case SortedRecords of
+	[#push_session{timestamp = TS, xml = El} | _] ->
 	    {ok, {TS, PushLJID, Node, decode_xdata(El)}};
 	[] ->
 	    ?DEBUG("No push session found for ~ts@~ts (~p, ~ts)",


### PR DESCRIPTION
Delete all existing push sessions for the same account, service, and node before storing a replacement; make lookup tolerate legacy duplicate rows by selecting the newest session.

Fixes https://github.com/processone/ejabberd/issues/4584
